### PR TITLE
 Implemented TextEditing and TextInput events.

### DIFF
--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -90,6 +90,17 @@ impl event::EventHandler for MainState {
                  repeat);
     }
 
+    fn text_editing_event(&mut self, _ctx: &mut Context, text: String, start: i32, length: i32) {
+        println!("Text editing: {}, start {}, length: {}",
+                 text,
+                 start,
+                 length);
+    }
+
+    fn text_input_event(&mut self, _ctx: &mut Context, text: String) {
+        println!("Text input: {}", text);
+    }
+
     fn controller_button_down_event(&mut self, _ctx: &mut Context, btn: Button, instance_id: i32) {
         println!("Controller button pressed: {:?} Controller_Id: {}",
                  btn,

--- a/src/event.rs
+++ b/src/event.rs
@@ -112,6 +112,24 @@ pub trait EventHandler {
     fn key_up_event(&mut self, _ctx: &mut Context, _keycode: Keycode, _keymod: Mod, _repeat: bool) {
     }
 
+    /// Candidate text is passed by the OS (via Input Method Editor).
+    /// Refer to:
+    /// https://wiki.libsdl.org/SDL_TextEditingEvent
+    /// https://wiki.libsdl.org/SDL_TextInputEvent
+    /// https://wiki.libsdl.org/Tutorials/TextInput
+    fn text_editing_event(&mut self, _ctx: &mut Context, _text: String, _start: i32, _length: i32) {
+
+    }
+
+    /// Resulting text (usually a unicode character) is passed by the OS (via Input Method Editor).
+    /// Refer to:
+    /// https://wiki.libsdl.org/SDL_TextEditingEvent
+    /// https://wiki.libsdl.org/SDL_TextInputEvent
+    /// https://wiki.libsdl.org/Tutorials/TextInput
+    fn text_input_event(&mut self, _ctx: &mut Context, _text: String) {
+
+    }
+
     /// A controller button was pressed; instance_id identifies which controller.
     fn controller_button_down_event(
         &mut self,
@@ -213,6 +231,16 @@ where
                         state.key_up_event(ctx, key, keymod, repeat)
                     }
                 }
+                TextEditing {
+                    text,
+                    start,
+                    length,
+                    ..
+                } => state.text_editing_event(ctx, text, start, length),
+                TextInput {
+                    text,
+                    ..
+                } => state.text_input_event(ctx, text),
                 MouseButtonDown {
                     mouse_btn, x, y, ..
                 } => state.mouse_button_down_event(ctx, mouse_btn, x, y),


### PR DESCRIPTION
Can be played with in the input_test example (work just fine on my Win10 instance, tested with Russian and Chinese Simplified layouts).

These are important for multi-language support, how they work and what they do is best described by SDL Wiki:
- [TextEditing](https://wiki.libsdl.org/SDL_TextEditingEvent)
- [TextInput](https://wiki.libsdl.org/SDL_TextInputEvent) (detailed explanation under Remarks is particularly useful, could be adapted for docs)
- [Text input tutorial](https://wiki.libsdl.org/Tutorials/TextInput)

When we eventually migrate to [glutin](https://github.com/tomaka/glutin), TextInput can probably be replaced as-is by [WindowEvent::ReceivedCharacter](https://docs.rs/glutin/0.13.1/glutin/enum.WindowEvent.html#variant.ReceivedCharacter).