### PR TITLE
Line caps and joins

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -18,6 +18,9 @@ pub(crate) struct GraphicsContextGeneric<B>
 where
     B: BackendSpec,
 {
+    pub(crate) line_join: LineJoin,
+    pub(crate) line_cap: LineCap,
+
     pub(crate) foreground_color: Color,
     pub(crate) background_color: Color,
     shader_globals: Globals,
@@ -168,6 +171,9 @@ impl GraphicsContext {
         };
 
         let mut gfx = GraphicsContext {
+            line_join: LineJoin::Miter,
+            line_cap: LineCap::Butt,
+
             foreground_color: types::WHITE,
             background_color: Color::new(0.1, 0.2, 0.3, 1.0),
             shader_globals: globals,

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -586,6 +586,27 @@ pub fn set_projection(context: &mut Context, proj: Matrix4) {
     gfx.set_projection(proj);
 }
 
+
+/// Sets the line join style
+pub fn set_line_join(context: &mut Context, line_join: LineJoin) {
+    context.gfx_context.line_join = line_join;
+}
+
+/// Gets the line join style
+pub fn get_line_join(context: &Context) -> LineJoin {
+    context.gfx_context.line_join
+}
+
+/// Sets the line cap style
+pub fn set_line_cap(context: &mut Context, line_cap: LineCap) {
+    context.gfx_context.line_cap = line_cap;
+}
+
+/// Gets the line cap style
+pub fn get_line_cap(context: &Context) -> LineCap {
+    context.gfx_context.line_cap
+}
+
 /// Premultiplies the given transformation matrix with the current projection matrix
 ///
 /// You must call `apply_transformations(ctx)` after calling this to apply

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -2,6 +2,8 @@ use std::f32;
 use std::u32;
 use nalgebra as na;
 
+use super::{LineJoin, LineCap};
+
 /// A 2 dimensional point representing a location
 pub type Point2 = na::Point2<f32>;
 /// A 2 dimensional vector representing an offset of a location
@@ -358,7 +360,7 @@ impl From<LinearColor> for [f32; 4] {
 #[derive(Debug, Copy, Clone)]
 pub enum DrawMode {
     /// A stroked line with the given width
-    Line(f32),
+    Line(f32, LineJoin, LineCap),
     /// A filled shape.
     Fill,
 }


### PR DESCRIPTION
This commit adds the following methods to the ``graphics`` module. These
both exist in LOVE:

 - ``set_line_join`` - Sets the style to use to join two connected line
 segments together. Possible values are miter, miter-clip, round, bevel
 and arcs. See https://nical.github.io/lyon-doc/lyon/tessellation/path_stroke/enum.LineJoin.html
 - ``set_line_cap`` - Sets the style to terminate the end of line
 segments that aren't connected to another. Possible values are butt,
 square and round. See https://nical.github.io/lyon-doc/lyon/tessellation/path_stroke/enum.LineCap.html