### PR TITLE
make sure when rendering the light and shadow canvases we take DPI into account

### DIFF
--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -370,8 +370,8 @@ impl event::EventHandler for MainState {
         graphics::set_canvas(ctx, None);
         graphics::set_color(ctx, graphics::WHITE)?;
         graphics::draw_ex(ctx, &self.background, center)?;
-        graphics::draw_ex(ctx, &self.shadows, center)?;
-        graphics::draw_ex(ctx, &self.lights, center)?;
+        graphics::draw_ex(ctx, &self.shadows, canvascenter)?;
+        graphics::draw_ex(ctx, &self.lights, canvascenter)?;
         // We switch the color to the shadow color before drawing the foreground objects
         // this has the same effect as applying this color in a multiply blend mode with
         // full opacity. We also reset the blend mode back to the default Alpha blend mode.


### PR DESCRIPTION
@termhn Finally got around to testing the shadows example on my mac and there was indeed an issue with it when high DPI is enabled, this pull request should fix that.

Also there it seems to be only running at 30FPS on my mac and I'm not sure why... I'm going to investigate a bit and see if I can it out.