### PR TITLE
Use SDL 0.27.2 (from 0.25)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,13 @@ readme = "README.md"
 name = "ggez"
 path = "src/lib.rs"
 
+[dependencies.sdl2]
+version = "0.27.2"
+default-features = false
+features = ["image", "mixer"]
+
 [dependencies]
-sdl2 = "0.25"
-sdl2-sys = "0.25"
-sdl2_image = "0.25"
-sdl2_mixer = "0.25"
+sdl2-sys = "0.27.2"
 rusttype = "0.2"
 rand = "0.3"
 zip = "0.1"

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
-# ggez
+# What is this?
 [![Build Status](https://travis-ci.org/ggez/ggez.svg?branch=master)](https://travis-ci.org/ggez/ggez) [![Docs Status](https://docs.rs/ggez/badge.svg)](https://docs.rs/ggez) [![license](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/svenstaro/ggez/blob/master/LICENSE) [![Crates.io](https://img.shields.io/crates/v/ggez.svg)](https://crates.io/crates/ggez) [![Crates.io](https://img.shields.io/crates/d/ggez.svg)](https://crates.io/crates/ggez)
 
-A Rust library to create a Good Game Easily.
+ggez is a Rust library to create a Good Game Easily.
 
-More specifically, ggez is a lightweight game framework for making 2D games.  It is built on SDL2, and aims to
-implement an API quite similar to (a Rustified version of) the Love2D game engine.  This means it will contain
-basic and portable 2D drawing, sound, resource loading and event handling.
+More specifically, ggez is a lightweight game framework for making 2D
+games with minimum friction.  It aims to implement an API quite
+similar to (a Rustified version of) the Love2D game engine.  This
+means it will contain basic and portable 2D drawing, sound, resource
+loading and event handling.
 
-It's not meant to be everything to everyone, but rather a good base upon which to build.  However, eventually
-there is also a [ggez-goodies](https://github.com/ggez/ggez-goodies) crate that aims to implement higher-level 
-tools atop this, such as a resource cache, basic GUI/debugger, scene manager, and more sophisticated drawing 
-systems such as sprites, layer, tiled maps, etc.
-
+ggez is not meant to be everything to everyone, but rather a good base
+upon which to build.  Thus it takes a fairly batteries-included
+approach without needing a million options and plugins for everything
+imaginable, but also does not dictate higher-level functionality such
+as physics engine or ECS.  Instead the goal is to allow you to use
+whichever libraries you want to provide these functions, or build your
+own libraries atop ggez such as the
+[ggez-goodies](https://github.com/ggez/ggez-goodies) crate.
 
 ## Features
 
@@ -25,27 +30,39 @@ systems such as sprites, layer, tiled maps, etc.
 
 ## Usage
 
-ggez is built on the latest stable Rust compiler and distributed on crates.io.  To include it in your project, just
-add the dependency line to your `Cargo.toml` file:
+ggez is built on the latest stable Rust compiler and distributed on
+crates.io.  To include it in your project, just add the dependency
+line to your `Cargo.toml` file:
 
-```
+```text
 ggez = "0.2.0"
 ```
 
-However you also need to have the SDL2, SDL2_mixer and SDL2_image libraries installed on your system.  The best way to do this is documented
-[by the SDL2 crate](https://github.com/AngryLawyer/rust-sdl2#user-content-requirements).
+However you also need to have the SDL2, SDL2_mixer and SDL2_image
+libraries installed on your system.  The best way to do this is
+documented [by the SDL2
+crate](https://github.com/AngryLawyer/rust-sdl2#user-content-requirements).
+
+ggez consists of three main parts: A `Context` object which contains
+all the state requierd to interface with the computer's hardware, a
+`GameState` trait that the user implements to register callbacks for
+events, and various sub-modules such as `graphics` and `audio` that
+provide the functionality to actually get stuff done.
 
 
 ## Examples
 
-See the examples.  `imageview` is a simple hello-world-y program that shows off a number of things, badly.
-`astroblasto` is a small Asteroids-like game.
+See the `examples/` directory in the source.  `hello_world` is exactly
+what it says.  `imageview` is a simple program that shows off a number
+of features such as sound and drawing.  `astroblasto` is a small
+Asteroids-like game.
 
-To run the examples, you have to copy or symlink the `resources` directory to a
-place the running game can find it.  Cargo does not have an easy way
-of doing this itself at the moment, so the procedure is (on Linux):
+To run the examples, you have to copy or symlink the `resources`
+directory to a place the running game can find it.  Cargo does not
+have an easy way of doing this itself at the moment, so the procedure
+is (on Linux):
 
-```
+```text
 cargo build --example astroblasto
 cp -R resources target/debug/
 cargo run --example astroblasto
@@ -54,8 +71,23 @@ cargo run --example astroblasto
 Either way, if it can't find the resources it will give you an error
 along the lines of `ResourceNotFound("'resources' directory not
 found!  Should be in "/home/foo/src/ggez/target/debug/resources")`.
-Just copy or symlink the `resources` directory to where the error says it's
+Just copy or symlink the `resources/` directory to where the error says it's
 looking.
+
+## Implementation details
+
+ggez is a fairly thin wrapper around SDL2 and a few other
+libraries, which does influence some of the API and impose some
+restrictions.  For example, thread safety.
+
+SDL2 is generally speaking NOT thread-safe.  It uses lots of
+globals internally, and just isn't designed with thread safety in
+mind.  This isn't generally a huge restriction in C code, but in
+Rust the practical result is that none of the types derived from
+SDL2 are `Send` or `Sync`, such as the `ggez::graphics::Image`
+type.  It's inconvenient and we want to work around it eventually,
+but for now, them's the breaks.
+
 
 ## Extant things to do
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ looking.
 
 Enhancements that don't actually change the API or compatibility
 
-* Get rid of unwraps
 * Crate-level docs (so you get an intro instead of just a list of modules on the root page)
 * Document SDL's thread constraints!  It's mentioned in Context struct docs but maybe should be in other places.  The
 Game trait would be a good place to do it perhaps?  Or just a mention in the docs for each resource type?

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -8,8 +8,8 @@
 use std::fmt;
 use std::path;
 
-use sdl2_mixer;
-use sdl2_mixer::LoaderRWops;
+use sdl2;
+use sdl2::mixer::LoaderRWops;
 
 use context::Context;
 use util;
@@ -17,7 +17,7 @@ use GameError;
 use GameResult;
 
 /// An object representing a channel that may be playing a particular Sound.
-pub type Channel = sdl2_mixer::Channel;
+pub type Channel = sdl2::mixer::Channel;
 
 
 /// A trait for general operations on sound objects.
@@ -37,7 +37,7 @@ pub trait AudioOps {
 
 /// A source of audio data.
 pub struct Sound {
-    chunk: sdl2_mixer::Chunk,
+    chunk: sdl2::mixer::Chunk,
 }
 
 impl Sound {
@@ -46,7 +46,7 @@ impl Sound {
         let path = path.as_ref();
         let mut buffer: Vec<u8> = Vec::new();
         let rwops = try!(util::rwops_from_path(context, path, &mut buffer));
-        // SDL2_image SNEAKILY adds this method to RWops.
+        // SDL2_mixer SNEAKILY adds this method to RWops.
         let chunk = try!(rwops.load_wav());
 
         Ok(Sound { chunk: chunk })
@@ -57,7 +57,7 @@ impl Sound {
     /// Returns a `Channel`, which can be used to manipulate the
     /// playback, eg pause, stop, restart, etc.
     pub fn play(&self) -> GameResult<Channel> {
-        let channel = sdl2_mixer::channel(-1);
+        let channel = sdl2::mixer::channel(-1);
         // This try! is a little redundant but make the
         // GameResult type conversion work right.
         channel.play(&self.chunk, 0)
@@ -77,7 +77,7 @@ impl fmt::Debug for Sound {
 impl AudioOps for Channel {
     /// Return a new channel that is not playing anything.
     fn new_channel() -> Channel {
-        sdl2_mixer::channel(-1)
+        sdl2::mixer::channel(-1)
     }
 
     /// Plays the given Sound on this `Channel`
@@ -120,7 +120,7 @@ impl AudioOps for Channel {
 /// `Context::print_sound_stats()` to print out which decoders
 /// are supported for your build.
 pub struct Music {
-    music: sdl2_mixer::Music,
+    music: sdl2::mixer::Music,
 }
 
 
@@ -130,7 +130,7 @@ impl Music {
         let path = path.as_ref();
         let mut buffer: Vec<u8> = Vec::new();
         let rwops = try!(util::rwops_from_path(context, path, &mut buffer));
-        // SDL2_image SNEAKILY adds this method to RWops.
+        // SDL2_mixer SNEAKILY adds this method to RWops.
         let music = try!(rwops.load_music());
 
         Ok(Music { music: music })
@@ -145,7 +145,7 @@ impl fmt::Debug for Music {
 }
 
 /// Play the given music n times.  -1 loops forever.
-pub fn play_music_times(music: &Music, n: isize) -> GameResult<()> {
+pub fn play_music_times(music: &Music, n: i32) -> GameResult<()> {
     music.music
         .play(n)
         .map_err(GameError::from)
@@ -158,21 +158,21 @@ pub fn play_music(music: &Music) -> GameResult<()> {
 
 /// Pause currently playing music
 pub fn pause_music() {
-    sdl2_mixer::Music::pause()
+    sdl2::mixer::Music::pause()
 }
 
 /// Resume currently playing music, if any
 pub fn resume_music() {
-    sdl2_mixer::Music::resume()
+    sdl2::mixer::Music::resume()
 
 }
 
 /// Stop currently playing music
 pub fn stop_music() {
-    sdl2_mixer::Music::halt()
+    sdl2::mixer::Music::halt()
 }
 
 /// Rewind the currently playing music to the beginning.
 pub fn rewind_music() {
-    sdl2_mixer::Music::rewind()
+    sdl2::mixer::Music::rewind()
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,11 +1,9 @@
 
 
 use sdl2::{self, Sdl};
+use sdl2::mixer::Sdl2MixerContext;
 use sdl2::render::Renderer;
 use sdl2::video::Window;
-
-use sdl2_mixer;
-use sdl2_mixer::Sdl2MixerContext;
 
 use std::fmt;
 use std::path;
@@ -59,13 +57,13 @@ fn init_audio(sdl_context: &Sdl) -> GameResult<sdl2::AudioSubsystem> {
 
 fn init_mixer() -> GameResult<Sdl2MixerContext> {
     let frequency = 44100;
-    let format = sdl2_mixer::AUDIO_S16LSB; // signed 16 bit samples, in little-endian byte order
+    let format = sdl2::mixer::AUDIO_S16LSB; // signed 16 bit samples, in little-endian byte order
     let channels = 2; // Stereo
     let chunk_size = 1024;
-    try!(sdl2_mixer::open_audio(frequency, format, channels, chunk_size));
+    try!(sdl2::mixer::open_audio(frequency, format, channels, chunk_size));
 
-    let flags = sdl2_mixer::InitFlag::all();
-    sdl2_mixer::init(flags).map_err(GameError::AudioError)
+    let flags = sdl2::mixer::InitFlag::all();
+    sdl2::mixer::init(flags).map_err(GameError::AudioError)
 }
 
 fn init_window(video: sdl2::VideoSubsystem,
@@ -147,20 +145,20 @@ impl<'a> Context<'a> {
     /// Prints out information on the sound subsystem.
     pub fn print_sound_stats(&self) {
         println!("Allocated {} sound channels",
-                 sdl2_mixer::allocate_channels(-1));
-        let n = sdl2_mixer::get_chunk_decoders_number();
+                 sdl2::mixer::allocate_channels(-1));
+        let n = sdl2::mixer::get_chunk_decoders_number();
         println!("available chunk(sample) decoders: {}", n);
 
         for i in 0..n {
-            println!("  decoder {} => {}", i, sdl2_mixer::get_chunk_decoder(i));
+            println!("  decoder {} => {}", i, sdl2::mixer::get_chunk_decoder(i));
         }
 
-        let n = sdl2_mixer::get_music_decoders_number();
+        let n = sdl2::mixer::get_music_decoders_number();
         println!("available music decoders: {}", n);
         for i in 0..n {
-            println!("  decoder {} => {}", i, sdl2_mixer::get_music_decoder(i));
+            println!("  decoder {} => {}", i, sdl2::mixer::get_music_decoder(i));
         }
-        println!("query spec => {:?}", sdl2_mixer::query_spec());
+        println!("query spec => {:?}", sdl2::mixer::query_spec());
     }
 
     /// Prints out information on the resources subsystem.

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,5 +4,5 @@
 
 pub use sdl2::keyboard::Keycode;
 pub use sdl2::keyboard::Mod;
-pub use sdl2::mouse::Mouse;
+pub use sdl2::mouse::MouseButton;
 pub use sdl2::mouse::MouseState;

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,4 +1,4 @@
-//! This module contains traits and structs to actually run your game mainloop
+//! The `game` module contains traits and structs to actually run your game mainloop
 //! and handle top-level state.
 
 use context::Context;

--- a/src/game.rs
+++ b/src/game.rs
@@ -55,9 +55,9 @@ pub trait GameState {
     // do nothing.
     // It might be nice to be able to have custom event types and a map or
     // such of handlers?  Hmm, maybe later.
-    fn mouse_button_down_event(&mut self, _button: mouse::Mouse, _x: i32, _y: i32) {}
+    fn mouse_button_down_event(&mut self, _button: mouse::MouseButton, _x: i32, _y: i32) {}
 
-    fn mouse_button_up_event(&mut self, _button: mouse::Mouse, _x: i32, _y: i32) {}
+    fn mouse_button_up_event(&mut self, _button: mouse::MouseButton, _x: i32, _y: i32) {}
 
     fn mouse_motion_event(&mut self,
                           _state: mouse::MouseState,
@@ -197,10 +197,10 @@ impl<'a, S: GameState + 'static> Game<'a, S> {
                         self.state.mouse_motion_event(mousestate, x, y, xrel, yrel)
                     }
                     MouseWheel { x, y, .. } => self.state.mouse_wheel_event(x, y),
-                    Window { win_event_id: event::WindowEventId::FocusGained, .. } => {
+                    Window { win_event: event::WindowEvent::FocusGained, .. } => {
                         self.state.focus_event(true)
                     }
-                    Window { win_event_id: event::WindowEventId::FocusLost, .. } => {
+                    Window { win_event: event::WindowEvent::FocusLost, .. } => {
                         self.state.focus_event(false)
                     }
                     _ => {}

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -14,7 +14,7 @@ use std::io::Read;
 use sdl2::pixels;
 use sdl2::render;
 use sdl2::surface;
-use sdl2_image::ImageRWops;
+use sdl2::image::ImageRWops;
 use rusttype;
 
 use context::Context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 extern crate sdl2;
-extern crate sdl2_image;
-extern crate sdl2_mixer;
 extern crate rand;
 extern crate rustc_serialize;
 extern crate rusttype;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,94 @@
-//! # ggez
-//!
-//! ggez is a framework for creating 2D video games.  Its API is
-//! heavily based on the Love2D game engine, though inevitably
-//! with some differences due to the fact that Rust is not Lua.
-//!
+//! # What is this?
+//! [![Build Status](https://!travis-ci.org/ggez/ggez.svg?branch=master)](https://!travis-ci.org/ggez/ggez) [![Docs Status](https://!docs.rs/ggez/badge.svg)](https://!docs.rs/ggez) [![license](http://!img.shields.io/badge/license-MIT-blue.svg)](https://!github.com/svenstaro/ggez/blob/master/LICENSE) [![Crates.io](https://!img.shields.io/crates/v/ggez.svg)](https://!crates.io/crates/ggez) [![Crates.io](https://!img.shields.io/crates/d/ggez.svg)](https://!crates.io/crates/ggez)
+//! 
+//! ggez is a Rust library to create a Good Game Easily.
+//! 
+//! More specifically, ggez is a lightweight game framework for making 2D
+//! games with minimum friction.  It aims to implement an API quite
+//! similar to (a Rustified version of) the Love2D game engine.  This
+//! means it will contain basic and portable 2D drawing, sound, resource
+//! loading and event handling.
+//! 
+//! ggez is not meant to be everything to everyone, but rather a good base
+//! upon which to build.  Thus it takes a fairly batteries-included
+//! approach without needing a million options and plugins for everything
+//! imaginable, but also does not dictate higher-level functionality such
+//! as physics engine or ECS.  Instead the goal is to allow you to use
+//! whichever libraries you want to provide these functions, or build your
+//! own libraries atop ggez such as the
+//! [ggez-goodies](https://!github.com/ggez/ggez-goodies) crate.
+//! 
+//! ## Features
+//! 
+//! * Filesystem abstraction that lets you load resources from folders or zip files
+//! * Hardware-accelerated rendering of bitmaps
+//! * Playing and loading sounds through SDL2_mixer
+//! * TTF font rendering with rusttype, as well as bitmap fonts.
+//! * Interface for handling keyboard and mouse events easily through callbacks
+//! * Config file for defining engine and game settings
+//! * Easy timing and FPS measurement functions.
+//! 
+//! ## Usage
+//! 
+//! ggez is built on the latest stable Rust compiler and distributed on
+//! crates.io.  To include it in your project, just add the dependency
+//! line to your `Cargo.toml` file:
+//! 
+//! ```text
+//! ggez = "0.2.0"
+//! ```
+//! 
+//! However you also need to have the SDL2, SDL2_mixer and SDL2_image
+//! libraries installed on your system.  The best way to do this is
+//! documented [by the SDL2
+//! crate](https://!github.com/AngryLawyer/rust-sdl2#user-content-requirements).
+//! 
 //! ggez consists of three main parts: A `Context` object which contains
-//! all the state requierd to interface with the computer's hardware,
-//! a `GameState` trait that the user implements to register callbacks
-//! for events, and various sub-modules such as `graphics` and `audio`
-//! that provide the functionality to actually get stuff done.
-//!
-//! Note that ggez isn't intended to be everything to everyone; it is
-//! deliberately opinionated and tries to provide a good basic framework
-//! for getting stuff done rather than having a million options for everything
-//! imaginable.
-//!
-//! # Implementation notes
-//!
+//! all the state requierd to interface with the computer's hardware, a
+//! `GameState` trait that the user implements to register callbacks for
+//! events, and various sub-modules such as `graphics` and `audio` that
+//! provide the functionality to actually get stuff done.
+//! 
+//! ## Examples
+//! 
+//! See the `examples/` directory in the source.  `hello_world` is exactly
+//! what it says.  `imageview` is a simple program that shows off a number
+//! of features such as sound and drawing.  `astroblasto` is a small
+//! Asteroids-like game.
+//! 
+//! To run the examples, you have to copy or symlink the `resources`
+//! directory to a place the running game can find it.  Cargo does not
+//! have an easy way of doing this itself at the moment, so the procedure
+//! is (on Linux):
+//! 
+//! ```text
+//! cargo build --example astroblasto
+//! cp -R resources target/debug/
+//! cargo run --example astroblasto
+//! ```
+//! 
+//! Either way, if it can't find the resources it will give you an error
+//! along the lines of `ResourceNotFound("'resources' directory not
+//! found!  Should be in "/home/foo/src/ggez/target/debug/resources")`.
+//! Just copy or symlink the `resources/` directory to where the error says it's
+//! looking.
+//! 
+//! ## Implementation details
+//! 
 //! ggez is a fairly thin wrapper around SDL2 and a few other
 //! libraries, which does influence some of the API and impose some
 //! restrictions.  For example, thread safety.
-//!
-//! ## Thread safety
-//!
-//! SDL2 is generally speaking NOT thread-safe.  It uses lots of globals
-//! internally, and just isn't designed with thread safety in mind.  This
-//! isn't generally a huge restriction in C code, but in Rust the practical
-//! result is that none of the types derived from SDL2 are `Send` or `Sync`,
-//! such as the `ggez::graphics::Image` type.
+//! 
+//! SDL2 is generally speaking NOT thread-safe.  It uses lots of
+//! globals internally, and just isn't designed with thread safety in
+//! mind.  This isn't generally a huge restriction in C code, but in
+//! Rust the practical result is that none of the types derived from
+//! SDL2 are `Send` or `Sync`, such as the `ggez::graphics::Image`
+//! type.  It's inconvenient and we want to work around it eventually,
+//! but for now, them's the breaks.
+
+
+
 
 extern crate sdl2;
 extern crate rand;
@@ -40,7 +101,7 @@ extern crate zip;
 pub mod audio;
 pub mod conf;
 mod context;
-mod error;
+pub mod error;
 pub mod event;
 pub mod filesystem;
 pub mod game;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,34 @@
+//! # ggez
+//!
+//! ggez is a framework for creating 2D video games.  Its API is
+//! heavily based on the Love2D game engine, though inevitably
+//! with some differences due to the fact that Rust is not Lua.
+//!
+//! ggez consists of three main parts: A `Context` object which contains
+//! all the state requierd to interface with the computer's hardware,
+//! a `GameState` trait that the user implements to register callbacks
+//! for events, and various sub-modules such as `graphics` and `audio`
+//! that provide the functionality to actually get stuff done.
+//!
+//! Note that ggez isn't intended to be everything to everyone; it is
+//! deliberately opinionated and tries to provide a good basic framework
+//! for getting stuff done rather than having a million options for everything
+//! imaginable.
+//!
+//! # Implementation notes
+//!
+//! ggez is a fairly thin wrapper around SDL2 and a few other
+//! libraries, which does influence some of the API and impose some
+//! restrictions.  For example, thread safety.
+//!
+//! ## Thread safety
+//!
+//! SDL2 is generally speaking NOT thread-safe.  It uses lots of globals
+//! internally, and just isn't designed with thread safety in mind.  This
+//! isn't generally a huge restriction in C code, but in Rust the practical
+//! result is that none of the types derived from SDL2 are `Send` or `Sync`,
+//! such as the `ggez::graphics::Image` type.
+
 extern crate sdl2;
 extern crate rand;
 extern crate rustc_serialize;

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@
 use std::path;
 use sdl2::rwops;
 use sdl2::surface;
-use sdl2_image::ImageRWops;
+use sdl2::image::ImageRWops;
 
 use context::Context;
 use GameError;


### PR DESCRIPTION
Hi,

I got the urge to update this library to the latest version of rust-sdl2, which merges the image and mixer crates into features of the sdl2 crate.

As far as I can see all examples still work!

Also, it seems there are two breaking changes on our side (if I'm understanding this right :) )

1) play_num_times should take an i32 instead of an isize to match the rust-sdl2 api change
2) MouseButton instead of Mouse in the mouse button events

Very new to rust, so hope all looks ok.