### PR TITLE
Change SoundData storage to Arc<[u8]>

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -48,12 +48,12 @@ impl fmt::Debug for AudioContext {
 /// Static sound data stored in memory.
 /// It is Arc'ed, so cheap to clone.
 #[derive(Clone, Debug)]
-pub struct SoundData(Arc<Box<[u8]>>);
+pub struct SoundData(Arc<[u8]>);
 
 impl SoundData {
     /// Copies the data in the given slice into a new SoundData object.
     pub fn from_bytes(data: &[u8]) -> Self {
-        SoundData::from(Vec::from(data))
+        SoundData(Arc::from(data))
     }
 
     /// Creates a SoundData from any Read object; this involves
@@ -71,13 +71,13 @@ impl SoundData {
 
 impl From<Vec<u8>> for SoundData {
     fn from(v: Vec<u8>) -> Self {
-        v.into_boxed_slice().into()
+        SoundData(Arc::from(v))
     }
 }
 
 impl From<Box<[u8]>> for SoundData {
     fn from(b: Box<[u8]>) -> Self {
-        SoundData(Arc::new(b))
+        SoundData(Arc::from(b))
     }
 }
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -69,6 +69,13 @@ impl SoundData {
     }
 }
 
+impl From<Arc<[u8]>> for SoundData {
+    #[inline]
+    fn from(arc: Arc<[u8]>) -> Self {
+        SoundData(arc)
+    }
+}
+
 impl From<Vec<u8>> for SoundData {
     fn from(v: Vec<u8>) -> Self {
         SoundData(Arc::from(v))

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -53,9 +53,7 @@ pub struct SoundData(Arc<Vec<u8>>);
 impl SoundData {
     /// Copies the data in the given slice into a new SoundData object.
     pub fn from_bytes(data: &[u8]) -> Self {
-        let mut buffer = Vec::with_capacity(data.len());
-        buffer.extend(data);
-        SoundData::from(buffer)
+        SoundData::from(Vec::from(data))
     }
 
     /// Creates a SoundData from any Read object; this involves

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -48,7 +48,7 @@ impl fmt::Debug for AudioContext {
 /// Static sound data stored in memory.
 /// It is Arc'ed, so cheap to clone.
 #[derive(Clone, Debug)]
-pub struct SoundData(Arc<Vec<u8>>);
+pub struct SoundData(Arc<Box<[u8]>>);
 
 impl SoundData {
     /// Copies the data in the given slice into a new SoundData object.
@@ -71,7 +71,7 @@ impl SoundData {
 
 impl From<Vec<u8>> for SoundData {
     fn from(v: Vec<u8>) -> Self {
-        SoundData(Arc::new(v))
+        SoundData(Arc::new(v.into_boxed_slice()))
     }
 }
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -71,7 +71,13 @@ impl SoundData {
 
 impl From<Vec<u8>> for SoundData {
     fn from(v: Vec<u8>) -> Self {
-        SoundData(Arc::new(v.into_boxed_slice()))
+        v.into_boxed_slice().into()
+    }
+}
+
+impl From<Box<[u8]>> for SoundData {
+    fn from(b: Box<[u8]>) -> Self {
+        SoundData(Arc::new(b))
     }
 }
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -89,8 +89,9 @@ impl From<Box<[u8]>> for SoundData {
 }
 
 impl AsRef<[u8]> for SoundData {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
-        self.0.as_ref().as_ref()
+        self.0.as_ref()
     }
 }
 


### PR DESCRIPTION
The inner data never gets mutated, so there's no reason to keep track of capacity via `Vec`.

Also added `From` impls for `Box<[u8]>` and `Arc<[u8]>`.