### PR TITLE
Send instance transform as matrices encoded in column vectors

### DIFF
--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -79,11 +79,10 @@ gfx_defines!{
     /// Internal structure containing values that are different for each rect.
     vertex InstanceProperties {
         src: [f32; 4] = "a_Src",
-        dest: [f32; 2] = "a_Dest",
-        scale: [f32; 2] = "a_Scale",
-        offset: [f32; 2] = "a_Offset",
-        shear: [f32; 2] = "a_Shear",
-        rotation: f32 = "a_Rotation",
+        col1: [f32; 4] = "a_TCol1",
+        col2: [f32; 4] = "a_TCol2",
+        col3: [f32; 4] = "a_TCol3",
+        col4: [f32; 4] = "a_TCol4",
     }
 
     /// Internal structure containing global shader state.
@@ -106,24 +105,23 @@ impl Default for InstanceProperties {
     fn default() -> Self {
         InstanceProperties {
             src: [0.0, 0.0, 1.0, 1.0],
-            dest: [0.0, 0.0],
-            scale: [1.0, 1.0],
-            offset: [0.0, 0.0],
-            shear: [0.0, 0.0],
-            rotation: 0.0,
+            col1: [1.0, 0.0, 0.0, 0.0],
+            col2: [0.0, 1.0, 0.0, 0.0],
+            col3: [1.0, 0.0, 1.0, 0.0],
+            col4: [1.0, 0.0, 0.0, 1.0],
         }
     }
 }
 
 impl From<DrawParam> for InstanceProperties {
     fn from(p: DrawParam) -> Self {
-        InstanceProperties {
+        let mat: [[f32; 4]; 4] = p.into_matrix().into();
+        Self {
             src: p.src.into(),
-            dest: types::pt2arr(p.dest),
-            scale: types::pt2arr(p.scale),
-            offset: types::pt2arr(p.offset),
-            shear: types::pt2arr(p.shear),
-            rotation: p.rotation,
+            col1: mat[0],
+            col2: mat[1],
+            col3: mat[2],
+            col4: mat[3],
         }
     }
 }

--- a/src/graphics/shader/basic_150.glslv
+++ b/src/graphics/shader/basic_150.glslv
@@ -4,11 +4,10 @@ in vec2 a_Pos;
 in vec2 a_Uv;
 
 in vec4 a_Src;
-in vec2 a_Dest;
-in vec2 a_Scale;
-in vec2 a_Offset;
-in vec2 a_Shear;
-in float a_Rotation;
+in vec4 a_TCol1;
+in vec4 a_TCol2;
+in vec4 a_TCol3;
+in vec4 a_TCol4;
 
 layout (std140) uniform Globals {
     mat4 u_MVP;
@@ -19,9 +18,8 @@ out vec2 v_Uv;
 
 void main() {
     v_Uv = a_Uv * a_Src.zw + a_Src.xy;
-    mat2 rotation = mat2(cos(a_Rotation), -sin(a_Rotation), sin(a_Rotation), cos(a_Rotation));
-    mat2 shear = mat2(1, a_Shear.x, a_Shear.y, 1);
-    vec2 position = (((a_Pos * a_Scale) * shear) + a_Offset) * rotation + a_Dest;
+    mat4 instance_transform = mat4(a_TCol1, a_TCol2, a_TCol1, a_TCol4);
+    vec4 position = instance_transform * vec4(a_Pos, 0.0, 1.0);
 
-    gl_Position = u_MVP * vec4(position, 0.0, 1.0);
+    gl_Position = u_MVP * position;
 }

--- a/src/graphics/shader/basic_150.glslv
+++ b/src/graphics/shader/basic_150.glslv
@@ -18,7 +18,7 @@ out vec2 v_Uv;
 
 void main() {
     v_Uv = a_Uv * a_Src.zw + a_Src.xy;
-    mat4 instance_transform = mat4(a_TCol1, a_TCol2, a_TCol1, a_TCol4);
+    mat4 instance_transform = mat4(a_TCol1, a_TCol2, a_TCol3, a_TCol4);
     vec4 position = instance_transform * vec4(a_Pos, 0.0, 1.0);
 
     gl_Position = u_MVP * position;


### PR DESCRIPTION
Last piece of #145. It works, but I haven't done any testing to see if there's any impact on performance. The code definitely is cleaner though, especially in the vertex shader.