### PR TITLE
Draw shapes using lyon tessellation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ rodio = {git="https://github.com/tomaka/rodio.git", branch="master"}
 
 rustc-serialize = "0.3"
 toml = "0.2"
+lyon = "0.3.2"

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -61,6 +61,7 @@ impl event::EventHandler for MainState {
         let rect = graphics::Rect::new(450.0, 450.0, 50.0, 50.0);
         graphics::rectangle(ctx, graphics::DrawMode::Fill, rect)?;
 
+        graphics::set_line_width(ctx, 4.0);
         graphics::line(ctx, &[
             Point { x: 200.0, y: 200.0 },
             Point { x: 400.0, y: 200.0 },

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -4,6 +4,7 @@ use ggez::event;
 use ggez::{GameResult, Context};
 use ggez::graphics;
 use ggez::timer;
+use ggez::graphics::Point;
 use std::time::Duration;
 
 // First we make a structure to contain the game's state
@@ -59,6 +60,15 @@ impl event::EventHandler for MainState {
 
         let rect = graphics::Rect::new(450.0, 450.0, 50.0, 50.0);
         graphics::rectangle(ctx, graphics::DrawMode::Fill, rect)?;
+
+        graphics::line(ctx, &[
+            Point { x: 200.0, y: 200.0 },
+            Point { x: 400.0, y: 200.0 },
+            Point { x: 400.0, y: 400.0 },
+            Point { x: 200.0, y: 400.0 },
+            Point { x: 200.0, y: 200.0 },
+        ])?;
+
         graphics::present(ctx);
         // println!("Approx FPS: {}", timer::get_fps(ctx));
         // timer::sleep_until_next_frame(ctx, 60);

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -4,7 +4,7 @@ use ggez::event;
 use ggez::{GameResult, Context};
 use ggez::graphics;
 use ggez::timer;
-use ggez::graphics::Point;
+use ggez::graphics::{ DrawMode, Point };
 use std::time::Duration;
 
 // First we make a structure to contain the game's state
@@ -69,6 +69,15 @@ impl event::EventHandler for MainState {
             Point { x: 200.0, y: 400.0 },
             Point { x: 200.0, y: 200.0 },
         ])?;
+
+        graphics::ellipse(ctx,
+                          DrawMode::Fill,
+                          Point { x: 600.0, y: 200.0 },
+                          50.0,
+                          120.0,
+                          32)?;
+
+        graphics::circle(ctx, DrawMode::Fill, Point {x : 600.0, y: 380.0 }, 40.0, 32)?;
 
         graphics::present(ctx);
         // println!("Approx FPS: {}", timer::get_fps(ctx));

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -421,7 +421,7 @@ pub fn ellipse(ctx: &mut Context,
 pub fn line(ctx: &mut Context, points: &[Point]) -> GameResult<()> {
     let gfx = &mut ctx.gfx_context;
 
-    let buffers = tessellation::build_line(points, tessellation::ScreenUV).unwrap();
+    let buffers = tessellation::build_line(points, gfx.line_width, tessellation::ScreenUV).unwrap();
 
     let (buf, slice) = gfx.factory.create_vertex_buffer_with_slice(
         &buffers.vertices[..],

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -28,6 +28,8 @@ use GameError;
 use GameResult;
 
 mod types;
+mod tessellation;
+
 pub use self::types::{Rect, Point, Color, BlendMode};
 
 const GL_MAJOR_VERSION: u8 = 3;
@@ -143,6 +145,7 @@ pub struct GraphicsContextGeneric<R, F, C, D>
     pso: gfx::PipelineState<R, pipe::Meta>,
     data: pipe::Data<R>,
     quad_slice: gfx::Slice<R>,
+    quad_vertex_buffer: gfx::handle::Buffer<R, Vertex>,
 }
 
 // GL only
@@ -225,14 +228,14 @@ impl GraphicsContext {
         let sampler = factory.create_sampler_linear();
         let white_image = Image::make_raw(&mut factory, 1, 1, &[&[255, 255, 255, 255]]).unwrap();
         let texture = white_image.texture.clone();
+
         let data = pipe::Data {
-            vbuf: quad_vertex_buffer,
+            vbuf: quad_vertex_buffer.clone(),
             tex: (texture, sampler),
             rect_properties: rect_props,
             globals: globals_buffer,
             out: color_view,
         };
-
 
         // Set initial uniform values
         let globals = Globals {
@@ -264,6 +267,7 @@ impl GraphicsContext {
             pso: pso,
             data: data,
             quad_slice: quad_slice,
+            quad_vertex_buffer: quad_vertex_buffer,
         };
         gfx.update_globals();
         Ok(gfx)
@@ -415,7 +419,22 @@ pub fn ellipse(ctx: &mut Context,
 
 /// Draws a line of one or more connected segments.
 pub fn line(ctx: &mut Context, points: &[Point]) -> GameResult<()> {
-    unimplemented!();
+    let gfx = &mut ctx.gfx_context;
+
+    let buffers = tessellation::build_line(points, tessellation::ScreenUV).unwrap();
+
+    let (buf, slice) = gfx.factory.create_vertex_buffer_with_slice(
+        &buffers.vertices[..],
+        &buffers.indices[..],
+    );
+
+    gfx.encoder.update_buffer(&gfx.data.rect_properties, &[RectProperties::default()], 0);
+
+    gfx.data.vbuf = buf;
+    gfx.data.tex.0 = gfx.white_image.texture.clone();
+
+    gfx.encoder.draw(&slice, &gfx.pso, &gfx.data);
+    Ok(())
 }
 
 /// Draws points.
@@ -758,6 +777,7 @@ impl Drawable for Image {
         // gfx.encoder.update_buffer(&gfx.data.transform, &[transform], 0);
         // TODO: BUGGO: Make sure these clones are cheap; they should be.
         let (_, sampler) = gfx.data.tex.clone();
+        gfx.data.vbuf = gfx.quad_vertex_buffer.clone();
         gfx.data.tex = (self.texture.clone(), sampler);
         gfx.encoder.draw(&gfx.quad_slice, &gfx.pso, &gfx.data);
         Ok(())

--- a/src/graphics/tessellation.rs
+++ b/src/graphics/tessellation.rs
@@ -1,0 +1,64 @@
+use lyon;
+use lyon::path;
+use lyon::path_builder::BaseBuilder;
+use lyon::path_iterator::PathIterator;
+use lyon::tessellation;
+use lyon::tessellation::math;
+use lyon::tessellation::path_stroke;
+use lyon::tessellation::geometry_builder;
+
+use super::{ Point, Vertex };
+
+pub type Buffer = geometry_builder::VertexBuffers<Vertex>;
+
+pub struct ConstantUV {
+    uv: [f32; 2],
+}
+
+impl geometry_builder::VertexConstructor<math::Point, Vertex> for ConstantUV {
+    fn new_vertex(&mut self, input: math::Point) -> Vertex {
+        Vertex {
+            pos: [ input.x, input.y ],
+            uv: self.uv.clone(),
+        }
+    }
+}
+
+pub struct ScreenUV;
+
+impl geometry_builder::VertexConstructor<math::Point, Vertex> for ScreenUV {
+    fn new_vertex(&mut self, input: math::Point) -> Vertex {
+        Vertex {
+            pos: [ input.x, input.y ],
+            uv: [ input.x, input.y ],
+        }
+    }
+}
+
+fn build_path(points: &[Point]) -> path::Path {
+    let mut path_builder = path::Builder::with_capacity(points.len());
+    path_builder.move_to(math::point(points[0].x, points[0].y));
+
+    for p in &points[1..] {
+        path_builder.line_to(math::point(p.x, p.y));
+    }
+
+    path_builder.build()
+}
+
+pub fn build_line<T>(points: &[Point], ctor: T) -> Result<Buffer, ()>
+    where T: geometry_builder::VertexConstructor<math::Point, Vertex>
+{
+    let path = build_path(points);
+
+    let mut buffers = geometry_builder::VertexBuffers::new();
+    {
+        let mut buf_builder = geometry_builder::BuffersBuilder::new(&mut buffers, ctor);
+
+        let opts = path_stroke::StrokeOptions::default();
+        let mut tesselator = path_stroke::StrokeTessellator::new();
+        tesselator.tessellate(path.path_iter().flattened(0.5), &opts, &mut buf_builder)?;
+    }
+
+    Ok(buffers)
+}

--- a/src/graphics/tessellation.rs
+++ b/src/graphics/tessellation.rs
@@ -46,7 +46,7 @@ fn build_path(points: &[Point]) -> path::Path {
     path_builder.build()
 }
 
-pub fn build_line<T>(points: &[Point], ctor: T) -> Result<Buffer, ()>
+pub fn build_line<T>(points: &[Point], line_width: f32, ctor: T) -> Result<Buffer, ()>
     where T: geometry_builder::VertexConstructor<math::Point, Vertex>
 {
     let path = build_path(points);
@@ -55,7 +55,7 @@ pub fn build_line<T>(points: &[Point], ctor: T) -> Result<Buffer, ()>
     {
         let mut buf_builder = geometry_builder::BuffersBuilder::new(&mut buffers, ctor);
 
-        let opts = path_stroke::StrokeOptions::default();
+        let opts = path_stroke::StrokeOptions::stroke_width(line_width);
         let mut tesselator = path_stroke::StrokeTessellator::new();
         tesselator.tessellate(path.path_iter().flattened(0.5), &opts, &mut buf_builder)?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ extern crate rustc_serialize;
 extern crate rusttype;
 extern crate toml;
 extern crate zip;
-
+extern crate lyon;
 
 pub mod audio;
 pub mod conf;


### PR DESCRIPTION
This is a quick and dirty prototype of drawing functions based on lyon crate. Probably not in a mergeable shape yet.

This PR implements line, filled circle and ellipse drawing. Line circles and ellipses do not seem to be supported in lyon currently.