### PR TITLE
Fix screenshot capturing

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -147,12 +147,8 @@ impl Filesystem {
         // Writeable local dir, ~/.config/whatever/
         // Save game dir is read-write
         {
-            use std::path::Path;
-
             user_config_path = app_root(AppDataType::UserConfig, &app_info)?;
             let physfs = vfs::PhysicalFS::new(&user_config_path, false);
-            // Ensure the screenshots subdirectory exists
-            physfs.mkdir(Path::new("/screenshots"))?;
             overlay.push_back(Box::new(physfs));
         }
 

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -313,15 +313,12 @@ pub fn present(ctx: &mut Context) {
 
 /// Take a screenshot by outputting the current render surface
 /// (screen or selected canvas) to a PNG file.
-/// 
-/// `screenshot` should be preferred if you do not need absolute control
-/// over where the screenshot will be placed.
 pub fn screenshot(ctx: &mut Context) -> GameResult<Image> {
-    use gfx::memory::Typed;
+    use gfx::memory::{Bind, Typed};
     use gfx::format::Formatted;
 
     let gfx = &mut ctx.gfx_context;
-    let (w, h, depth, aa) = gfx.data.out.get_dimensions();
+    let (w, h, _depth, aa) = gfx.data.out.get_dimensions();
     let surface_format = <ColorFormat as Formatted>::get_format();
 
     // TODO: The bind and data settings here might be worth
@@ -332,7 +329,7 @@ pub fn screenshot(ctx: &mut Context) -> GameResult<Image> {
     let target_texture: gfx::handle::Texture<_, <ColorFormat as Formatted>::Surface> = gfx.factory.create_texture(
         texture_kind,
         1,
-        gfx::memory::Bind::empty(),
+        Bind::TRANSFER_SRC | Bind::TRANSFER_DST | Bind::SHADER_RESOURCE,
         gfx::memory::Usage::Data,
         Some(gfx::format::ChannelType::Srgb)
     )?;
@@ -343,7 +340,7 @@ pub fn screenshot(ctx: &mut Context) -> GameResult<Image> {
         zoffset: 0,
         width: w,
         height: h,
-        depth: depth,
+        depth: 0,
         format: surface_format,
         mipmap: 0,
     };


### PR DESCRIPTION
It seems that after the screenshot reworking in devel, screenshots got broken.

This only _partially_ solves the issue; Canvas screenshotting also used to work but now outputs garbage image data. I'm still trying to fix that (I really don't know where to start) but this at least fixes the common case of screenshotting the default screen.