### PR TITLE
Screenshot

### DIFF
--- a/examples/astroblasto.rs
+++ b/examples/astroblasto.rs
@@ -576,7 +576,10 @@ impl EventHandler for MainState {
             }
             Keycode::Space => {
                 self.input.fire = true;
-            }
+            },
+            Keycode::P => {
+                graphics::screenshot(ctx, "screenshot.png");
+            },
             Keycode::Escape => ctx.quit().unwrap(),
             _ => (), // Do nothing
         }

--- a/examples/astroblasto.rs
+++ b/examples/astroblasto.rs
@@ -578,7 +578,8 @@ impl EventHandler for MainState {
                 self.input.fire = true;
             },
             Keycode::P => {
-                graphics::screenshot(ctx, "screenshot.png");
+                // Because this is an example, we silently discard any error while screenshotting
+                let _ = graphics::screenshot(ctx, "screenshot.png");
             },
             Keycode::Escape => ctx.quit().unwrap(),
             _ => (), // Do nothing

--- a/src/error.rs
+++ b/src/error.rs
@@ -201,6 +201,20 @@ impl From<gfx::PipelineStateError<std::string::String>> for GameError {
     }
 }
 
+impl From<gfx::mapping::Error> for GameError {
+    fn from(e: gfx::mapping::Error) -> GameError {
+        let errstr = format!("Buffer mapping error: {:?}", e);
+        GameError::VideoError(errstr)
+    }
+}
+
+impl<S, D> From<gfx::CopyError<S, D>> for GameError where S: fmt::Debug, D: fmt::Debug {
+    fn from(e: gfx::CopyError<S, D>) -> GameError {
+        let errstr = format!("Memory copy error: {:?}", e);
+        GameError::VideoError(errstr)
+    }
+}
+
 impl From<gfx::CombinedError> for GameError {
     fn from(e: gfx::CombinedError) -> GameError {
         let errstr = format!("Texture+view load error: {}", e.description());

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -147,8 +147,12 @@ impl Filesystem {
         // Writeable local dir, ~/.config/whatever/
         // Save game dir is read-write
         {
+            use std::path::Path;
+
             user_config_path = app_root(AppDataType::UserConfig, &app_info)?;
             let physfs = vfs::PhysicalFS::new(&user_config_path, false);
+            // Ensure the screenshots subdirectory exists
+            physfs.mkdir(Path::new("/screenshots"))?;
             overlay.push_back(Box::new(physfs));
         }
 

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -57,7 +57,7 @@ impl Canvas {
         let tex = factory.create_texture(
             kind,
             levels,
-            Bind::SHADER_RESOURCE | Bind::RENDER_TARGET,
+            Bind::SHADER_RESOURCE | Bind::RENDER_TARGET | Bind::TRANSFER_SRC,
             Usage::Data,
             Some(cty),
         )?;

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -667,8 +667,26 @@ pub fn present(ctx: &mut Context) {
 }
 
 /// Take a screenshot by outputting the current render surface
+/// (screen or selected canvas) to a PNG file with the given name,
+/// in the game's data directory.
+pub fn screenshot(ctx: &mut Context, name: &str) -> GameResult<()> {
+    use std::path::PathBuf;
+
+    let mut full_path = PathBuf::from(ctx.filesystem.get_user_data_dir());
+    full_path.push("screenshots");
+    full_path.push(name);
+    println!("{}", full_path.to_string_lossy());
+    screenshot_to_path(ctx, &*full_path.to_string_lossy())
+}
+
+// TODO link screenshot fn in below doc
+
+/// Take a screenshot by outputting the current render surface
 /// (screen or selected canvas) to a PNG file.
-pub fn screenshot(ctx: &mut Context, path: &str) -> GameResult<()> {
+/// 
+/// `screenshot` should be preferred if you do not need absolute control
+/// over where the screenshot will be placed.
+pub fn screenshot_to_path(ctx: &mut Context, path: &str) -> GameResult<()> {
     use gfx::memory::Typed;
     use gfx::format::Formatted;
     use gfx::format::SurfaceTyped;

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -436,7 +436,7 @@ impl GraphicsContext {
             projection: initial_projection,
             modelview_stack: vec![initial_transform],
             white_image: white_image,
-            screen_rect: Rect::new(left, top, (right - left), (bottom - top)),
+            screen_rect: Rect::new(left, top, right - left, bottom - top),
             dpi: dpi,
 
             backend_spec: backend,


### PR DESCRIPTION
Basically taken verbatim from the gfx example.

Works fine with canvases too (once I adjusted the viewport accordingly.)

It's a bit slow - you can see my note about instantiating the download buffer on the fly. I imagine acting on that may speed things up, but ensuring that it is always the correct size everywhere in the codebase looked like a pain. I can try to take a shot at it if you're interested.

Reversing the images is a bit weird, maybe there's a better way to handle that.

Closes #244 

  