### PR TITLE
Added a `GraphicsContext::resize_viewport()` call to `set_mode()`

### DIFF
--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -708,8 +708,10 @@ pub fn set_mode(context: &mut Context, mode: WindowMode) -> GameResult<()> {
     }
     {
         let video = &mut context.sdl_context.video()?;
-        GraphicsContext::set_vsync(video, mode.vsync)
+        GraphicsContext::set_vsync(video, mode.vsync)?;
     }
+    context.gfx_context.resize_viewport();
+    Ok(())
 }
 
 /// Toggles the fullscreen state of the window subsystem


### PR DESCRIPTION
This sort of sidesteps #170, without fixing the underlying issue.

Without this, changing resolution by `graphics::set_resolution()` screws up the viewport, which can only be fixed by a resize event (ultimately triggering `GraphicsContext::resize_viewport()`).

Minimal-ish example to reproduce/test, adapted from @mpatraw's:

```rust
extern crate ggez;

use ggez::conf::{WindowMode, WindowSetup};
use ggez::event;
use ggez::{Context, ContextBuilder, GameResult};
use ggez::graphics::{self, Point2, Rect};
use std::env;
use std::path;

struct MainState {
    text: graphics::Text,
}

impl MainState {
    fn new(ctx: &mut Context) -> GameResult<MainState> {
        let font = graphics::Font::new(ctx, "/DejaVuSerif.ttf", 12)?;
        let (w, h) = (font.get_width("W") * 80, font.get_height() * 25);
        graphics::set_resolution(ctx, w as u32, h as u32)?;
        graphics::set_screen_coordinates(ctx, Rect::new(0.0, 0.0, w as f32, h as f32))?;
        let text = graphics::Text::new(ctx, "Hello world!", &font)?;
        Ok(MainState { text })
    }
}

impl event::EventHandler for MainState {
    fn update(&mut self, _ctx: &mut Context) -> GameResult<()> {
        Ok(())
    }

    fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
        graphics::clear(ctx);
        graphics::draw(ctx, &self.text, Point2::new(0.0, 0.0), 0.0)?;
        graphics::draw(ctx, &self.text, Point2::new(0.0, 100.0), 0.0)?;
        graphics::present(ctx);
        Ok(())
    }
}

pub fn main() {
    let ctx = &mut ContextBuilder::new("helloworld", "ggez")
        .window_setup(WindowSetup::default())
        .window_mode(WindowMode::default().dimensions(640, 480))
        .build()
        .unwrap();

    if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
        let mut path = path::PathBuf::from(manifest_dir);
        path.push("resources");
        ctx.filesystem.mount(&path, true);
    }

    let state = &mut MainState::new(ctx).unwrap();
    if let Err(e) = event::run(ctx, state) {
        println!("Error encountered: {}", e);
    } else {
        println!("Game exited cleanly.");
    }
}
```