### PR TITLE
Add `PixelShader::from_u8()`

### DIFF
--- a/src/graphics/pixelshader.rs
+++ b/src/graphics/pixelshader.rs
@@ -116,7 +116,16 @@ impl<C> PixelShader<C>
             reader.read_to_end(&mut buf)?;
             buf
         };
+        PixelShader::from_u8(ctx, &source, consts, name)
+    }
 
+    /// Create a new `PixelShader` directly from source given a gfx pipeline
+    /// object
+    pub fn from_u8<S: Into<String>>(ctx: &mut Context,
+                                    source: &[u8],
+                                    consts: C,
+                                    name: S)
+                                    -> GameResult<PixelShader<C>> {
         let (mut shader, draw) = create_shader(&source,
                                                consts,
                                                name,

--- a/src/graphics/pixelshader.rs
+++ b/src/graphics/pixelshader.rs
@@ -51,17 +51,18 @@ pub struct PixelShaderGeneric<Spec: graphics::BackendSpec, C: Structure<ConstFor
 /// with a ggez graphics context
 pub type PixelShader<C> = PixelShaderGeneric<graphics::GlBackendSpec, C>;
 
-pub(crate) fn create_shader<C, S, Spec>
-    (source: &[u8],
-     consts: C,
-     name: S,
-     encoder: &mut Encoder<Spec::Resources, Spec::CommandBuffer>,
-     factory: &mut Spec::Factory,
-     multisample_samples: u8)
-     -> GameResult<(PixelShaderGeneric<Spec, C>, Box<PixelShaderDraw<Spec>>)>
-    where C: 'static + Pod + Structure<ConstFormat> + Clone + Copy,
-          S: Into<String>,
-          Spec: graphics::BackendSpec + 'static
+pub(crate) fn create_shader<C, S, Spec>(
+    source: &[u8],
+    consts: C,
+    name: S,
+    encoder: &mut Encoder<Spec::Resources, Spec::CommandBuffer>,
+    factory: &mut Spec::Factory,
+    multisample_samples: u8,
+) -> GameResult<(PixelShaderGeneric<Spec, C>, Box<PixelShaderDraw<Spec>>)>
+where
+    C: 'static + Pod + Structure<ConstFormat> + Clone + Copy,
+    S: Into<String>,
+    Spec: graphics::BackendSpec + 'static,
 {
     let buffer = factory.create_constant_buffer(1);
     let buffer = Rc::new(buffer);
@@ -70,8 +71,7 @@ pub(crate) fn create_shader<C, S, Spec>
 
     let pso = {
         let init = ConstInit::<C>(graphics::pipe::new(), name.into(), PhantomData);
-        let set = factory
-            .create_shader_set(include_bytes!("shader/basic_150.glslv"), &source)?;
+        let set = factory.create_shader_set(include_bytes!("shader/basic_150.glslv"), &source)?;
         let sample = if multisample_samples > 1 {
             Some(MultiSample)
         } else {
@@ -85,8 +85,7 @@ pub(crate) fn create_shader<C, S, Spec>
             samples: sample,
         };
 
-        factory
-            .create_pipeline_state(&set, Primitive::TriangleList, rasterizer, init)?
+        factory.create_pipeline_state(&set, Primitive::TriangleList, rasterizer, init)?
     };
 
     let program = PixelShaderProgram {
@@ -102,14 +101,16 @@ pub(crate) fn create_shader<C, S, Spec>
 }
 
 impl<C> PixelShader<C>
-    where C: 'static + Pod + Structure<ConstFormat> + Clone + Copy
+where
+    C: 'static + Pod + Structure<ConstFormat> + Clone + Copy,
 {
     /// Create a new `PixelShader` given a gfx pipeline object
-    pub fn new<P: AsRef<Path>, S: Into<String>>(ctx: &mut Context,
-                                                path: P,
-                                                consts: C,
-                                                name: S)
-                                                -> GameResult<PixelShader<C>> {
+    pub fn new<P: AsRef<Path>, S: Into<String>>(
+        ctx: &mut Context,
+        path: P,
+        consts: C,
+        name: S,
+    ) -> GameResult<PixelShader<C>> {
         let source = {
             let mut buf = Vec::new();
             let mut reader = ctx.filesystem.open(path)?;
@@ -121,17 +122,20 @@ impl<C> PixelShader<C>
 
     /// Create a new `PixelShader` directly from source given a gfx pipeline
     /// object
-    pub fn from_u8<S: Into<String>>(ctx: &mut Context,
-                                    source: &[u8],
-                                    consts: C,
-                                    name: S)
-                                    -> GameResult<PixelShader<C>> {
-        let (mut shader, draw) = create_shader(&source,
-                                               consts,
-                                               name,
-                                               &mut ctx.gfx_context.encoder,
-                                               &mut *ctx.gfx_context.factory,
-                                               ctx.gfx_context.multisample_samples)?;
+    pub fn from_u8<S: Into<String>>(
+        ctx: &mut Context,
+        source: &[u8],
+        consts: C,
+        name: S,
+    ) -> GameResult<PixelShader<C>> {
+        let (mut shader, draw) = create_shader(
+            &source,
+            consts,
+            name,
+            &mut ctx.gfx_context.encoder,
+            &mut *ctx.gfx_context.factory,
+            ctx.gfx_context.multisample_samples,
+        )?;
         shader.id = ctx.gfx_context.shaders.len();
         ctx.gfx_context.shaders.push(draw);
 
@@ -154,8 +158,9 @@ impl<C> PixelShader<C>
 }
 
 impl<Spec, C> fmt::Debug for PixelShaderGeneric<Spec, C>
-    where Spec: graphics::BackendSpec,
-          C: Structure<ConstFormat>
+where
+    Spec: graphics::BackendSpec,
+    C: Structure<ConstFormat>,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "<PixelShader[{}]: {:p}>", self.id, self)
@@ -168,8 +173,9 @@ struct PixelShaderProgram<Spec: graphics::BackendSpec, C: Structure<ConstFormat>
 }
 
 impl<Spec, C> fmt::Debug for PixelShaderProgram<Spec, C>
-    where Spec: graphics::BackendSpec,
-          C: Structure<ConstFormat>
+where
+    Spec: graphics::BackendSpec,
+    C: Structure<ConstFormat>,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "<PixelShaderProgram: {:p}>", self)
@@ -180,20 +186,25 @@ impl<Spec, C> fmt::Debug for PixelShaderProgram<Spec, C>
 /// Structure<ConstFormat> type of the constant data for drawing
 pub trait PixelShaderDraw<Spec: graphics::BackendSpec>: fmt::Debug {
     /// Draw with the current PixelShader
-    fn draw(&self,
-            &mut Encoder<Spec::Resources, Spec::CommandBuffer>,
-            &Slice<Spec::Resources>,
-            &graphics::pipe::Data<Spec::Resources>);
+    fn draw(
+        &self,
+        &mut Encoder<Spec::Resources, Spec::CommandBuffer>,
+        &Slice<Spec::Resources>,
+        &graphics::pipe::Data<Spec::Resources>,
+    );
 }
 
 impl<Spec, C> PixelShaderDraw<Spec> for PixelShaderProgram<Spec, C>
-    where Spec: graphics::BackendSpec,
-          C: Structure<ConstFormat>
+where
+    Spec: graphics::BackendSpec,
+    C: Structure<ConstFormat>,
 {
-    fn draw(&self,
-            encoder: &mut Encoder<Spec::Resources, Spec::CommandBuffer>,
-            slice: &Slice<Spec::Resources>,
-            data: &graphics::pipe::Data<Spec::Resources>) {
+    fn draw(
+        &self,
+        encoder: &mut Encoder<Spec::Resources, Spec::CommandBuffer>,
+        slice: &Slice<Spec::Resources>,
+        data: &graphics::pipe::Data<Spec::Resources>,
+    ) {
         encoder.draw(slice, &self.pso, &ConstData(data, &self.buffer));
     }
 }
@@ -214,7 +225,8 @@ impl Drop for PixelShaderLock {
 
 /// Use a shader until the returned lock goes out of scope
 pub fn use_shader<C>(ctx: &mut Context, ps: &PixelShader<C>) -> PixelShaderLock
-    where C: Structure<ConstFormat>
+where
+    C: Structure<ConstFormat>,
 {
     let cell = ctx.gfx_context.current_shader.clone();
     let previous_shader = (*cell.borrow()).clone();
@@ -227,7 +239,8 @@ pub fn use_shader<C>(ctx: &mut Context, ps: &PixelShader<C>) -> PixelShaderLock
 
 /// Set the current pixel shader for the Context to render with
 pub fn set_shader<C>(ctx: &mut Context, ps: &PixelShader<C>)
-    where C: Structure<ConstFormat>
+where
+    C: Structure<ConstFormat>,
 {
     *ctx.gfx_context.current_shader.borrow_mut() = Some(ps.id);
 }
@@ -244,16 +257,19 @@ struct ConstMeta<C: Structure<ConstFormat>>(graphics::pipe::Meta, ConstantBuffer
 struct ConstData<'a, R: Resources, C: 'a>(&'a graphics::pipe::Data<R>, &'a Buffer<R, C>);
 
 impl<'a, R, C> PipelineData<R> for ConstData<'a, R, C>
-    where R: Resources,
-          C: Structure<ConstFormat>
+where
+    R: Resources,
+    C: Structure<ConstFormat>,
 {
     type Meta = ConstMeta<C>;
 
-    fn bake_to(&self,
-               out: &mut RawDataSet<R>,
-               meta: &Self::Meta,
-               man: &mut Manager<R>,
-               access: &mut AccessInfo<R>) {
+    fn bake_to(
+        &self,
+        out: &mut RawDataSet<R>,
+        meta: &Self::Meta,
+        man: &mut Manager<R>,
+        access: &mut AccessInfo<R>,
+    ) {
         self.0.bake_to(out, &meta.0, man, access);
         meta.1.bind_to(out, &self.1, man, access);
     }
@@ -263,14 +279,16 @@ impl<'a, R, C> PipelineData<R> for ConstData<'a, R, C>
 struct ConstInit<'a, C>(graphics::pipe::Init<'a>, String, PhantomData<C>);
 
 impl<'a, C> PipelineInit for ConstInit<'a, C>
-    where C: Structure<ConstFormat>
+where
+    C: Structure<ConstFormat>,
 {
     type Meta = ConstMeta<C>;
 
-    fn link_to<'s>(&self,
-                   desc: &mut Descriptor,
-                   info: &'s ProgramInfo)
-                   -> Result<Self::Meta, InitError<&'s str>> {
+    fn link_to<'s>(
+        &self,
+        desc: &mut Descriptor,
+        info: &'s ProgramInfo,
+    ) -> Result<Self::Meta, InitError<&'s str>> {
         let mut meta1 = ConstantBuffer::<C>::new();
 
         let mut index = None;


### PR DESCRIPTION
Implemented `PixelShader::from_u8()` for consistency with other resource types (see #157). Also I updated my rust-fmt which reformatted quite a bit of pixelshader.rs so the changes look like a lot more than they actually are.