### PR TITLE
Move color settings into InstanceProperties/DrawParam

### DIFF
--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -133,12 +133,12 @@ gfx_defines!{
         col2: [f32; 4] = "a_TCol2",
         col3: [f32; 4] = "a_TCol3",
         col4: [f32; 4] = "a_TCol4",
+        color: [f32; 4] = "a_Color",
     }
 
     /// Internal structure containing global shader state.
     constant Globals {
         mvp_matrix: [[f32; 4]; 4] = "u_MVP",
-        color: [f32; 4] = "u_Color",
     }
 
     pipeline pipe {
@@ -159,6 +159,7 @@ impl Default for InstanceProperties {
             col2: [0.0, 1.0, 0.0, 0.0],
             col3: [1.0, 0.0, 1.0, 0.0],
             col4: [1.0, 0.0, 0.0, 1.0],
+            color: types::WHITE.into()
         }
     }
 }
@@ -172,6 +173,7 @@ impl From<DrawParam> for InstanceProperties {
             col2: mat[1],
             col3: mat[2],
             col4: mat[3],
+            color: p.color.into()
         }
     }
 }
@@ -216,7 +218,6 @@ impl<B> SamplerCache<B>
 pub(crate) struct GraphicsContextGeneric<B>
     where B: BackendSpec
 {
-    foreground_color: Color,
     background_color: Color,
     shader_globals: Globals,
     projection: Matrix4,
@@ -406,11 +407,9 @@ impl GraphicsContext {
         let initial_transform = Matrix4::identity();
         let globals = Globals {
             mvp_matrix: initial_projection.into(),
-            color: types::WHITE.into(),
         };
 
         let mut gfx = GraphicsContext {
-            foreground_color: types::WHITE,
             background_color: Color::new(0.1, 0.2, 0.3, 1.0),
             shader_globals: globals,
             projection: initial_projection,
@@ -776,11 +775,6 @@ pub fn get_background_color(ctx: &Context) -> Color {
     ctx.gfx_context.background_color
 }
 
-/// Returns the current foreground color.
-pub fn get_color(ctx: &Context) -> Color {
-    ctx.gfx_context.foreground_color
-}
-
 /// Get the default filter mode for new images.
 pub fn get_default_filter(ctx: &Context) -> FilterMode {
     let gfx = &ctx.gfx_context;
@@ -815,16 +809,6 @@ pub fn get_screen_coordinates(ctx: &Context) -> Rect {
 /// Sets the background color.  Default: blue.
 pub fn set_background_color(ctx: &mut Context, color: Color) {
     ctx.gfx_context.background_color = color;
-}
-
-/// Sets the foreground color, which will be used for drawing
-/// rectangles, lines, etc.  Default: white.
-pub fn set_color(ctx: &mut Context, color: Color) -> GameResult<()> {
-    let gfx = &mut ctx.gfx_context;
-    gfx.foreground_color = color;
-    let linear_color: types::LinearColor = color.into();
-    gfx.shader_globals.color = linear_color.into();
-    gfx.update_globals()
 }
 
 /// Sets the default filter mode used to scale images.
@@ -1172,6 +1156,8 @@ pub struct DrawParam {
     pub offset: Point2,
     /// x/y shear factors expressed as a `Point2`.
     pub shear: Point2,
+    /// color to tint the drawable.
+    pub color: Color,
 }
 
 impl Default for DrawParam {
@@ -1183,6 +1169,7 @@ impl Default for DrawParam {
             scale: Point2::new(1.0, 1.0),
             offset: Point2::new(0.0, 0.0),
             shear: Point2::new(0.0, 0.0),
+            color: types::WHITE
         }
     }
 }

--- a/src/graphics/shader/basic_150.glslf
+++ b/src/graphics/shader/basic_150.glslf
@@ -2,14 +2,14 @@
 
 uniform sampler2D t_Texture;
 in vec2 v_Uv;
+in vec4 v_Color;
 out vec4 Target0;
 
 layout (std140) uniform Globals {
     mat4 u_MVP;
-    vec4 u_Color;
 };
 
 void main() {
     //Target0 = vec4(1.0, 1.0, 1.0, 1.0);
-    Target0 = texture(t_Texture, v_Uv) * u_Color;
+    Target0 = texture(t_Texture, v_Uv) * v_Color;
 }

--- a/src/graphics/shader/basic_150.glslv
+++ b/src/graphics/shader/basic_150.glslv
@@ -8,16 +8,18 @@ in vec4 a_TCol1;
 in vec4 a_TCol2;
 in vec4 a_TCol3;
 in vec4 a_TCol4;
+in vec4 a_Color;
 
 layout (std140) uniform Globals {
     mat4 u_MVP;
-    vec4 u_Color;
 };
 
 out vec2 v_Uv;
+out vec4 v_Color;
 
 void main() {
     v_Uv = a_Uv * a_Src.zw + a_Src.xy;
+    v_Color = a_Color;
     mat4 instance_transform = mat4(a_TCol1, a_TCol2, a_TCol3, a_TCol4);
     vec4 position = instance_transform * vec4(a_Pos, 0.0, 1.0);
 


### PR DESCRIPTION
As discussed in #216!

This PR takes a first stab at removing some of the implicit state around drawing things with a color, removing `set_color` and adding a `color` field to `InstanceProperties` and `DrawParam`.

Fully anticipating that this might not end up going anywhere (not entirely sold on the API as is), but it might give people smarter than me an idea of where to go next. Plus if I'm honest, I just wanted an excuse to ferret around in the codebase :p

Couple of observations:
* I am wholly unfamiliar with GFX and OpenGL, so apologies if I've made any rookie errors with the shaders!
* I'm not sure how I feel about having to use `draw_ex` every time I want to draw something with a color 🤔 
* Some thought would need to be given as to how this would interact with the primitive drawing API (`circle`, `line`, etc.)
  * This is why I haven't updated the examples yet - everything's in white!