### PR TITLE
Blend modes!

### DIFF
--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -362,9 +362,7 @@ impl event::EventHandler for MainState {
         self.render_light(ctx, light, center, canvascenter)?;
 
         // Now lets finally render to screen starting with out background, then
-        // the shadows and lights overtop and finally our foreground. Note that we set the
-        // light color as the color for our render giving everything the "tint"
-        // we desire.
+        // the shadows and lights overtop and finally our foreground.
         graphics::set_canvas(ctx, None);
         graphics::set_color(ctx, graphics::WHITE)?;
         graphics::set_blend_mode(ctx, BlendMode::Alpha)?;

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -11,7 +11,7 @@ use std::path;
 gfx_defines!{
     /// Constants used by the shaders to calculate stuff
     constant Light {
-        light_color: [f32; 4] = "u_Color",
+        light_color: [f32; 4] = "u_LightColor",
         shadow_color: [f32; 4] = "u_ShadowColor",
         pos: [f32; 2] = "u_Pos",
         screen_size: [f32; 2] = "u_ScreenSize",
@@ -34,7 +34,7 @@ in vec2 v_Uv;
 out vec4 Target0;
 
 layout (std140) uniform Light {
-    vec4 u_Color;
+    vec4 u_LightColor;
     vec4 u_ShadowColor;
     vec2 u_Pos;
     vec2 u_ScreenSize;
@@ -66,7 +66,7 @@ void main() {
 /// fragment cordinates and converts them to polar coordinates centered
 /// around the light source, using the angle to sample from the 1D shadow map.
 /// If the distance from the light source is greater than the distance of the
-/// closest reported shadow, then the output is black, else it calculates some
+/// closest reported shadow, then the output is the shadow color, else it calculates some
 /// shadow based on the distance from light source based on strength and glow
 /// uniform parameters.
 const SHADOWS_SHADER_SOURCE: &[u8] = b"#version 150 core
@@ -76,7 +76,7 @@ in vec2 v_Uv;
 out vec4 Target0;
 
 layout (std140) uniform Light {
-    vec4 u_Color;
+    vec4 u_LightColor;
     vec4 u_ShadowColor;
     vec2 u_Pos;
     vec2 u_ScreenSize;
@@ -95,15 +95,61 @@ void main() {
     float r = length(rel);
     float occl = texture(t_Texture, vec2(ox, 0.5)).r * 2.0;
 
-    float intensity = 0.9;
+    float intensity = 1.0;
     if (r < occl) {
         vec2 g = u_ScreenSize / u_ScreenSize.y;
         float p = u_Strength + u_Glow;
         float d = distance(g * coord, g * u_Pos);
-        intensity = 0.9 - clamp(p/(d*d), 0.0, 0.9);
+        intensity = 1.0 - clamp(p/(d*d), 0.0, 1.0);
     }
 
-    Target0 = vec4(u_ShadowColor.rgb / 80.0, intensity);
+    Target0 = mix(vec4(1.0, 1.0, 1.0, 1.0), vec4(u_ShadowColor.rgb, 1.0), intensity);
+}
+";
+
+/// Shader for drawing lights based on a 1D shadow map. It takes current
+/// fragment cordinates and converts them to polar coordinates centered
+/// around the light source, using the angle to sample from the 1D shadow map.
+/// If the distance from the light source is greater than the distance of the
+/// closest reported shadow, then the output is black, else it calculates some
+/// light based on the distance from light source based on strength and glow
+/// uniform parameters. It is meant to be used additively for drawing multiple
+/// lights.
+const LIGHTS_SHADER_SOURCE: &[u8] = b"#version 150 core
+
+uniform sampler2D t_Texture;
+in vec2 v_Uv;
+out vec4 Target0;
+
+layout (std140) uniform Light {
+    vec4 u_LightColor;
+    vec4 u_ShadowColor;
+    vec2 u_Pos;
+    vec2 u_ScreenSize;
+    float u_Glow;
+    float u_Strength;
+};
+
+void main() {
+    vec2 coord = gl_FragCoord.xy / u_ScreenSize;
+    vec2 rel = coord - u_Pos;
+    float theta = atan(rel.y, rel.x);
+    float ox = degrees(theta) / 360.0;
+    if (ox < 0) {
+        ox += 1.0;
+    }
+    float r = length(rel);
+    float occl = texture(t_Texture, vec2(ox, 0.5)).r * 2.0;
+
+    float intensity = 0.0;
+    if (r < occl) {
+        vec2 g = u_ScreenSize / u_ScreenSize.y;
+        float p = u_Strength + u_Glow;
+        float d = distance(g * coord, g * u_Pos);
+        intensity = clamp(p/(d*d), 0.0, 0.6);
+    }
+
+    Target0 = mix(vec4(0.0, 0.0, 0.0, 1.0), vec4(u_LightColor.rgb, 1.0), intensity);
 }
 ";
 
@@ -111,25 +157,31 @@ struct MainState {
     background: Image,
     tile: Image,
     text: Text,
-    light: Light,
+    torch: Light,
+    static_light: Light,
     foreground: Canvas,
     occlusions: Canvas,
+    shadows: Canvas,
+    lights: Canvas,
     occlusions_shader: PixelShader<Light>,
     shadows_shader: PixelShader<Light>,
+    lights_shader: PixelShader<Light>,
 }
 
 /// The color cast things take when not illuminated
-const AMBIENT_COLOR: [f32; 4] = [0.30, 0.30, 0.53, 1.0];
-/// The default color for the light
-const LIGHT_COLOR: [f32; 4] = [0.72, 0.64, 0.32, 1.0];
+const AMBIENT_COLOR: [f32; 4] = [0.25, 0.22, 0.34, 1.0];
+/// The default color for the static light
+const STATIC_LIGHT_COLOR: [f32; 4] = [0.37, 0.69, 0.75, 1.0];
+/// The default color for the mouse-controlled torch
+const TORCH_COLOR: [f32; 4] = [0.80, 0.73, 0.44, 1.0];
 /// The number of rays to cast to. Increasing this number will result in better
 /// quality shadows. If you increase too much you might hit some GPU shader
 /// hardware limits.
 const LIGHT_RAY_COUNT: u32 = 1440;
 /// The strength of the light - how far it shines
-const LIGHT_STRENGTH: f32 = 0.01;
+const LIGHT_STRENGTH: f32 = 0.0035;
 /// The factor at which the light glows - just for fun
-const LIGHT_GLOW_FACTOR: f32 = 0.001;
+const LIGHT_GLOW_FACTOR: f32 = 0.0001;
 /// The rate at which the glow effect oscillates
 const LIGHT_GLOW_RATE: f32 = 50.0;
 
@@ -145,30 +197,89 @@ impl MainState {
             let size = ctx.gfx_context.get_drawable_size();
             [size.0 as f32, size.1 as f32]
         };
-        let light = Light {
+        let torch = Light {
             pos: [0.0, 0.0],
-            light_color: LIGHT_COLOR,
+            light_color: TORCH_COLOR,
             shadow_color: AMBIENT_COLOR,
             screen_size,
             glow: 0.0,
             strength: LIGHT_STRENGTH,
         };
+        let (w, h) = ctx.gfx_context.get_size();
+        let (x, y) = (100 as f32 / w as f32, 1.0 - 75 as f32 / h as f32);
+        let static_light = Light {
+            pos: [x, y],
+            light_color: STATIC_LIGHT_COLOR,
+            shadow_color: AMBIENT_COLOR,
+            screen_size,
+            glow: 0.0,
+            strength: LIGHT_STRENGTH
+        };
         let foreground = Canvas::with_window_size(ctx)?;
         let occlusions = Canvas::new(ctx, LIGHT_RAY_COUNT, 1, conf::NumSamples::One)?;
+        let shadows = Canvas::with_window_size(ctx)?;
+        let lights = Canvas::with_window_size(ctx)?;
         let occlusions_shader =
-            PixelShader::from_u8(ctx, OCCLUSIONS_SHADER_SOURCE, light, "Light")?;
-        let shadows_shader = PixelShader::from_u8(ctx, SHADOWS_SHADER_SOURCE, light, "Light")?;
+            PixelShader::from_u8(ctx, OCCLUSIONS_SHADER_SOURCE, torch, "Light", None)?;
+        let shadows_shader =
+            PixelShader::from_u8(ctx, SHADOWS_SHADER_SOURCE, torch, "Light", None)?;
+        let lights_shader =
+            PixelShader::from_u8(ctx, LIGHTS_SHADER_SOURCE, torch, "Light", Some(&[BlendMode::Add]))?;
 
         Ok(MainState {
             background,
             tile,
             text,
-            light,
+            torch,
+            static_light,
             foreground,
             occlusions,
+            shadows,
+            lights,
             occlusions_shader,
             shadows_shader,
+            lights_shader,
         })
+    }
+    fn render_light(&mut self, ctx: &mut Context, light: Light, center: DrawParam, canvascenter: DrawParam) -> GameResult<()> {
+        let size = ctx.gfx_context.get_size();
+        // Now we want to run the occlusions shader to calculate our 1D shadow
+        // distances into the `occlusions` canvas.
+        graphics::set_canvas(ctx, Some(&self.occlusions));
+        {
+            let _shader_lock = graphics::use_shader(ctx, &self.occlusions_shader);
+
+            self.occlusions_shader.send(ctx, light)?;
+            graphics::draw_ex(ctx, &self.foreground, canvascenter)?;
+        }
+
+        // Now we render our shadow map and light map into their respective
+        // canvases based on the occlusion map. These will then be drawn onto
+        // the final render target using appropriate blending modes.
+        graphics::set_canvas(ctx, Some(&self.shadows));
+        {
+            let _shader_lock = graphics::use_shader(ctx, &self.shadows_shader);
+
+            let param = DrawParam {
+                scale: Point2::new((size.0 as f32) / (LIGHT_RAY_COUNT as f32), (size.1 as f32)),
+                ..center
+            };
+            self.shadows_shader.send(ctx, light)?;
+            graphics::draw_ex(ctx, &self.occlusions, param)?;
+
+        }
+        graphics::set_canvas(ctx, Some(&self.lights));
+        {
+            let _shader_lock = graphics::use_shader(ctx, &self.lights_shader);
+
+            let param = DrawParam {
+                scale: Point2::new((size.0 as f32) / (LIGHT_RAY_COUNT as f32), (size.1 as f32)),
+                ..center
+            };
+            self.lights_shader.send(ctx, light)?;
+            graphics::draw_ex(ctx, &self.occlusions, param)?;
+        }
+        Ok(())
     }
 }
 
@@ -178,10 +289,13 @@ impl event::EventHandler for MainState {
             println!("Average FPS: {}", timer::get_fps(ctx));
         }
 
-        self.light.glow = LIGHT_GLOW_FACTOR *
+        self.torch.glow = LIGHT_GLOW_FACTOR *
             ((timer::get_ticks(ctx) as f32) / LIGHT_GLOW_RATE).cos();
+        self.static_light.glow = LIGHT_GLOW_FACTOR *
+            ((timer::get_ticks(ctx) as f32) / LIGHT_GLOW_RATE * 0.75).sin();
         Ok(())
     }
+
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
         let size = ctx.gfx_context.get_size();
@@ -237,36 +351,38 @@ impl event::EventHandler for MainState {
         )?;
         graphics::draw_ex(ctx, &self.text, center)?;
 
-        // Now we want to run the occlusions shader to calculate our 1D shadow
-        // distances into the `occlusions` canvas.
-        {
-            let _shader_lock = graphics::use_shader(ctx, &self.occlusions_shader);
-            self.occlusions_shader.send(ctx, self.light)?;
-
-            graphics::set_canvas(ctx, Some(&self.occlusions));
-            graphics::draw_ex(ctx, &self.foreground, canvascenter)?;
-        }
+        // First we draw our light and shadow maps
+        let torch = self.torch.clone();
+        let light = self.static_light.clone();
+        graphics::set_canvas(ctx, Some(&self.lights));
+        graphics::clear(ctx);
+        graphics::set_canvas(ctx, Some(&self.shadows));
+        graphics::clear(ctx);
+        self.render_light(ctx, torch, center, canvascenter)?;
+        self.render_light(ctx, light, center, canvascenter)?;
 
         // Now lets finally render to screen starting with out background, then
-        // the shadows overtop and finally our foreground. Note that we set the
+        // the shadows and lights overtop and finally our foreground. Note that we set the
         // light color as the color for our render giving everything the "tint"
         // we desire.
         graphics::set_canvas(ctx, None);
-        // color filter so things take the light color
-        graphics::set_color(ctx, self.light.light_color.into())?;
-        graphics::clear(ctx);
+        graphics::set_color(ctx, graphics::WHITE)?;
+        graphics::set_blend_mode(ctx, BlendMode::Alpha)?;
         graphics::draw_ex(ctx, &self.background, center)?;
-        {
-            let _shader_lock = graphics::use_shader(ctx, &self.shadows_shader);
-            self.shadows_shader.send(ctx, self.light)?;
 
-            let param = DrawParam {
-                scale: Point2::new((size.0 as f32) / (LIGHT_RAY_COUNT as f32), (size.1 as f32)),
-                ..center
-            };
-            graphics::draw_ex(ctx, &self.occlusions, param)?;
-        }
+        // The shadow map will be drawn on top using the mutiply blend mode
+        graphics::set_blend_mode(ctx, BlendMode::Multiply)?;
+        graphics::draw_ex(ctx, &self.shadows, center)?;
+
+        // The light map will be drawn on top using the add blend mode
+        graphics::set_blend_mode(ctx, BlendMode::Add)?;
+        graphics::draw_ex(ctx, &self.lights, center)?;
+
+        // We switch the color to the shadow color before drawing the foreground objects
+        // this has the same effect as applying this color in a multiply blend mode with
+        // full opacity. We also reset the blend mode back to the default Alpha blend mode.
         graphics::set_color(ctx, AMBIENT_COLOR.into())?;
+        graphics::set_blend_mode(ctx, BlendMode::Alpha)?;
         graphics::draw_ex(ctx, &self.foreground, canvascenter)?;
 
         // Uncomment following two lines to visualize the 1D occlusions canvas,
@@ -291,7 +407,7 @@ impl event::EventHandler for MainState {
     ) {
         let (w, h) = ctx.gfx_context.get_size();
         let (x, y) = (x as f32 / w as f32, 1.0 - y as f32 / h as f32);
-        self.light.pos = [x, y];
+        self.torch.pos = [x, y];
     }
 }
 

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -64,6 +64,7 @@ impl Canvas {
             image: Image {
                 texture: resource,
                 sampler_info: ctx.gfx_context.default_sampler_info,
+                blend_mode: None,
                 width,
                 height,
             },
@@ -91,6 +92,12 @@ impl Drawable for Canvas {
             param.scale.y = -param.scale.y;
         }
         self.image.draw_ex(ctx, param)
+    }
+    fn set_blend_mode(&mut self, mode: Option<BlendMode>) {
+        self.image.blend_mode = mode;
+    }
+    fn get_blend_mode(&self) -> Option<BlendMode> {
+        self.image.blend_mode
     }
 }
 

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -309,7 +309,7 @@ impl Drawable for Mesh {
         gfx.data.vbuf = self.buffer.clone();
         gfx.data.tex.0 = gfx.white_image.texture.clone();
 
-        gfx.draw(Some(&self.slice));
+        gfx.draw(Some(&self.slice))?;
 
         Ok(())
     }

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -209,6 +209,7 @@ impl MeshBuilder {
         Ok(Mesh {
                buffer: vbuf,
                slice: slice,
+               blend_mode: None
            })
     }
 }
@@ -242,6 +243,7 @@ impl t::VertexConstructor<t::StrokeVertex, Vertex> for VertexBuilder {
 pub struct Mesh {
     buffer: gfx::handle::Buffer<gfx_device_gl::Resources, Vertex>,
     slice: gfx::Slice<gfx_device_gl::Resources>,
+    blend_mode: Option<BlendMode>,
 }
 
 
@@ -312,5 +314,11 @@ impl Drawable for Mesh {
         gfx.draw(Some(&self.slice))?;
 
         Ok(())
+    }
+    fn set_blend_mode(&mut self, mode: Option<BlendMode>) {
+        self.blend_mode = mode;
+    }
+    fn get_blend_mode(&self) -> Option<BlendMode> {
+        self.blend_mode
     }
 }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -337,7 +337,8 @@ impl GraphicsContext {
                                            "Empty",
                                            &mut encoder,
                                            &mut factory,
-                                           samples)?;
+                                           samples,
+                                           None)?;
 
         let rect_inst_props = factory
             .create_buffer(1,
@@ -497,12 +498,13 @@ impl GraphicsContext {
 
     /// Draws with the current encoder, slice, and pixel shader. Prefer calling
     /// this method from `Drawables` so that the pixel shader gets used
-    fn draw(&mut self, slice: Option<&gfx::Slice<gfx_device_gl::Resources>>) {
+    fn draw(&mut self, slice: Option<&gfx::Slice<gfx_device_gl::Resources>>) -> GameResult<()> {
         let slice = slice.unwrap_or(&self.quad_slice);
         let id = (*self.current_shader.borrow()).unwrap_or(self.default_shader);
         let shader = &self.shaders[id];
 
-        shader.draw(&mut self.encoder, slice, &self.data);
+        shader.draw(&mut self.encoder, slice, &self.data)?;
+        Ok(())
     }
 
     /// Returns a reference to the SDL window.

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -332,13 +332,23 @@ impl GraphicsContext {
                                       gfx_device_gl::CommandBuffer> =
             factory.create_command_buffer().into();
 
+        let blend_modes = vec![
+            BlendMode::Alpha,
+            BlendMode::Add,
+            BlendMode::Subtract,
+            BlendMode::Invert,
+            BlendMode::Multiply,
+            BlendMode::Replace,
+            BlendMode::Lighten,
+            BlendMode::Darken
+        ];
         let (shader, draw) = create_shader(include_bytes!("shader/basic_150.glslf"),
                                            EmptyConst,
                                            "Empty",
                                            &mut encoder,
                                            &mut factory,
                                            samples,
-                                           None)?;
+                                           Some(&blend_modes[..]))?;
 
         let rect_inst_props = factory
             .create_buffer(1,

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -923,6 +923,11 @@ pub fn apply_transformations(context: &mut Context) -> GameResult<()> {
     gfx.update_globals()
 }
 
+/// Sets the blend mode of the currently active shader program
+pub fn set_blend_mode(ctx: &mut Context, mode: BlendMode) -> GameResult<()> {
+    ctx.gfx_context.set_blend_mode(mode)
+}
+
 /// Sets the window mode, such as the size and other properties.
 ///
 /// Setting the window mode may have side effects, such as clearing

--- a/src/graphics/pixelshader.rs
+++ b/src/graphics/pixelshader.rs
@@ -328,8 +328,11 @@ pub trait PixelShaderHandle<Spec: graphics::BackendSpec>: fmt::Debug {
         &graphics::pipe::Data<Spec::Resources>
     ) -> GameResult<()>;
 
-    /// Sets the shader's blend mode
+    /// Sets the shader program's blend mode
     fn set_blend_mode(&mut self, mode: BlendMode) -> GameResult<()>;
+
+    /// Gets the shader program's current blend mode
+    fn get_blend_mode(&self) -> BlendMode;
 }
 
 impl<Spec, C> PixelShaderHandle<Spec> for PixelShaderProgram<Spec, C>
@@ -351,6 +354,10 @@ impl<Spec, C> PixelShaderHandle<Spec> for PixelShaderProgram<Spec, C>
         self.psos.get_mode(&mode)?;
         self.active_blend_mode = mode;
         Ok(())
+    }
+
+    fn get_blend_mode(&self) -> BlendMode {
+        self.active_blend_mode
     }
 }
 
@@ -394,7 +401,6 @@ where
 pub fn clear_shader(ctx: &mut Context) {
     *ctx.gfx_context.current_shader.borrow_mut() = None;
 }
-
 
 #[derive(Debug)]
 struct ConstMeta<C: Structure<ConstFormat>>(graphics::pipe::Meta, ConstantBuffer<C>);

--- a/src/graphics/pixelshader.rs
+++ b/src/graphics/pixelshader.rs
@@ -104,13 +104,18 @@ impl From<BlendMode> for Blend {
         }
     }
 }
-
-/// A structure for conveniently storing Sampler's, based off
-/// their `SamplerInfo`.
+/// A struct to easily store a set of PSOs that is
+/// associated with a specific shader program.
 ///
-/// Making this generic is tricky 'cause it has methods that depend
-/// on the generic Factory trait, it seems, so for now we just kind
-/// of hack it.
+/// In gfx, because Vulkan and DX are more strict 
+/// about how blend modes work than GL is, blend modes are 
+/// baked in as a piece of state for a PSO and you can't change it 
+/// dynamically. After chatting with @kvark on IRC and looking 
+/// how he does it in three-rs, the best way to change blend 
+/// modes is to just make multiple PSOs with respective blend modes baked in. 
+/// The PsoSet struct is basically just a hash map for easily 
+/// storing each shader set's PSOs and then retrieving them based 
+/// on a BlendMode.
 struct PsoSet<Spec, C>
     where Spec: graphics::BackendSpec,
           C: Structure<ConstFormat>
@@ -236,6 +241,11 @@ where
     C: 'static + Pod + Structure<ConstFormat> + Clone + Copy,
 {
     /// Create a new `PixelShader` given a gfx pipeline object
+    ///
+    /// In order to use a specific blend mode when this shader is being
+    /// used, you must include that blend mode as part of the
+    /// `blend_modes` parameter at creation. If `None` is given, only the
+    /// default `Alpha` blend mode is used.
     pub fn new<P: AsRef<Path>, S: Into<String>>(
         ctx: &mut Context,
         path: P,
@@ -254,6 +264,11 @@ where
 
     /// Create a new `PixelShader` directly from source given a gfx pipeline
     /// object
+    ///
+    /// In order to use a specific blend mode when this shader is being
+    /// used, you must include that blend mode as part of the
+    /// `blend_modes` parameter at creation. If `None` is given, only the
+    /// default `Alpha` blend mode is used.
     pub fn from_u8<S: Into<String>>(
         ctx: &mut Context,
         source: &[u8],

--- a/src/graphics/pixelshader.rs
+++ b/src/graphics/pixelshader.rs
@@ -76,7 +76,6 @@ impl From<BlendMode> for Blend {
             BlendMode::Invert => blend::INVERT,
             BlendMode::Multiply => blend::MULTIPLY,
             BlendMode::Replace => blend::REPLACE,
-            // TODO: IMPLEMENT Lighten and Darken blend modes
             BlendMode::Lighten => Blend {
                 color: BlendChannel {
                     equation: Equation::Max,
@@ -396,10 +395,6 @@ pub fn clear_shader(ctx: &mut Context) {
     *ctx.gfx_context.current_shader.borrow_mut() = None;
 }
 
-/// Sets the blend mode of the currently active shader program
-pub fn set_blend_mode(ctx: &mut Context, mode: BlendMode) -> GameResult<()> {
-    ctx.gfx_context.set_blend_mode(mode)
-}
 
 #[derive(Debug)]
 struct ConstMeta<C: Structure<ConstFormat>>(graphics::pipe::Meta, ConstantBuffer<C>);

--- a/src/graphics/pixelshader.rs
+++ b/src/graphics/pixelshader.rs
@@ -240,6 +240,7 @@ where
         path: P,
         consts: C,
         name: S,
+        blend_modes: Option<&[BlendMode]>,
     ) -> GameResult<PixelShader<C>> {
         let source = {
             let mut buf = Vec::new();
@@ -247,7 +248,7 @@ where
             reader.read_to_end(&mut buf)?;
             buf
         };
-        PixelShader::from_u8(ctx, &source, consts, name)
+        PixelShader::from_u8(ctx, &source, consts, name, blend_modes)
     }
 
     /// Create a new `PixelShader` directly from source given a gfx pipeline
@@ -257,6 +258,7 @@ where
         source: &[u8],
         consts: C,
         name: S,
+        blend_modes: Option<&[BlendMode]>,
     ) -> GameResult<PixelShader<C>> {
         let (mut shader, draw) = create_shader(
             &source,
@@ -265,7 +267,7 @@ where
             &mut ctx.gfx_context.encoder,
             &mut *ctx.gfx_context.factory,
             ctx.gfx_context.multisample_samples,
-            None
+            blend_modes
         )?;
         shader.id = ctx.gfx_context.shaders.len();
         ctx.gfx_context.shaders.push(draw);

--- a/src/graphics/pixelshader.rs
+++ b/src/graphics/pixelshader.rs
@@ -76,6 +76,7 @@ impl From<BlendMode> for Blend {
             BlendMode::Invert => blend::INVERT,
             BlendMode::Multiply => blend::MULTIPLY,
             BlendMode::Replace => blend::REPLACE,
+            // TODO: IMPLEMENT Lighten and Darken blend modes
             BlendMode::Lighten => Blend {
                 color: BlendChannel {
                     equation: Equation::Max,

--- a/src/graphics/pixelshader.rs
+++ b/src/graphics/pixelshader.rs
@@ -84,21 +84,22 @@ impl From<BlendMode> for Blend {
                     destination: Factor::One
                 },
                 alpha: BlendChannel {
-                    equation: Equation::Sub,
-                    source: Factor::One,
-                    destination: Factor::One
+                    equation: Equation::Add,
+                    source: Factor::ZeroPlus(BlendValue::SourceAlpha),
+                    destination: Factor::OneMinus(BlendValue::SourceAlpha)
                 },
             },
             BlendMode::Darken => Blend {
                 color: BlendChannel {
-                    equation: Equation::Sub,
+                    equation: Equation::Min,
                     source: Factor::One,
                     destination: Factor::One
                 },
                 alpha: BlendChannel {
-                    equation: Equation::Sub,
-                    source: Factor::One,
-                    destination: Factor::One
+
+                    equation: Equation::Add,
+                    source: Factor::ZeroPlus(BlendValue::SourceAlpha),
+                    destination: Factor::OneMinus(BlendValue::SourceAlpha)
                 },
             },
         }

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -130,7 +130,7 @@ impl graphics::Drawable for SpriteBatch {
         gfx.push_transform(param.into_matrix());
         gfx.calculate_transform_matrix();
         gfx.update_globals()?;
-        gfx.draw(Some(&slice));
+        gfx.draw(Some(&slice))?;
         gfx.pop_transform();
         gfx.calculate_transform_matrix();
         gfx.update_globals()?;

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -6,6 +6,7 @@ use error;
 use gfx;
 use gfx::Factory;
 use GameResult;
+use super::pixelshader::BlendMode;
 
 // Owning the given Image is inconvenient because we might want, say,
 // the same Rc<Image> shared among many SpriteBatch'es.
@@ -30,6 +31,7 @@ use GameResult;
 pub struct SpriteBatch {
     image: graphics::Image,
     sprites: Vec<graphics::InstanceProperties>,
+    blend_mode: Option<BlendMode>,
 }
 
 /// An index of a particular sprite in a SpriteBatch.
@@ -41,6 +43,7 @@ impl SpriteBatch {
         Self {
             image: image,
             sprites: vec![],
+            blend_mode: None
         }
     }
 
@@ -130,10 +133,30 @@ impl graphics::Drawable for SpriteBatch {
         gfx.push_transform(param.into_matrix());
         gfx.calculate_transform_matrix();
         gfx.update_globals()?;
+        let previous_mode: Option<BlendMode> = if let Some(mode) = self.blend_mode {
+            let current_mode = gfx.get_blend_mode();
+            if current_mode != mode {
+                gfx.set_blend_mode(mode)?;
+                Some(current_mode)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         gfx.draw(Some(&slice))?;
+        if let Some(mode) = previous_mode {
+            gfx.set_blend_mode(mode)?;
+        }
         gfx.pop_transform();
         gfx.calculate_transform_matrix();
         gfx.update_globals()?;
         Ok(())
+    }
+    fn set_blend_mode(&mut self, mode: Option<BlendMode>) {
+        self.blend_mode = mode;
+    }
+    fn get_blend_mode(&self) -> Option<BlendMode> {
+        self.blend_mode
     }
 }

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -215,6 +215,7 @@ impl fmt::Debug for Font {
 pub struct Text {
     texture: Image,
     contents: String,
+    blend_mode: Option<BlendMode>,
 }
 
 /// Compute a scale for a font of a given size.
@@ -308,6 +309,7 @@ fn render_ttf(context: &mut Context,
     Ok(Text {
            texture: image,
            contents: text_string,
+           blend_mode: None,
        })
 
 }
@@ -385,6 +387,7 @@ fn render_bitmap(context: &mut Context,
     Ok(Text {
            texture: image,
            contents: text_string,
+           blend_mode: None,
        })
 }
 
@@ -440,6 +443,12 @@ impl Text {
 impl Drawable for Text {
     fn draw_ex(&self, ctx: &mut Context, param: DrawParam) -> GameResult<()> {
         draw_ex(ctx, &self.texture, param)
+    }
+    fn set_blend_mode(&mut self, mode: Option<BlendMode>) {
+        self.blend_mode = mode;
+    }
+    fn get_blend_mode(&self) -> Option<BlendMode> {
+        self.blend_mode
     }
 }
 


### PR DESCRIPTION
An easy to use API (basically the same as LOVE's) to switch the blend mode of the current shader program. The main limitation is that it requires you to provide a list of blend modes that you want your shader program to support when you create it (or `None` to apply only the default Alpha blend mode). The default shader program comes with all of them by default. This allows us to do things like this :D (the updated shadows example).

![image](https://user-images.githubusercontent.com/887711/31312861-ec796f3e-ab84-11e7-9570-7c868c775c1b.png)

TODO:
* ~~Still need to figure out how to implement the Lighten and Darken blend modes using gfx's API--for now they're just placeholders. All the rest of the blend modes work, though.~~
* ~~Perhaps restructure where a few things live; I'm not sure it makes sense to have the `graphics::set_blend_mode()` function inside `pixelshader.rs`~~
