### PR TITLE
Add basic 2D mesh

### DIFF
--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -276,6 +276,25 @@ impl GraphicsContext {
     fn update_globals(&mut self) {
         self.encoder.update_buffer(&self.data.globals, &[self.shader_globals], 0);
     }
+
+    fn update_rect_properties(&mut self,
+                              quad: Rect,
+                              dest: Point,
+                              rotation: f32,
+                              scale: Point,
+                              offset: Point,
+                              shear: Point) {
+        let properties = RectProperties {
+            src: [0.0, 0.0, 0.0, 0.0],
+            dest: dest.into(),
+            scale: [scale.x, scale.y],
+            offset: offset.into(),
+            shear: shear.into(),
+            rotation: rotation,
+        };
+
+        self.encoder.update_buffer(&self.data.rect_properties, &[properties], 0);
+    }
 }
 
 
@@ -770,15 +789,11 @@ impl Drawable for Image {
                -> GameResult<()> {
         let gfx = &mut context.gfx_context;
 
-        let properties = RectProperties {
-            src: [0.0, 0.0, 0.0, 0.0],
-            dest: dest.into(),
-            scale: [scale.x * self.width as f32, scale.y * self.height as f32],
-            offset: offset.into(),
-            shear: shear.into(),
-            rotation: rotation,
+        let real_scale = Point {
+            x: scale.x * self.width as f32,
+            y: scale.y * self.height as f32,
         };
-        gfx.encoder.update_buffer(&gfx.data.rect_properties, &[properties], 0);
+        gfx.update_rect_properties(quad, dest, rotation, real_scale, offset, shear);
 
         // let transform = Transform { transform: ortho(-1.5, 1.5, 1.0, -1.0, 1.0, -1.0) };
         // gfx.encoder.update_buffer(&gfx.data.transform, &[transform], 0);

--- a/src/graphics/tessellation.rs
+++ b/src/graphics/tessellation.rs
@@ -71,13 +71,7 @@ pub fn build_line(points: &[Point], line_width: f32) -> GameResult<Buffer> {
     build_geometry(|builder| tessellator.tessellate(path.path_iter().flattened(0.5), &opts, builder))
 }
 
-pub fn build_ellipse_fill(point: Point,
-                          r1: f32,
-                          r2: f32,
-                          segments: u32,
-                          line_width: f32)
-                          -> GameResult<Buffer> {
-    let opts = path_stroke::StrokeOptions::stroke_width(line_width);
+pub fn build_ellipse_fill(point: Point, r1: f32, r2: f32, segments: u32) -> GameResult<Buffer> {
     build_geometry(|builder| {
         Ok(tessellation::basic_shapes::tessellate_ellipsis(math::point(point.x, point.y),
                                                            math::point(r1, r2),

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
 pub struct Point {
     pub x: f32,
     pub y: f32,
@@ -21,7 +21,7 @@ impl From<Point> for [f32; 2] {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
 pub struct Rect {
     pub x: f32,
     pub y: f32,


### PR DESCRIPTION
This PR adds a simple wrapper around vertex buffer and a slice, and a bunch of constructors that mirror existing immediate mode drawing commands. Immediate drawing functions now simply create throwaway meshes and call draw on them.

There is no API yet to create arbitrary meshes, since there is no public type to represent a point with UV coordinates.

Unanswered questions:
- how API for custom meshes should look like?
- what is the right abstraction level for the mesh? Is it just a bunch of vertices, and the graphics state (colors, textures, transformations) are inherited from the global context, or do meshes have attributes of their own? 
  
  Love2d actually has a little bit of both - colors can be set for each vertex or globally, but it seems that the texture can only be set on the mesh itself.