### PR TITLE
Fixed issues related to high DPI support with canvas + shader examples

### DIFF
--- a/examples/render_to_image.rs
+++ b/examples/render_to_image.rs
@@ -1,7 +1,7 @@
 extern crate ggez;
 
 use ggez::*;
-use ggez::graphics::{Canvas, Color, DrawMode, DrawParam, Point2};
+use ggez::graphics::*;
 
 struct MainState {
     canvas: Canvas,
@@ -28,6 +28,11 @@ impl event::EventHandler for MainState {
 
         // now lets render our scene once in the top right and in the bottom
         // right
+        let window_size = ctx.gfx_context.get_size();
+        let scale = Point2::new(
+            0.5 * window_size.0 as f32 / self.canvas.get_image().width() as f32,
+            0.5 * window_size.1 as f32 / self.canvas.get_image().height() as f32,
+        );
         graphics::set_canvas(ctx, None);
         graphics::set_background_color(ctx, Color::new(0.0, 0.0, 0.0, 1.0));
         graphics::clear(ctx);
@@ -36,7 +41,7 @@ impl event::EventHandler for MainState {
             &self.canvas,
             DrawParam {
                 dest: Point2::new(200.0, 150.0),
-                scale: Point2::new(0.5, 0.5),
+                scale,
                 ..Default::default()
             },
         )?;
@@ -45,7 +50,7 @@ impl event::EventHandler for MainState {
             &self.canvas,
             DrawParam {
                 dest: Point2::new(600.0, 450.0),
-                scale: Point2::new(0.5, 0.5),
+                scale,
                 ..Default::default()
             },
         )?;

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -31,18 +31,18 @@ use GameError;
 use GameResult;
 
 mod canvas;
-mod text;
-mod types;
 mod mesh;
 mod pixelshader;
+mod text;
+mod types;
 
 pub mod spritebatch;
 
-pub use self::text::*;
-pub use self::types::*;
+pub use self::canvas::*;
 pub use self::mesh::*;
 pub use self::pixelshader::*;
-pub use self::canvas::*;
+pub use self::text::*;
+pub use self::types::*;
 
 /// A marker trait that something is a label for a particular backend.
 pub trait BackendSpec: fmt::Debug {
@@ -771,18 +771,6 @@ pub fn get_renderer_info(ctx: &Context) -> GameResult<String> {
 /// will be negative.
 pub fn get_screen_coordinates(ctx: &Context) -> Rect {
     ctx.gfx_context.screen_rect
-}
-
-/// Converts coordinates in between pixel and screen coordinates taking into
-/// account the direction in which the Y axis increases. This method is useful
-/// sending positions to PixelShaders.
-pub fn convert_screen_coordinates(ctx: &Context, p: Point2) -> Point2 {
-    let y = if ctx.gfx_context.screen_rect.h < 0.0 {
-        -ctx.gfx_context.screen_rect.h - p.y
-    } else {
-        p.y
-    };
-    Point2::new(p.x, y)
 }
 
 /// Sets the background color.  Default: blue.


### PR DESCRIPTION
So the high DPI support messed up couple of the examples - they assumed that `ctx.gfx_context.get_size() == ctx.gfx_context.get_drawable_size()` was true but it clearly isn't in high DPI senario.

