### PR TITLE
Surface bzip2 feature and put it in default features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,12 @@ path = "src/lib.rs"
 # If this feature is enabled, it will add <cargo root dir>/resources/ to
 # the resource search path.
 cargo-resource-root = []
+bzip2 = ["zip/bzip2"]
+default = ["bzip2"]
 
 [dependencies]
 rusttype = "0.3"
-zip = "0.2"
+zip = { version = "0.2", default-features = false }
 app_dirs = "1"
 gfx = "0.17"
 gfx_device_gl = "0.15"


### PR DESCRIPTION
This solves Issue #306 by allowing developers to specify "default-features=false" so they don't need to have a C/C++ installed when using ggez. It preserves backwards compatibility, because the bzip2 feature is still on-by-default.