### PR TITLE
Update to lyon 0.8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rodio = "0.5.1"
 serde = "1.0"
 serde_derive = "1.0"
 toml = "0.4"
-lyon = "0.7"
+lyon = "0.8"
 euclid = "0.15"
 mint = { version = "0.4", optional = true }
 smart-default = "0.2"


### PR DESCRIPTION
Lyon 0.8 is fresh out with bug fixes, performance improvements and newly supported bevel line joins (although ggez doesn't appear to expose stroke options).

There were few enough API changes that it looks like none of them affected ggez (I did `cargo build --all` and `cargo build --examples`), so the PR is disappointingly simple (unless I built the wrong branch or something).

This fixes issue #161.