### PR TITLE
Fix some clippy warnings

### DIFF
--- a/examples/astroblasto.rs
+++ b/examples/astroblasto.rs
@@ -245,12 +245,12 @@ impl Assets {
         let shot_sound = audio::Source::new(ctx, "/pew.ogg")?;
         let hit_sound = audio::Source::new(ctx, "/boom.ogg")?;
         Ok(Assets {
-            player_image: player_image,
-            shot_image: shot_image,
-            rock_image: rock_image,
-            font: font,
-            shot_sound: shot_sound,
-            hit_sound: hit_sound,
+            player_image,
+            shot_image,
+            rock_image,
+            font,
+            shot_sound,
+            hit_sound,
         })
     }
 
@@ -329,12 +329,12 @@ impl MainState {
         let rocks = create_rocks(5, player.pos, 100.0, 250.0);
 
         let s = MainState {
-            player: player,
+            player,
             shots: Vec::new(),
-            rocks: rocks,
+            rocks,
             level: 0,
             score: 0,
-            assets: assets,
+            assets,
             screen_width: ctx.conf.window_mode.width,
             screen_height: ctx.conf.window_mode.height,
             input: InputState::default(),

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -189,7 +189,7 @@ void main() {
 
         // Bundle all the data together.
         let data = pipe::Data {
-            vbuf: vbuf,
+            vbuf,
             transform: transform.into(),
             locals: factory.create_constant_buffer(1),
             color: (texture_view, factory.create_sampler(sinfo)),
@@ -198,12 +198,12 @@ void main() {
         };
 
         MainState {
-            text1: text1,
-            text2: text2,
+            text1,
+            text2,
             frames: 0,
-            data: data,
-            pso: pso,
-            slice: slice,
+            data,
+            pso,
+            slice,
             rotation: 0.0,
         }
     }

--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -24,9 +24,9 @@ impl MainState {
         let mut image2_nearest = graphics::Image::new(ctx, "/shot.png")?;
         image2_nearest.set_filter(graphics::FilterMode::Nearest);
         let s = MainState {
-            image1: image1,
-            image2_linear: image2_linear,
-            image2_nearest: image2_nearest,
+            image1,
+            image2_linear,
+            image2_nearest,
             zoomlevel: 1.0,
         };
 
@@ -84,7 +84,7 @@ impl event::EventHandler for MainState {
                 dest: dst,
                 rotation: self.zoomlevel,
                 // offset: Point2::new(-16.0, 0.0),
-                scale: scale,
+                scale,
                 // shear: shear,
                 ..Default::default()
             },
@@ -97,7 +97,7 @@ impl event::EventHandler for MainState {
                 dest: dst2,
                 rotation: self.zoomlevel,
                 offset: Point2::new(0.5, 0.5),
-                scale: scale,
+                scale,
                 // shear: shear,
                 ..Default::default()
             },

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -22,7 +22,7 @@ impl MainState {
         let text = graphics::Text::new(ctx, "Hello world!", &font)?;
 
         let s = MainState {
-            text: text,
+            text,
             frames: 0,
         };
         Ok(s)

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -62,15 +62,15 @@ impl MainState {
         let s = MainState {
             a: 0,
             direction: 1,
-            image: image,
-            text: text,
-            bmptext: bmptext,
+            image,
+            text,
+            bmptext,
             // BUGGO: We never use sound again,
             // but we have to hang on to it, Or Else!
             // The optimizer will decide we don't need it
             // since play() has "no side effects" and free it.
             // Or something.
-            sound: sound,
+            sound,
         };
 
         Ok(s)

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -305,7 +305,7 @@ impl MainState {
             let _shader_lock = graphics::use_shader(ctx, &self.lights_shader);
 
             let param = DrawParam {
-                scale: Point2::new((size.0 as f32) / (LIGHT_RAY_COUNT as f32), (size.1 as f32)),
+                scale: Point2::new((size.0 as f32) / (LIGHT_RAY_COUNT as f32), size.1 as f32),
                 ..origin
             };
             self.lights_shader.send(ctx, light)?;

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -133,8 +133,8 @@ impl Source {
         let sink = rodio::Sink::new(&context.audio_context.endpoint);
         let cursor = io::Cursor::new(data);
         Ok(Source {
+            sink,
             data: cursor,
-            sink: sink,
             repeat: false,
         })
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -107,15 +107,15 @@ impl Context {
         let mouse_context = mouse::MouseContext::new();
 
         let mut ctx = Context {
-            conf: conf,
-            sdl_context: sdl_context,
+            conf,
+            sdl_context,
             filesystem: fs,
             gfx_context: graphics_context,
-            event_context: event_context,
-            timer_context: timer_context,
-            audio_context: audio_context,
-            gamepad_context: gamepad_context,
-            mouse_context: mouse_context,
+            event_context,
+            timer_context,
+            audio_context,
+            gamepad_context,
+            mouse_context,
 
             default_font: font,
         };
@@ -208,8 +208,8 @@ impl ContextBuilder {
     /// Create a new ContextBuilder
     pub fn new(game_id: &'static str, author: &'static str) -> Self {
         Self {
-            game_id: game_id,
-            author: author,
+            game_id,
+            author,
             conf: conf::Conf::default(),
             paths: vec![],
             load_conf_file: true,

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -102,7 +102,7 @@ impl Filesystem {
     pub fn new(id: &'static str, author: &'static str) -> GameResult<Filesystem> {
         let app_info = AppInfo {
             name: id,
-            author: author,
+            author,
         };
         let mut root_path = env::current_exe()?;
 
@@ -165,10 +165,10 @@ impl Filesystem {
 
         let fs = Filesystem {
             vfs: overlay,
-            resources_path: resources_path,
+            resources_path,
             zip_path: resources_zip_path,
-            user_config_path: user_config_path,
-            user_data_path: user_data_path,
+            user_config_path,
+            user_data_path,
         };
 
         Ok(fs)

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -93,7 +93,7 @@ impl GraphicsContext {
             window_builder.allow_highdpi();
         }
         let (window, gl_context, device, mut factory, screen_render_target, depth_view) =
-            gfx_window_sdl::init(&video, window_builder)?;
+            gfx_window_sdl::init(video, window_builder)?;
 
         GraphicsContext::set_vsync(video, window_mode.vsync)?;
 
@@ -173,26 +173,26 @@ impl GraphicsContext {
             shader_globals: globals,
             projection: initial_projection,
             modelview_stack: vec![initial_transform],
-            white_image: white_image,
+            white_image,
             screen_rect: Rect::new(left, top, right - left, bottom - top),
-            dpi: dpi,
+            dpi,
 
             backend_spec: backend,
-            window: window,
+            window,
             multisample_samples: samples,
-            gl_context: gl_context,
+            gl_context,
             device: Box::new(device),
             factory: Box::new(factory),
-            encoder: encoder,
-            screen_render_target: screen_render_target,
-            depth_view: depth_view,
+            encoder,
+            screen_render_target,
+            depth_view,
 
-            data: data,
-            quad_slice: quad_slice,
-            quad_vertex_buffer: quad_vertex_buffer,
+            data,
+            quad_slice,
+            quad_vertex_buffer,
 
             default_sampler_info: sampler_info,
-            samplers: samplers,
+            samplers,
 
             default_shader: shader.shader_id(),
             current_shader: Rc::new(RefCell::new(None)),

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -225,7 +225,7 @@ impl MeshBuilder {
 
         Ok(Mesh {
             buffer: vbuf,
-            slice: slice,
+            slice,
             blend_mode: None,
         })
     }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -79,8 +79,8 @@ impl From<conf::Backend> for GlBackendSpec {
     fn from(c: conf::Backend) -> Self {
         match c {
             conf::Backend::OpenGL { major, minor } => Self {
-                major: major,
-                minor: minor,
+                major,
+                minor,
             },
         }
     }
@@ -369,8 +369,8 @@ pub fn screenshot(ctx: &mut Context) -> GameResult<Image> {
         texture_handle: target_texture,
         sampler_info: gfx.default_sampler_info,
         blend_mode: None,
-        width: w as u32,
-        height: h as u32,
+        width: u32::from(w),
+        height: u32::from(h),
     };
 
     Ok(image)
@@ -876,8 +876,8 @@ pub trait Drawable {
         self.draw_ex(
             ctx,
             DrawParam {
-                dest: dest,
-                rotation: rotation,
+                dest,
+                rotation,
                 ..Default::default()
             },
         )

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -51,7 +51,7 @@ impl SpriteBatch {
     /// Creates a new `SpriteBatch`, drawing with the given image.
     pub fn new(image: graphics::Image) -> Self {
         Self {
-            image: image,
+            image,
             sprites: vec![],
             blend_mode: None,
         }
@@ -148,7 +148,7 @@ impl SpriteBatch {
     #[allow(deprecated)]
     pub fn with_image<'a>(&'a mut self, image: &'a graphics::Image) -> BoundSpriteBatch<'a> {
         BoundSpriteBatch {
-            image: image,
+            image,
             batch: self,
         }
     }

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -101,9 +101,9 @@ impl Font {
         let scale = display_independent_scale(points, x_dpi, y_dpi);
 
         Ok(Font::TTFFont {
-            font: font,
-            points: points,
-            scale: scale,
+            font,
+            points,
+            scale,
         })
     }
 

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -29,10 +29,10 @@ impl Rect {
     /// Create a new rect.
     pub fn new(x: f32, y: f32, w: f32, h: f32) -> Self {
         Rect {
-            x: x,
-            y: y,
-            w: w,
-            h: h,
+            x,
+            y,
+            w,
+            h,
         }
     }
 
@@ -136,7 +136,7 @@ impl From<Rect> for [f32; 4] {
     }
 }
 
-/// A RGBA color in the sRGB color space represented as `f32`'s in the range `[0.0-1.0]`
+/// A RGBA color in the `sRGB` color space represented as `f32`'s in the range `[0.0-1.0]`
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Color {
     /// Red component
@@ -169,10 +169,10 @@ impl Color {
     /// Create a new Color from four f32's in the range [0.0-1.0]
     pub fn new(r: f32, g: f32, b: f32, a: f32) -> Self {
         Color {
-            r: r,
-            g: g,
-            b: b,
-            a: a,
+            r,
+            g,
+            b,
+            a,
         }
     }
 
@@ -332,7 +332,7 @@ impl From<LinearColor> for Color {
     fn from(c: LinearColor) -> Self {
         fn f(component: f32) -> f32 {
             let a = 0.055;
-            if component <= 0.0031308 {
+            if component <= 0.003_130_8 {
                 component * 12.92
             } else {
                 (1.0 + a) * component.powf(1.0 / 2.4)

--- a/src/input.rs
+++ b/src/input.rs
@@ -41,8 +41,8 @@ impl GamepadContext {
             }
         }
         Ok(GamepadContext {
-            gamepads: gamepads,
-            controller_ctx: controller_ctx,
+            gamepads,
+            controller_ctx,
         })
     }
 }

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -25,6 +25,12 @@ impl MouseContext {
     }
 }
 
+impl Default for MouseContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Get whether or not the mouse is "grabbed", ie, confined to the window.
 pub fn get_grabbed(ctx: &Context) -> bool {
     graphics::get_window(ctx).grab()

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -46,7 +46,7 @@ where
         v.resize(size, init_val);
         LogBuffer {
             head: 0,
-            size: size,
+            size,
             contents: v,
         }
     }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -214,7 +214,7 @@ impl PhysicalFS {
     pub fn new(root: &Path, readonly: bool) -> Self {
         PhysicalFS {
             root: root.into(),
-            readonly: readonly,
+            readonly,
         }
     }
 


### PR DESCRIPTION
Remaining warnings:
```text
warning: use of deprecated item 'graphics::spritebatch::BoundSpriteBatch'
  |
  = note: #[warn(deprecated)] on by default

warning: very complex type used. Consider factoring parts into `type` definitions
   --> src/graphics/shader.rs:186:6
    |
186 | ) -> GameResult<(ShaderGeneric<Spec, C>, Box<ShaderHandle<Spec>>)>
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(type_complexity)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.188/index.html#type_complexity

warning: this function has too many arguments (8/7)
   --> src/graphics/shader.rs:177:1
    |
177 | / pub(crate) fn create_shader<C, S, Spec>(
178 | |     vertex_source: &[u8],
179 | |     pixel_source: &[u8],
180 | |     consts: C,
...   |
238 | |     Ok((shader, draw))
239 | | }
    | |_^
    |
    = note: #[warn(too_many_arguments)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.188/index.html#too_many_arguments

warning: very complex type used. Consider factoring parts into `type` definitions
   --> src/graphics/mod.rs:833:6
    |
833 |   ) -> (
    |  ______^
834 | |     &mut <GlBackendSpec as BackendSpec>::Factory,
835 | |     &mut <GlBackendSpec as BackendSpec>::Device,
836 | |     &mut gfx::Encoder<
...   |
847 | |     >,
848 | | ) {
    | |_^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.188/index.html#type_complexity
```
> cargo clippy -V
0.0.188