### PR TITLE
Allow high DPI flag

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -65,6 +65,9 @@ pub struct WindowMode {
     /// Whether or not the window is resizable
     #[default = r#"false"#]
     pub resizable: bool,
+    /// Whether or not to allow high DPI mode when creating the window
+    #[default = r#"true"#]
+    pub allow_highdpi: bool,
     /// Fullscreen type
     #[default = r#"FullscreenType::Off"#]
     pub fullscreen_type: FullscreenType,

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -314,6 +314,9 @@ impl GraphicsContext {
         if window_mode.resizable {
             window_builder.resizable();
         }
+        if window_mode.allow_highdpi {
+            window_builder.allow_highdpi();
+        }
         let (window, gl_context, device, mut factory, color_view, depth_view) =
             gfx_window_sdl::init(window_builder)?;
 


### PR DESCRIPTION
Add configuration flag to allow High DPI when creating the SDL window. Makes a huge difference on macs with retina display:

<img width="482" alt="highdpi" src="https://user-images.githubusercontent.com/4210206/31277395-0e079a8e-aaa1-11e7-953d-a44bf8e56d5a.png">
