### PR TITLE
Read CARGO_MANIFEST_DIR at runtime instead of compile-time

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -155,10 +155,12 @@ impl Filesystem {
         // Cargo manifest dir!
         #[cfg(feature = "cargo-resource-root")]
         {
-            let mut path = path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-            path.push("resources");
-            let physfs = vfs::PhysicalFS::new(&path, false);
-            overlay.push_back(Box::new(physfs));
+            if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
+                let mut path = path::PathBuf::from(manifest_dir);
+                path.push("resources");
+                let physfs = vfs::PhysicalFS::new(&path, false);
+                overlay.push_back(Box::new(physfs));
+            }
         }
 
         let fs = Filesystem { 


### PR DESCRIPTION
I spent last night playing around with ggez for the first time - I absolutely love it so far (*"Love2D in Rust"* is basically my dream game library, so no surprises there)!

The only major issue I ran into was when I tried to set up the `cargo-resource-root` feature - no matter what I did, I couldn't seem to get it to load my sprites. Printing out the initial state of the VFS tipped me off to the cause:

![Screenshot of a console showing ggez searching for resources in the Cargo registry directory - huh?!](https://cloud.githubusercontent.com/assets/784533/26600475/25d50530-4574-11e7-9045-c72c91a39d76.png)

It seems that `CARGO_MANIFEST_DIR` gets set for each dependency during a build - meaning that calling `env!("CARGO_MANIFEST_DIR")` from within ggez actually gives you *ggez's* root directory, rather than your game's. Grabbing the value of the environment variable at runtime instead gives much more reasonable results:

![Screenshot of a console showing ggez searching for resources in the expected place](https://cloud.githubusercontent.com/assets/784533/26600563/74bdab7a-4574-11e7-8866-ffe1ff0f540c.png)

Looking at #39, this was something that was planned anyway to avoid exposing build paths in your binary, and it seemed like an easy change to make, so I thought I'd give it a go :) Let me know if any changes need making, or if there's a reason I'm missing why this is a bad idea!

---

Areas I'm slightly uncertain about with this change (quite new to opening PRs!):
* Is it okay for the code to just get ignored if `CARGO_MANIFEST_DIR` doesn't exist?
* Was this issue also present on MacOS/Linux? I only have access to a Windows PC :(
* Are there any issues with the code style that need fixing? [rustfmt is broken on Windows at the minute](https://github.com/rust-lang-nursery/rustfmt/issues/1525), so I can't run it.