### PR TITLE
Add glyph cache implement into ggez(WIP)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rusttype = "0.5"
 zip = { version = "0.3", default-features = false }
 app_dirs2 = "2"
 gfx = "0.17"
+gfx_glyph = "0.10.1"
 gfx_device_gl = "0.15"
 gfx_window_sdl = "0.8"
 image = "0.18"

--- a/examples/glyph_cache.rs
+++ b/examples/glyph_cache.rs
@@ -1,0 +1,213 @@
+//! How to glyph cache text render in ggez.
+extern crate ggez;
+
+use ggez::conf;
+use ggez::event::{self, EventHandler};
+use ggez::graphics::glyphcache::{GlyphCache, HorizontalAlign, Layout, TextParam};
+use ggez::graphics::{self, Color, Point2};
+use ggez::{Context, ContextBuilder, GameResult};
+
+struct MainState {
+    frames: usize,
+    glyph_brush: GlyphCache<'static>,
+    text_base: String,
+    text_src: Vec<char>,
+    window_w: f32,
+    window_h: f32,
+}
+
+impl MainState {
+    fn new(ctx: &mut Context) -> GameResult<MainState> {
+        // Set window size.
+        let (window_w, window_h) = (
+            ctx.conf.window_mode.width as f32,
+            ctx.conf.window_mode.height as f32,
+        );
+
+        // currently `GlyphCache` no compatible `graphics::Font`
+        let font = include_bytes!("../resources/DejaVuSerif.ttf");
+
+        // build glyph brush
+        let glyph_brush = GlyphCache::from_bytes(ctx, font as &[u8]);
+
+        // Set background color.
+        let bg_color = graphics::Color::from_rgba(50, 50, 50, 255);
+        graphics::set_background_color(ctx, bg_color);
+
+        Ok(MainState {
+            frames: 0,
+            text_base: String::new(),
+            text_src: "Lorem ipsum dolor sit amet, ferri simul omittantur eam eu, no debet doming dolorem ius.".chars().collect(),
+            glyph_brush,
+            window_w,
+            window_h,
+        })
+    }
+}
+
+impl EventHandler for MainState {
+    fn update(&mut self, ctx: &mut Context) -> GameResult<()> {
+        self.frames += 1;
+        if self.frames % 100 == 0 {
+            println!("FPS: {}", ggez::timer::get_fps(ctx));
+        }
+
+        // Update typewriter like text message
+        {
+            let i = self.text_base.chars().count();
+
+            if self.frames % 2 == 0 {
+                if i < self.text_src.len() {
+                    self.text_base.push(self.text_src[i]);
+                } else {
+                    self.text_base.clear();
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
+        graphics::clear(ctx);
+
+        // glyph cache queue
+        {
+            // Default setting except font_size and color.
+            self.glyph_brush.queue(TextParam {
+                text: "Hello, world.",
+                font_size: 42.0,
+                color: Color::new(0.9, 0.9, 0.9, 1.0),
+                ..TextParam::default()
+            });
+
+            // Center align(no bounds)
+            self.glyph_brush.queue(TextParam {
+                text: "Let's resize this window!",
+                position: Point2::new(self.window_w / 2.0, self.window_h * 0.1),
+                font_size: 42.0,
+                color: Color::new(0.9, 0.9, 0.3, 1.0),
+                layout: Layout::default().h_align(HorizontalAlign::Center),
+                ..TextParam::default()
+            });
+
+            // Divided into three parts(left)
+            self.glyph_brush.queue(TextParam {
+                text: "The quick brown fox jumps over the lazy dog",
+                position: Point2::new(0.0, self.window_h * 0.25),
+                bounds: Point2::new(self.window_w / 3.15, self.window_h),
+                font_size: 24.0,
+                color: Color::new(0.3, 0.3, 0.9, 1.0),
+                ..TextParam::default()
+            });
+
+            // Divided into three parts(center)
+            self.glyph_brush.queue(TextParam {
+                text: "The quick brown fox jumps over the lazy dog",
+                position: Point2::new(self.window_w / 2.0, self.window_h * 0.25),
+                bounds: Point2::new(self.window_w / 3.15, self.window_h),
+                font_size: 24.0,
+                color: Color::new(0.3, 0.3, 0.9, 1.0),
+                layout: Layout::default().h_align(HorizontalAlign::Center),
+                ..TextParam::default()
+            });
+
+            // Divided into three parts(right)
+            self.glyph_brush.queue(TextParam {
+                text: "The quick brown fox jumps over the lazy dog",
+                position: Point2::new(self.window_w, self.window_h * 0.25),
+                bounds: Point2::new(self.window_w / 3.15, self.window_h),
+                font_size: 24.0,
+                color: Color::new(0.3, 0.3, 0.9, 1.0),
+                layout: Layout::default().h_align(HorizontalAlign::Right),
+                ..TextParam::default()
+            });
+
+            // Multi line text
+            self.glyph_brush.queue(TextParam {
+                text: "1. Multi line test text\n2. Multi line test text\n3. Multi line test text",
+                position: Point2::new(0.0, self.window_h * 0.5),
+                bounds: Point2::new(self.window_w, self.window_h),
+                font_size: 24.0,
+                color: Color::new(0.9, 0.3, 0.3, 1.0),
+                layout: Layout::default_wrap(),
+                ..TextParam::default()
+            });
+
+            // Like a typewriter
+            self.glyph_brush.queue(TextParam {
+                text: &self.text_base,
+                position: Point2::new(0.0, self.window_h * 0.7),
+                bounds: Point2::new(self.window_w, self.window_h),
+                font_size: 36.0,
+                color: Color::new(0.3, 0.9, 0.3, 1.0),
+                ..TextParam::default()
+            });
+
+            // Draws all queue
+            self.glyph_brush.draw(ctx)?;
+        } // end glyph cache closure
+
+        graphics::present(ctx);
+
+        Ok(())
+    }
+
+    fn resize_event(&mut self, _ctx: &mut Context, width: u32, height: u32) {
+        println!("Resized screen to {}, {}", width, height);
+        // reset window size
+        self.window_w = width as f32;
+        self.window_h = height as f32;
+    }
+}
+
+/// In default, ggez has create `user_config_dir` and `user_data_dir`.
+/// e.g. `$HOME/.config/foobar` and `$HOME/.local/share/foobar`
+///
+/// but this example don't use these directory.
+///
+/// "Cast no dirt into the well that gives you water".
+fn unused_dir_remove(ctx: &mut Context) -> GameResult<()> {
+    let user_conf_dir_path = ctx.filesystem.get_user_config_dir();
+    let user_data_dir_path = ctx.filesystem.get_user_data_dir();
+
+    if user_conf_dir_path.is_dir() {
+        ::std::fs::remove_dir(user_conf_dir_path)?;
+    }
+
+    if user_data_dir_path.is_dir() {
+        ::std::fs::remove_dir(user_data_dir_path)?;
+    }
+
+    Ok(())
+}
+
+pub fn main() {
+    let mut cb = ContextBuilder::new("glyph_cache_example", "ggez")
+        .window_setup(
+            conf::WindowSetup::default()
+                .title("glyph cache example")
+                .resizable(true),
+        )
+        .window_mode(conf::WindowMode::default().dimensions(512, 512));
+
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let mut path = std::path::PathBuf::from(manifest_dir);
+        path.push("resources");
+        cb = cb.add_resource_path(path);
+    } else {
+        println!("Not building from cargo?  Ok.");
+    }
+
+    let ctx = &mut cb.build().unwrap();
+
+    // User directory clean up.
+    let _ = unused_dir_remove(ctx);
+
+    let state = &mut MainState::new(ctx).unwrap();
+    if let Err(e) = event::run(ctx, state) {
+        println!("Error encountered: {}", e);
+    } else {
+        println!("Game exited cleanly.");
+    }
+}

--- a/src/graphics/glyphcache.rs
+++ b/src/graphics/glyphcache.rs
@@ -1,0 +1,123 @@
+//! A `GlyphCache` is a quickly and dynamically text rendering way.
+
+use std::f32;
+
+use gfx_device_gl;
+use gfx_glyph::{GlyphBrush, GlyphBrushBuilder, Scale, Section};
+
+use GameResult;
+use context::Context;
+use graphics::{self, Color, Point2};
+
+/// Re-exports `gfx_glyph` some enum for `TextParam.layout`.
+#[doc(no_inline)]
+pub use gfx_glyph::{BuiltInLineBreaker, HorizontalAlign, Layout, VerticalAlign};
+
+/// A `GlyphCache` draw texts from gpu glyph cache.
+///
+/// This is faster than `graphics::Text`, and ideal for dynamic text change.
+/// e.g. "typewriter like text message", "update score every frame"
+#[derive(Debug)]
+pub struct GlyphCache<'a> {
+    glyph_brush: GlyphBrush<'a, gfx_device_gl::Resources, gfx_device_gl::Factory>,
+}
+
+impl<'a> GlyphCache<'a> {
+    //
+    // TODO: Build a new GlyphCache from Font struct.
+    // e.g. `GlyphCache::new()`
+    //
+    // but graphics::Font struct is optimized for graphics::Text,
+    // not suitable for this GlyphCache implement currently.
+    //
+
+    /// Build a new GlyphCache from font bytes data.
+    pub fn from_bytes(ctx: &mut Context, font_bytes: &'a [u8]) -> Self {
+        let builder = GlyphBrushBuilder::using_font_bytes(font_bytes);
+        let factory = graphics::get_factory(ctx);
+
+        let glyph_brush = builder.build(factory.clone());
+
+        GlyphCache { glyph_brush }
+    }
+
+    /// Set text and display param.
+    pub fn queue(&mut self, param: TextParam) {
+        self.glyph_brush.queue(Section {
+            text: param.text,
+            screen_position: (param.position.x, param.position.y),
+            bounds: (param.bounds.x, param.bounds.y),
+            scale: Scale::uniform(param.font_size),
+            color: [param.color.r, param.color.g, param.color.b, param.color.a],
+            z: param.z,
+            layout: param.layout,
+            ..Section::default()
+        })
+    }
+
+    /// Draw to canvas. Almost same as `graphics::Draw()`.
+    ///
+    /// `graphics::Draw()` and `graphics::DrawParam` struct is not compatible
+    /// for `gfx_glyph::Section`.
+    pub fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
+        let gfx = &mut ctx.gfx_context;
+
+        self.glyph_brush
+            .draw_queued(&mut gfx.encoder, &gfx.screen_render_target, &gfx.depth_view)?;
+
+        Ok(())
+    }
+
+    /// Extract GlyphCache inner `gfx_glyph::GlyphBrush`.
+    ///
+    /// Currently, ggez not have `gfx_glyph` had full implement,
+    /// probably some user will decide way to the DIY.
+    ///
+    /// At that time this function will be useful.
+    pub fn extract_glyph_brush(
+        self,
+    ) -> GlyphBrush<'a, gfx_device_gl::Resources, gfx_device_gl::Factory> {
+        self.glyph_brush
+    }
+}
+
+/// This struct feature like a `graphics::DrawParam`,
+/// but `graphics::DrawParam` is not compatible for `gfx_glyph::Section` struct.
+///
+/// Some doc comment quote from `gfx_glyph::Section` comment.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct TextParam<'a> {
+    /// GlyphCache render from this text.
+    pub text: &'a str,
+    /// Position on screen to render text, in pixels from top-left.
+    /// Defaults to Point2(0, 0).
+    pub position: Point2,
+    /// Max (width, height) bounds, in pixels from top-left.
+    /// Defaults to unbounded.
+    pub bounds: Point2,
+    /// Font size. Defaults to 16.0.
+    pub font_size: f32,
+    /// Rgba color of rendered text. Defaults to black.
+    pub color: Color,
+    /// Z values for use in depth testing. Defaults to 0.0.
+    ///
+    /// **NOTICE: Currently no worked!**
+    pub z: f32,
+    /// Display layout.
+    /// Defaults to "Left-align and No-wrap"
+    pub layout: Layout<BuiltInLineBreaker>,
+}
+
+impl Default for TextParam<'static> {
+    fn default() -> Self {
+        Self {
+            text: "",
+            position: Point2::new(0.0, 0.0),
+            bounds: Point2::new(f32::INFINITY, f32::INFINITY),
+            font_size: 16.0,
+            color: Color::new(0.0, 0.0, 0.0, 1.0),
+            z: 0.0,
+            layout: Layout::default(),
+        }
+    }
+}

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -35,6 +35,7 @@ mod text;
 mod types;
 use nalgebra as na;
 
+pub mod glyphcache;
 pub mod spritebatch;
 
 pub use self::canvas::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@
 extern crate app_dirs2;
 #[macro_use]
 extern crate gfx;
+extern crate gfx_glyph;
 extern crate gfx_device_gl;
 extern crate gfx_window_sdl;
 extern crate image;


### PR DESCRIPTION
See #342

I'm try `gfx_glyph` implment into ggez itself. For now glyph cache text render worked somewhat.

But, currently have following issues.

* maybe z-axis param no worked
* `graphics::Font` struct optimized for `graphics::Text`, not best for `gfx_glyph` implement.
* `gfx_glyph` implment can't use `graphics::Drawable` trait, because `graphics::DrawParam` is not suitable for `gfx_glyph`.
* more comfortable comments (my English is so broken)

Please suggestions and help.