### PR TITLE
Sound development - SoundData.from_file(), Source.repeat

### DIFF
--- a/examples/astroblasto.rs
+++ b/examples/astroblasto.rs
@@ -245,8 +245,8 @@ impl Assets {
         let rock_image = graphics::Image::new(ctx, "/rock.png")?;
         let font = graphics::Font::new(ctx, "/DejaVuSerif.ttf", 18)?;
 
-        let shot_sound = audio::Source::new(ctx, "/pew.ogg")?;
-        let hit_sound = audio::Source::new(ctx, "/boom.ogg")?;
+        let shot_sound = audio::Source::new(ctx, "/pew.ogg", false)?;
+        let hit_sound = audio::Source::new(ctx, "/boom.ogg", false)?;
         Ok(Assets {
                player_image: player_image,
                shot_image: shot_image,

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -56,7 +56,7 @@ impl MainState {
         let bmpfont = graphics::Font::new_bitmap(ctx, "/arial.png", "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
             .unwrap();
         let bmptext = graphics::Text::new(ctx, "ZYXWVYTSRQPONMLKJIHGFEDCBA", &bmpfont).unwrap();
-        let sound = audio::Source::new(ctx, "/sound.ogg").unwrap();
+        let sound = audio::Source::new(ctx, "/sound.ogg", false).unwrap();
 
         let _ = sound.play();
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -67,6 +67,13 @@ impl SoundData {
 
         Ok(SoundData::from(buffer))
     }
+
+    /// Create a new SoundData from the given file.
+    pub fn from_file<P: AsRef<path::Path>>(context: &mut Context, path: P) -> GameResult<Self> {
+        let path = path.as_ref();
+        let file = &mut context.filesystem.open(path)?;
+        SoundData::from_read(file)
+    }
 }
 
 impl From<Arc<[u8]>> for SoundData {


### PR DESCRIPTION
This PR implements part of what is being discussed in https://github.com/ggez/ggez/issues/245. The second commit changes the way Source.play() works, ignoring the call if the sound is already playing, never simply appending more sound to the end of the rodio::Sink, which I thought was unintuitive as a user.