### PR TITLE
Bring back GameError::ResourceNotFound

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -381,7 +381,7 @@ mod tests {
         {
             let rel_file = "testfile.txt";
             match fs.open(rel_file) {
-                Err(GameError::FilesystemError(_)) => (),
+                Err(GameError::ResourceNotFound(_, _)) => (),
                 Err(e) => panic!("Invalid error for opening file with relative path: {:?}", e),
                 Ok(f) => panic!("Should have gotten an error but instead got {:?}!", f),
             }
@@ -391,7 +391,7 @@ mod tests {
             // This absolute path should work on Windows too since we
             // completely remove filesystem roots.
             match fs.open("/ooglebooglebarg.txt") {
-                Err(GameError::FilesystemError(_)) => (),
+                Err(GameError::ResourceNotFound(_, _)) => (),
                 Err(e) => panic!("Invalid error for opening nonexistent file: {}", e),
                 Ok(f) => panic!("Should have gotten an error but instead got {:?}", f),
             }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -133,6 +133,9 @@ pub trait VFS: Debug {
 
     /// Retrieve all file and directory entries in the given directory.
     fn read_dir(&self, path: &Path) -> GameResult<Box<Iterator<Item = GameResult<PathBuf>>>>;
+
+    /// Retrieve the actual location of the VFS root, if available.
+    fn to_path_buf(&self) -> Option<PathBuf>;
 }
 
 pub trait VMetadata {
@@ -345,6 +348,11 @@ impl VFS for PhysicalFS {
             .into_iter();
         Ok(Box::new(itr))
     }
+
+    /// Retrieve the actual location of the VFS root, if available.
+    fn to_path_buf(&self) -> Option<PathBuf> {
+        Some(self.root.clone())
+    }
 }
 
 /// A structure that joins several VFS's together in order.
@@ -450,6 +458,11 @@ impl VFS for OverlayFS {
             }
         }
         Ok(Box::new(v.into_iter()))
+    }
+
+    /// Retrieve the actual location of the VFS root, if available.
+    fn to_path_buf(&self) -> Option<PathBuf> {
+        None
     }
 }
 
@@ -656,6 +669,10 @@ impl VFS for ZipFS {
             .map(|s| Ok(PathBuf::from(s)))
             .collect::<Vec<_>>();
         Ok(Box::new(itr.into_iter()))
+    }
+
+    fn to_path_buf(&self) -> Option<PathBuf> {
+        Some(self.source.clone())
     }
 }
 

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -464,7 +464,7 @@ pub struct ZipFS {
     // ALSO THE SEMANTICS OF ZIPARCHIVE AND HAVING ZIPFILES BORROW IT IS
     // HORRIFICALLY BROKEN BY DESIGN SO WE'RE JUST GONNA REFCELL IT AND COPY
     // ALL CONTENTS OUT OF IT.
-    source: String,
+    source: PathBuf,
     archive: RefCell<zip::ZipArchive<fs::File>>,
     // We keep an index of what files are in the zip file
     // because trying to read it lazily is a pain in the butt.
@@ -479,7 +479,7 @@ impl ZipFS {
             .map(|i| archive.by_index(i).unwrap().name().to_string())
             .collect();
         Ok(Self {
-            source: filename.to_string_lossy().into_owned(),
+            source: filename.into(),
             archive: RefCell::new(archive),
             index: idx,
         })
@@ -588,7 +588,7 @@ impl VFS for ZipFS {
            open_options.truncate {
             let msg = format!("Cannot alter file {:?} in zipfile {:?}, filesystem read-only",
                               path,
-                              &self.source);
+                              self);
             return Err(GameError::FilesystemError(msg));
         }
         let mut stupid_archive_borrow = self.archive
@@ -602,7 +602,7 @@ impl VFS for ZipFS {
     fn mkdir(&self, path: &Path) -> GameResult<()> {
         let msg = format!("Cannot mkdir {:?} in zipfile {:?}, filesystem read-only",
                           path,
-                          &self.source);
+                          self);
         Err(GameError::FilesystemError(msg))
 
     }
@@ -610,14 +610,14 @@ impl VFS for ZipFS {
     fn rm(&self, path: &Path) -> GameResult<()> {
         let msg = format!("Cannot rm {:?} in zipfile {:?}, filesystem read-only",
                           path,
-                          &self.source);
+                          self);
         Err(GameError::FilesystemError(msg))
     }
 
     fn rmrf(&self, path: &Path) -> GameResult<()> {
         let msg = format!("Cannot rmrf {:?} in zipfile {:?}, filesystem read-only",
                           path,
-                          &self.source);
+                          self);
         Err(GameError::FilesystemError(msg))
     }
 


### PR DESCRIPTION
As requested in #84, I've had a go at updating the error message returned by `OverlayFS::open_options` to contain a list of searched paths. A lot of the work had already been done for me in #27 by @AaronM04 (cheers!) - just had to find a way to bring his code into the new VFS module.

Here's the changes I've made:

* There wasn't currently a way of getting the real root path of a `VFS` trait object, so I added a `to_path_buf` method. It returns `Option<PathBuf>`, just to futureproof in case a VFS type without a logical path gets added (e.g. a in-memory filesystem).
  * This is basically what the [`vfs`](https://docs.rs/vfs/0.2.0/vfs/trait.VPath.html#tymethod.to_path_buf) crate does.
  * As part of implementing this, I had to change the `source` field on `ZipFS` to a `PathBuf` - that made it more consistent with `PhysicalFS` though, so hopefully that's alright. I also updated the error messages to be more consistent, but I can back that out if you think they were fine as was.
* With that in place, I was able to collect the `PathBuf`s in `OverlayFS::open_options` and return a `GameError::ResourceNotFound`, as the old version of the filesystem used to.
* I also updated the filesystem tests to reflect the change in error type.

![the new error message, with a list of searched paths included](https://puu.sh/w9AQW/756d6e01a5.png)

Let me know if there's any issues/things you want changing!