### PR TITLE
Added an example to `MeshBuilder` doc

### DIFF
--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -9,6 +9,37 @@ use lyon::tessellation as t;
 /// many different complex pieces of geometry.  They don't
 /// have to be connected to each other, and will all be
 /// drawn at once.
+///
+/// ```rust
+/// use ggez::{Context, GameResult};
+/// use ggez::graphics::{self, DrawMode, MeshBuilder, Point2};
+///
+/// fn draw_danger_signs(ctx: &mut Context) -> GameResult<()> {
+///     // Initialize a builder instance.
+///     let mesh = MeshBuilder::new()
+///         // Add vertices for 3 lines (in an approximate equilateral triangle).
+///         .line(
+///             &[
+///                 Point2::new(0.0, 0.0),
+///                 Point2::new(-30.0, 52.0),
+///                 Point2::new(30.0, 52.0),
+///                 Point2::new(0.0, 0.0),
+///             ],
+///             1.0,
+///         )
+///         // Add vertices for an exclamation mark!
+///         .ellipse(DrawMode::Fill, Point2::new(0.0, 25.0), 2.0, 15.0, 2.0)
+///         .circle(DrawMode::Fill, Point2::new(0.0, 45.0), 2.0, 2.0)
+///         // Finalize then unwrap. Unwrapping via `?` operator either yields the final `Mesh`,
+///         // or propagates the error (note return type).
+///         .build(ctx)?;
+///     // Draw 3 meshes in a line, 1st and 3rd tilted by 1 radian.
+///     graphics::draw(ctx, &mesh, Point2::new(50.0, 50.0), -1.0).unwrap();
+///     graphics::draw(ctx, &mesh, Point2::new(150.0, 50.0), 0.0).unwrap();
+///     graphics::draw(ctx, &mesh, Point2::new(250.0, 50.0), 1.0).unwrap();
+///     Ok(())
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct MeshBuilder {
     buffer: t::geometry_builder::VertexBuffers<Vertex>,


### PR DESCRIPTION
Fixes #332.

Opted against `ignore` markdown - it compiles as-is.