### PR TITLE
Make font_from_bytes public

### DIFF
--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -47,7 +47,7 @@ impl Font {
         Font::font_from_bytes(&name, buf, size)
     }
 
-    fn font_from_bytes<B>(name: &str, bytes: B, size: u32) -> GameResult<Font>
+    pub fn font_from_bytes<B>(name: &str, bytes: B, size: u32) -> GameResult<Font>
         where B: Into<rusttype::SharedBytes<'static>>
     {
         let collection = rusttype::FontCollection::from_bytes(bytes);


### PR DESCRIPTION
This may defeat the spirit of ggez, but I'd love to have font_from_bytes public.

I'm writing a semi-asychronous asset manager and doing this allows me to create a font on a seperate thread entirely, as I don't need to worry about carrying Context and passing that in.

I feel like this should be fine, since it seems analagous to Image::from_rbga, which is public.

Thanks!