### PR TITLE
Fix bug with spritebatch global transform not being reset

### DIFF
--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -212,6 +212,7 @@ where
 {
     background_color: Color,
     shader_globals: Globals,
+    global_transform: Vec<GlobalTransform>,
     white_image: Image,
     line_width: f32,
     point_size: f32,
@@ -381,10 +382,13 @@ impl GraphicsContext {
             projection: ortho(left, right, top, bottom, 1.0, -1.0),
             color: types::WHITE.into(),
         };
+        let initial_transform: GlobalTransform = Default::default();
+        let global_transform = vec![initial_transform];
 
         let mut gfx = GraphicsContext {
             background_color: Color::new(0.1, 0.2, 0.3, 1.0),
             shader_globals: globals,
+            global_transform,
             line_width: 1.0,
             point_size: 1.0,
             white_image: white_image,
@@ -406,8 +410,6 @@ impl GraphicsContext {
             samplers: samplers,
         };
 
-        let transform: GlobalTransform = Default::default();
-        gfx.update_transform(transform)?;
         let w = screen_width as f32;
         let h = screen_height as f32;
         let rect = Rect {
@@ -418,6 +420,7 @@ impl GraphicsContext {
         };
         gfx.set_graphics_rect(rect);
         gfx.update_globals()?;
+        gfx.update_transform()?;
         Ok(gfx)
     }
 
@@ -427,11 +430,28 @@ impl GraphicsContext {
         Ok(())
     }
 
-    fn update_transform(&mut self, transform: GlobalTransform) -> GameResult<()> {
+    fn update_transform(&mut self) -> GameResult<()> {
+        let transform = self.get_transform();
         self.encoder.update_buffer(
-            &self.data.transform, &[transform], 0
+            &self.data.transform, 
+            &[transform],
+            0
         )?;
         Ok(())
+    }
+
+    fn push_transform(&mut self, transform: GlobalTransform) {
+        self.global_transform.push(transform);
+    }
+
+    fn pop_transform(&mut self) {
+        if self.global_transform.len() > 1 {
+            self.global_transform.pop();
+        }
+    }
+
+    fn get_transform(&self) -> GlobalTransform {
+        self.global_transform[self.global_transform.len() - 1]
     }
 
     fn update_rect_properties(&mut self, draw_params: DrawParam) -> GameResult<()> {

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -146,11 +146,13 @@ impl graphics::Drawable for SpriteBatch {
             .get_or_insert(self.image.sampler_info, gfx.factory.as_mut());
         gfx.data.vbuf = gfx.quad_vertex_buffer.clone();
         gfx.data.tex = (self.image.texture.clone(), sampler);
-        gfx.quad_slice.instances = Some((self.sprites.len() as u32, 0));
-        let prev_transform = gfx.data.transform.clone();
-        gfx.update_transform(param.into())?;
-        gfx.encoder.draw(&gfx.quad_slice, &gfx.pso, &gfx.data);
-        gfx.data.transform = prev_transform;
+        let mut slice = gfx.quad_slice.clone();
+        slice.instances = Some((self.sprites.len() as u32, 0));
+        gfx.push_transform(param.into());
+        gfx.update_transform()?;
+        gfx.encoder.draw(&slice, &gfx.pso, &gfx.data);
+        gfx.pop_transform();
+        gfx.update_transform()?;
         Ok(())
     }
 }


### PR DESCRIPTION
Also made global transform a stack with an update pattern more similar the "globals" object and with a more convenient push and pop modification pattern.