### PR TITLE
Add serde_json as a dev-dependency so tests don't fail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ nalgebra = "0.13"
 [dev-dependencies]
 rand = "0.3"
 cgmath = "0.15"
+serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,8 @@ extern crate image;
 extern crate rodio;
 #[macro_use]
 extern crate serde_derive;
+#[cfg(test)]
+extern crate serde_json;
 extern crate rusttype;
 extern crate toml;
 extern crate zip;


### PR DESCRIPTION
Tests are failing because serde_json crate is not dependency