### PR TITLE
new transform pipeline

### DIFF
--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -82,20 +82,20 @@ impl event::EventHandler for MainState {
 
         graphics::set_line_width(ctx, 4.0);
         graphics::line(ctx,
-                       &[Point { x: 200.0, y: 200.0 },
-                         Point { x: 400.0, y: 200.0 },
-                         Point { x: 400.0, y: 400.0 },
-                         Point { x: 200.0, y: 400.0 },
-                         Point { x: 200.0, y: 200.0 }])?;
+                       &[Point::new(200.0, 200.0),
+                         Point::new(400.0, 200.0),
+                         Point::new(400.0, 400.0),
+                         Point::new(200.0, 400.0),
+                         Point::new(200.0, 200.0)])?;
 
         graphics::ellipse(ctx,
                           DrawMode::Fill,
-                          Point { x: 600.0, y: 200.0 },
+                          Point::new(600.0, 200.0),
                           50.0,
                           120.0,
                           1.0)?;
 
-        graphics::circle(ctx, DrawMode::Fill, Point { x: 600.0, y: 380.0 }, 40.0, 1.0)?;
+        graphics::circle(ctx, DrawMode::Fill, Point::new(600.0, 380.0), 40.0, 1.0)?;
 
         graphics::present(ctx);
         Ok(())

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -24,10 +24,10 @@ impl event::EventHandler for MainState {
         graphics::clear(ctx);
         graphics::circle(ctx,
                          DrawMode::Fill,
-                         Point {
-                             x: self.pos_x,
-                             y: 380.0,
-                         },
+                         Point::new(
+                             self.pos_x,
+                             380.0,
+                         ),
                          100.0,
                          1.0)?;
         graphics::present(ctx);

--- a/examples/super_simple.rs
+++ b/examples/super_simple.rs
@@ -24,10 +24,10 @@ impl event::EventHandler for MainState {
         graphics::clear(ctx);
         graphics::circle(ctx,
                          DrawMode::Fill,
-                         Point {
-                             x: self.pos_x,
-                             y: 380.0,
-                         },
+                         Point::new(
+                             self.pos_x,
+                             380.0,
+                         ),
                          100.0,
                          2.0)?;
         graphics::present(ctx);

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -778,13 +778,7 @@ pub fn set_screen_coordinates(context: &mut Context, rect: Rect) -> GameResult<(
 /// pushes a copy of the current transform matrix to the top of the stack.
 ///
 /// A `DrawParam` can be converted into an appropriate transform
-/// matrix by calling `param.into_matrix()` like so:
-///
-/// ```
-/// # use ggez::graphics;
-/// # let param: graphics::DrawParam = Default::default();
-/// graphics::push_transform(Some(param.into_matrix()));
-/// ```
+/// matrix by calling `param.into_matrix()`.
 pub fn push_transform(context: &mut Context, transform: Option<Matrix4>) {
     let gfx = &mut context.gfx_context;
     if let Some(t) = transform {
@@ -806,13 +800,7 @@ pub fn pop_transform(context: &mut Context) {
 /// transformation matrix.
 ///
 /// A `DrawParam` can be converted into an appropriate transform
-/// matrix by calling `param.into_matrix()` like so:
-///
-/// ```
-/// # use ggez::graphics;
-/// # let param: graphics::DrawParam = Default::default();
-/// graphics::set_transform(param.into_matrix());
-/// ```
+/// matrix by calling `param.into_matrix()`.
 pub fn set_transform(context: &mut Context, transform: Matrix4) {
     let gfx = &mut context.gfx_context;
     gfx.set_transform(transform);
@@ -821,13 +809,7 @@ pub fn set_transform(context: &mut Context, transform: Matrix4) {
 /// Appends the given transform to the current model transform.
 /// 
 /// A `DrawParam` can be converted into an appropriate transform
-/// matrix by calling `param.into_matrix()` like so:
-///
-/// ```
-/// # use ggez::graphics;
-/// # let param: graphics::DrawParam = Default::default();
-/// graphics::transform(param.into_matrix());
-/// ```
+/// matrix by calling `param.into_matrix()`.
 pub fn transform(context: &mut Context, transform: Matrix4) {
     let gfx = &mut context.gfx_context;
     let curr = gfx.transform_stack[gfx.transform_stack.len() - 1].clone();

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -338,8 +338,8 @@ impl GraphicsContext {
         let right = screen_width as f32;
         let top = 0.0;
         let bottom = screen_height as f32;
-        let initial_projection = Matrix4::new_orthographic(left, right, top, bottom, -1.0, 1.0);
-        let initial_view = Matrix4::identity();//.prepend_scaling(0.05);
+        let initial_projection = Matrix4::identity(); // not the actual initial projection matrix, just placeholder
+        let initial_view = Matrix4::identity();
         let initial_transform = Matrix4::identity();
         let globals = Globals {
             mvp_matrix: initial_projection.into(),
@@ -374,6 +374,7 @@ impl GraphicsContext {
             samplers: samplers,
         };
 
+        // Calculate and apply the actual initial projection matrix
         let w = screen_width as f32;
         let h = screen_height as f32;
         let rect = Rect {
@@ -383,6 +384,7 @@ impl GraphicsContext {
             h: -h,
         };
         gfx.set_projection_rect(rect);
+        gfx.calculate_transform_matrix();
         gfx.update_globals()?;
         Ok(gfx)
     }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -781,7 +781,9 @@ pub fn set_screen_coordinates(context: &mut Context, rect: Rect) -> GameResult<(
 /// matrix by calling `param.into_matrix()` like so:
 ///
 /// ```
-/// graphics::push_transform(param.into_matrix());
+/// # use ggez::graphics;
+/// # let param: graphics::DrawParam = Default::default();
+/// graphics::push_transform(Some(param.into_matrix()));
 /// ```
 pub fn push_transform(context: &mut Context, transform: Option<Matrix4>) {
     let gfx = &mut context.gfx_context;
@@ -807,6 +809,8 @@ pub fn pop_transform(context: &mut Context) {
 /// matrix by calling `param.into_matrix()` like so:
 ///
 /// ```
+/// # use ggez::graphics;
+/// # let param: graphics::DrawParam = Default::default();
 /// graphics::set_transform(param.into_matrix());
 /// ```
 pub fn set_transform(context: &mut Context, transform: Matrix4) {
@@ -820,6 +824,8 @@ pub fn set_transform(context: &mut Context, transform: Matrix4) {
 /// matrix by calling `param.into_matrix()` like so:
 ///
 /// ```
+/// # use ggez::graphics;
+/// # let param: graphics::DrawParam = Default::default();
 /// graphics::transform(param.into_matrix());
 /// ```
 pub fn transform(context: &mut Context, transform: Matrix4) {

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -419,6 +419,12 @@ impl GraphicsContext {
         }
     }
 
+    /// Sets the current transform matrix.
+    fn set_transform(&mut self, t: Matrix4) {
+        let idx = self.transform_stack.len() - 1;
+        self.transform_stack[idx] = t;
+    }
+
     /// Pushes a homogeneous transform matrix to the top of the view 
     /// matrix stack.
     fn push_view(&mut self, v: Matrix4) {
@@ -431,6 +437,12 @@ impl GraphicsContext {
         if self.view_stack.len() > 1 {
             self.view_stack.pop();
         }
+    }
+
+    /// Sets the current transform matrix.
+    fn set_view(&mut self, t: Matrix4) {
+        let idx = self.view_stack.len() - 1;
+        self.view_stack[idx] = t;
     }
 
     /// Converts the given `DrawParam` into an `InstanceProperties` object and
@@ -760,7 +772,8 @@ pub fn set_screen_coordinates(context: &mut Context, rect: Rect) -> GameResult<(
 }
 
 /// Pushes a homogeneous transform matrix to the top of the transform 
-/// (model) matrix stack of the `Context`.
+/// (model) matrix stack of the `Context`. If no matrix is given, then
+/// pushes a copy of the current transform matrix to the top of the stack.
 ///
 /// A `DrawParam` can be converted into an appropriate transform
 /// matrix by calling `param.into_matrix()` like so:
@@ -768,9 +781,14 @@ pub fn set_screen_coordinates(context: &mut Context, rect: Rect) -> GameResult<(
 /// ```
 /// graphics::push_transform(param.into_matrix());
 /// ```
-pub fn push_transform(context: &mut Context, transform: Matrix4) {
+pub fn push_transform(context: &mut Context, transform: Option<Matrix4>) {
     let gfx = &mut context.gfx_context;
-    gfx.push_transform(transform);
+    if let Some(t) = transform {
+        gfx.push_transform(t);
+    } else {
+        let copy = gfx.transform_stack[gfx.transform_stack.len() - 1].clone();
+        gfx.push_transform(copy);
+    }
 }
 
 /// Pops the transform matrix off the top of the transform 
@@ -778,6 +796,40 @@ pub fn push_transform(context: &mut Context, transform: Matrix4) {
 pub fn pop_transform(context: &mut Context) {
     let gfx = &mut context.gfx_context;
     gfx.pop_transform();
+}
+
+/// Sets the current model transformation to the given homogeneous
+/// transformation matrix.
+///
+/// A `DrawParam` can be converted into an appropriate transform
+/// matrix by calling `param.into_matrix()` like so:
+///
+/// ```
+/// graphics::set_transform(param.into_matrix());
+/// ```
+pub fn set_transform(context: &mut Context, transform: Matrix4) {
+    let gfx = &mut context.gfx_context;
+    gfx.set_transform(transform);
+}
+
+/// Appends the given transform to the current model transform.
+/// 
+/// A `DrawParam` can be converted into an appropriate transform
+/// matrix by calling `param.into_matrix()` like so:
+///
+/// ```
+/// graphics::transform(param.into_matrix());
+/// ```
+pub fn transform(context: &mut Context, transform: Matrix4) {
+    let gfx = &mut context.gfx_context;
+    let curr = gfx.transform_stack[gfx.transform_stack.len() - 1].clone();
+    gfx.set_transform(transform * curr);
+}
+
+/// Sets the current model transform to the origin transform (no transformation)
+pub fn origin(context: &mut Context) {
+    let gfx = &mut context.gfx_context;
+    gfx.set_transform(Matrix4::identity());
 }
 
 /// Pushes a homogeneous transform matrix to the top of the view 
@@ -792,6 +844,20 @@ pub fn push_view(context: &mut Context, view: Matrix4) {
 pub fn pop_view(context: &mut Context) {
     let gfx = &mut context.gfx_context;
     gfx.pop_view();
+}
+
+/// Sets the current view matrix to the given homogeneous
+/// transformation matrix.
+pub fn set_view(context: &mut Context, view: Matrix4) {
+    let gfx = &mut context.gfx_context;
+    gfx.set_view(view);
+}
+
+/// Appends the given transformation matrix to the current view transform matrix 
+pub fn transform_view(context: &mut Context, transform: Matrix4) {
+    let gfx = &mut context.gfx_context;
+    let curr = gfx.view_stack[gfx.view_stack.len() - 1].clone();
+    gfx.set_view(transform * curr);
 }
 
 /// Calculates the new total transformation (Model-View-Projection) matrix

--- a/src/graphics/shader/basic_150.glslf
+++ b/src/graphics/shader/basic_150.glslf
@@ -5,7 +5,7 @@ in vec2 v_Uv;
 out vec4 Target0;
 
 layout (std140) uniform Globals {
-    mat4 u_Projection;
+    mat4 u_MVP;
     vec4 u_Color;
 };
 

--- a/src/graphics/shader/basic_150.glslv
+++ b/src/graphics/shader/basic_150.glslv
@@ -11,29 +11,17 @@ in vec2 a_Shear;
 in float a_Rotation;
 
 layout (std140) uniform Globals {
-    mat4 u_Projection;
+    mat4 u_MVP;
     vec4 u_Color;
-};
-
-layout (std140) uniform GlobalTransform {
-    vec2 u_Translation;
-    vec2 u_Scale;
-    vec2 u_Offset;
-    vec2 u_Shear;
-    float u_Rotation;
 };
 
 out vec2 v_Uv;
 
 void main() {
     v_Uv = a_Uv * a_Src.zw + a_Src.xy;
-    mat2 instance_rotation = mat2(cos(a_Rotation), -sin(a_Rotation), sin(a_Rotation), cos(a_Rotation));
-    mat2 instance_shear = mat2(1, a_Shear.x, a_Shear.y, 1);
-    vec2 instance_position = (((a_Pos * a_Scale) * instance_shear) + a_Offset) * instance_rotation + a_Dest;
+    mat2 rotation = mat2(cos(a_Rotation), -sin(a_Rotation), sin(a_Rotation), cos(a_Rotation));
+    mat2 shear = mat2(1, a_Shear.x, a_Shear.y, 1);
+    vec2 position = (((a_Pos * a_Scale) * shear) + a_Offset) * rotation + a_Dest;
 
-    mat2 global_rotation = mat2(cos(u_Rotation), -sin(u_Rotation), sin(u_Rotation), cos(u_Rotation));
-    mat2 global_shear = mat2(1, u_Shear.x, u_Shear.y, 1);
-    vec2 position = (((instance_position - u_Offset) * u_Scale) * global_shear) * global_rotation + u_Offset + u_Translation;
-
-    gl_Position = vec4(position, 0.0, 1.0) * u_Projection;
+    gl_Position = u_MVP * vec4(position, 0.0, 1.0);
 }

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -38,7 +38,7 @@ use GameResult;
 #[derive(Debug)]
 pub struct SpriteBatch {
     image: graphics::Image,
-    sprites: Vec<graphics::RectInstanceProperties>,
+    sprites: Vec<graphics::InstanceProperties>,
 }
 
 pub type SpriteIdx = usize;
@@ -135,10 +135,10 @@ impl graphics::Drawable for SpriteBatch {
         gfx.data.vbuf = gfx.quad_vertex_buffer.clone();
         gfx.data.tex = (self.image.texture.clone(), sampler);
         gfx.quad_slice.instances = Some((self.sprites.len() as u32, 0));
-        let prev_transform = gfx.data.transform.clone();
-        gfx.update_transform(param.into())?;
+        gfx.push_transform(param.into_matrix());
+        gfx.update_globals()?;
         gfx.encoder.draw(&gfx.quad_slice, &gfx.pso, &gfx.data);
-        gfx.data.transform = prev_transform;
+        gfx.pop_transform();
         Ok(())
     }
 }

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -134,11 +134,15 @@ impl graphics::Drawable for SpriteBatch {
             .get_or_insert(self.image.sampler_info, gfx.factory.as_mut());
         gfx.data.vbuf = gfx.quad_vertex_buffer.clone();
         gfx.data.tex = (self.image.texture.clone(), sampler);
-        gfx.quad_slice.instances = Some((self.sprites.len() as u32, 0));
+        let mut slice = gfx.quad_slice.clone();
+        slice.instances = Some((self.sprites.len() as u32, 0));
         gfx.push_transform(param.into_matrix());
+        gfx.calculate_transform_matrix();
         gfx.update_globals()?;
-        gfx.encoder.draw(&gfx.quad_slice, &gfx.pso, &gfx.data);
+        gfx.encoder.draw(&slice, &gfx.pso, &gfx.data);
         gfx.pop_transform();
+        gfx.calculate_transform_matrix();
+        gfx.update_globals()?;
         Ok(())
     }
 }

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -4,6 +4,7 @@ pub use nalgebra as na;
 
 pub type Point = na::Point2<f32>;
 pub type Vector = na::Vector2<f32>;
+pub type Matrix4 = na::Matrix4<f32>;
 
 pub fn pt2vec(pt: Point) -> [f32;2] {
     [pt.x, pt.y]


### PR DESCRIPTION
Possibility for what a new transform pipeline could look like as discussed in #149 and #145. The instance data cannot be sent as a matrix directly, though it would be possible to encode it which I might look into in the future. Currently, I anecdotally see a ~5-10% FPS increase on my desktop when running the spritebatch example vs the current master.

* Only send one combined MVP matrix to GPU
* use nalgebra to generate ortho projection matrix
* store view matrix in a vec with helpers for changing it
* store model matrix in a vec with helpers for changing it
* add helper conversion from DrawParam to matrix