### PR TITLE
Improved `lyon` support

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -21,9 +21,6 @@ where
     B: BackendSpec<SurfaceType = C>,
     C: gfx::format::Formatted,
 {
-    pub(crate) line_join: LineJoin,
-    pub(crate) line_cap: LineCap,
-
     pub(crate) foreground_color: Color,
     pub(crate) background_color: Color,
     shader_globals: Globals,
@@ -241,9 +238,6 @@ impl GraphicsContext {
         };
 
         let mut gfx = GraphicsContext {
-            line_join: LineJoin::Miter,
-            line_cap: LineCap::Butt,
-
             foreground_color: types::WHITE,
             background_color: Color::new(0.1, 0.2, 0.3, 1.0),
             shader_globals: globals,

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -577,27 +577,6 @@ pub fn set_projection(context: &mut Context, proj: Matrix4) {
     gfx.set_projection(proj);
 }
 
-
-/// Sets the line join style
-pub fn set_line_join(context: &mut Context, line_join: LineJoin) {
-    context.gfx_context.line_join = line_join;
-}
-
-/// Gets the line join style
-pub fn get_line_join(context: &Context) -> LineJoin {
-    context.gfx_context.line_join
-}
-
-/// Sets the line cap style
-pub fn set_line_cap(context: &mut Context, line_cap: LineCap) {
-    context.gfx_context.line_cap = line_cap;
-}
-
-/// Gets the line cap style
-pub fn get_line_cap(context: &Context) -> LineCap {
-    context.gfx_context.line_cap
-}
-
 /// Premultiplies the given transformation matrix with the current projection matrix
 ///
 /// You must call `apply_transformations(ctx)` after calling this to apply

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -2,7 +2,7 @@ use nalgebra as na;
 use std::f32;
 use std::u32;
 
-use super::{LineJoin, LineCap};
+use super::{FillOptions, StrokeOptions};
 
 /// A 2 dimensional point representing a location
 pub type Point2 = na::Point2<f32>;
@@ -349,10 +349,14 @@ impl From<LinearColor> for [f32; 4] {
 /// filled or as an outline.
 #[derive(Debug, Copy, Clone)]
 pub enum DrawMode {
-    /// A stroked line with the given width
-    Line(f32, LineJoin, LineCap),
+    /// A stroked line with the given width.
+    Line(f32),
     /// A filled shape.
     Fill,
+    /// A stroked line with given parameters, see `StrokeOptions` documentation.
+    CustomLine(StrokeOptions),
+    /// A filled shape with given parameters, see `FillOptions` documentation.
+    CustomFill(FillOptions),
 }
 
 /// Specifies what blending method to use when scaling up/down images.


### PR DESCRIPTION
(also fixes #396)

With overall builder pattern renaissance being in full swing, adding variants to `DrawMode` that utilize `lyon`s own builders seemed like the most conservative yet expressive solution. Unfortunately, this nearly completely amends #308.

As a bonus, I'm almost certain this is a non-breaking change (unless exhaustive matching over `DrawMode` is something user applications would want to do).