### PR TITLE
Gradients

### DIFF
--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -12,6 +12,8 @@ struct MainState {
     image1: graphics::Image,
     image2_linear: graphics::Image,
     image2_nearest: graphics::Image,
+    gradient: graphics::Image,
+    gradient_rect: graphics::Rect,
     zoomlevel: f32,
 }
 
@@ -21,10 +23,26 @@ impl MainState {
         let image2_linear = graphics::Image::new(ctx, "/shot.png")?;
         let mut image2_nearest = graphics::Image::new(ctx, "/shot.png")?;
         image2_nearest.set_filter(graphics::FilterMode::Nearest);
+        let gradient_colors = [
+            graphics::Color::new(1.0, 1.0, 1.0, 0.5),
+            graphics::Color::new(1.0, 0.0, 0.0, 1.0),
+            graphics::Color::new(0.0, 0.0, 0.0, 0.0),
+        ];
+        let gradient = graphics::Image::gradient(
+            ctx,
+            &gradient_colors,
+            graphics::GradientDirection::Horizontal
+        )?;
+        let gradient_rect = graphics::Rect::new(
+            400.0, 300.0,
+            800.8, 600.0
+        );
         let s = MainState {
             image1: image1,
             image2_linear: image2_linear,
             image2_nearest: image2_nearest,
+            gradient: gradient,
+            gradient_rect: gradient_rect,
             zoomlevel: 1.0,
         };
 
@@ -60,8 +78,13 @@ impl event::EventHandler for MainState {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
-        graphics::clear(ctx);
+       graphics::clear(ctx);
         graphics::set_color(ctx, graphics::WHITE)?;
+        graphics::draw_in_rect(
+            ctx,
+            &self.gradient,
+            &self.gradient_rect,
+        )?;
         // let src = graphics::Rect::new(0.25, 0.25, 0.5, 0.5);
         // let src = graphics::Rect::one();
         let dst = graphics::Point2::new(200.0, 200.0);

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -615,6 +615,12 @@ pub fn draw(ctx: &mut Context, drawable: &Drawable, dest: Point2, rotation: f32)
     drawable.draw(ctx, dest, rotation)
 }
 
+/// Draws the given `Drawable` and `Rectangle` object to the screen by calling its
+/// `draw_in_rect()` method
+pub fn draw_in_rect<D>(ctx: &mut Context, drawable: &D, rect: &Rect) -> GameResult<()>
+    where D: Drawable + Rectangle {
+    drawable.draw_in_rect(ctx, rect)
+}
 
 /// Draws the given `Drawable` object to the screen by calling its `draw_ex()` method.
 pub fn draw_ex(ctx: &mut Context, drawable: &Drawable, params: DrawParam) -> GameResult<()> {
@@ -1069,6 +1075,31 @@ pub trait Drawable {
     }
 }
 
+/// A type that can be drawn within rectangle bounds
+pub trait RectDraw
+    where Self: Drawable + Rectangle {
+    /// Draws an image inside a specified rectangle, mainly useful for gradients.
+    fn draw_in_rect(&self, ctx: &mut Context, rect: &Rect) -> GameResult<()> {
+        self.draw_ex(ctx,
+                     DrawParam {
+                        //  dest: Point2::new(rect.x - rect.w / 2.0, rect.x - rect.h / 2.0),
+                         dest: rect.point(),
+                         scale: Point2::new(rect.w / self.width() as f32, rect.h / self.height() as f32),
+                         ..Default::default()
+                     })
+    }
+}
+
+impl<D> RectDraw for D where D: Drawable + Rectangle {}
+
+/// A type that can be represented with a width and height
+pub trait Rectangle {
+    /// Get width
+    fn width(&self) -> u32;
+    /// Get height
+    fn height(&self) -> u32;
+}
+
 /// Generic in-GPU-memory image data available to be drawn on the screen.
 #[derive(Clone)]
 pub struct ImageGeneric<R>
@@ -1114,6 +1145,15 @@ fn scale_rgba_up_to_power_of_2(width: u16, height: u16, rgba: &[u8]) -> (u16, u1
         }
     }
     (w2 as u16, h2 as u16, v)
+}
+
+/// Direction of a Gradient image.
+#[derive(Debug)]
+pub enum GradientDirection {
+    /// Horizontal gradient
+    Horizontal,
+    /// Vertical gradient
+    Vertical
 }
 
 impl Image {
@@ -1197,6 +1237,35 @@ impl Image {
         Image::from_rgba8(context, size, size, &buffer)
     }
 
+    /// A helper function to create a gradient from a slice of specified `Color`s
+    /// to be evenly spaced throughout the gradient in the given direction. Useful when
+    /// paired with `draw_in_rect()`
+    pub fn gradient(
+        ctx: &mut Context,
+        colors: &[Color],
+        direction: GradientDirection
+    ) -> GameResult<Image> {
+        let buf_size = colors.len();
+        let mut buffer: Vec<u8> = Vec::with_capacity(buf_size);
+        for color in colors {
+            let color: [u8; 4] = color.clone().into();
+            buffer.extend(color.iter());
+        }
+        let mut result;
+        match direction {
+            GradientDirection::Horizontal => {
+                result = Image::from_rgba8(ctx, buf_size as u16, 1, &buffer)?;
+                result.set_filter(FilterMode::Linear)
+            },
+            GradientDirection::Vertical => {
+                result = Image::from_rgba8(ctx, 1, buf_size as u16, &buffer)?;
+                result.set_filter(FilterMode::Linear);
+            }
+        }
+        Ok(result)
+    }
+
+
     /// Return the width of the image.
     pub fn width(&self) -> u32 {
         self.width
@@ -1247,6 +1316,10 @@ impl fmt::Debug for Image {
     }
 }
 
+impl Rectangle for Image {
+    fn width(&self) -> u32 { self.width }
+    fn height(&self) -> u32 { self.height }
+}
 
 impl Drawable for Image {
     fn draw_ex(&self, ctx: &mut Context, param: DrawParam) -> GameResult<()> {


### PR DESCRIPTION
Based on #172.

Implements a gradient creation helper function on Image and corresponding `draw_in_rect()` helper function with new `RectDraw` trait. Also gives an example in the `drawing` example.