### PR TITLE
[WIP] Add `GamepadContext` and event handling for gamepads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ nalgebra = {version = "^0.15.2", features = ["mint"] }
 # Has to be the same version of mint that nalgebra uses here.
 mint = "0.5"
 winit = { version = "0.15", features = ["icon_loading"] } 
+gilrs = "0.6"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -92,17 +92,17 @@ impl event::EventHandler for MainState {
         println!("Text input: {}", ch);
     }
 
-    fn controller_button_down_event(&mut self, _ctx: &mut Context, btn: Button, instance_id: i32) {
+    fn controller_button_down_event(&mut self, _ctx: &mut Context, btn: Button, id: usize) {
         println!(
             "Controller button pressed: {:?} Controller_Id: {}",
-            btn, instance_id
+            btn, id
         );
     }
 
-    fn controller_button_up_event(&mut self, _ctx: &mut Context, btn: Button, instance_id: i32) {
+    fn controller_button_up_event(&mut self, _ctx: &mut Context, btn: Button, id: usize) {
         println!(
             "Controller button released: {:?} Controller_Id: {}",
-            btn, instance_id
+            btn, id
         );
     }
 
@@ -110,12 +110,12 @@ impl event::EventHandler for MainState {
         &mut self,
         _ctx: &mut Context,
         axis: Axis,
-        value: i16,
-        instance_id: i32,
+        value: f32,
+        id: usize,
     ) {
         println!(
             "Axis Event: {:?} Value: {} Controller_Id: {}",
-            axis, value, instance_id
+            axis, value, id
         );
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,15 +2,16 @@ use winit;
 
 use std::fmt;
 
-use GameResult;
 use audio;
 use conf;
 use event::winit_event;
 use filesystem::Filesystem;
+use gamepad;
 use graphics::{self, Point2};
 use keyboard;
 use mouse;
 use timer;
+use GameResult;
 
 /// A `Context` is an object that holds on to global resources.
 /// It basically tracks hardware state such as the screen, audio
@@ -39,6 +40,8 @@ pub struct Context {
     pub keyboard_context: keyboard::KeyboardContext,
     /// Mouse context
     pub mouse_context: mouse::MouseContext,
+    /// Gamepad context
+    pub gamepad_context: gamepad::GamepadContext,
     /// Default font
     pub default_font: graphics::Font,
 
@@ -73,12 +76,13 @@ impl Context {
         )?;
         let mouse_context = mouse::MouseContext::new();
         let keyboard_context = keyboard::KeyboardContext::new();
+        let gamepad_context = gamepad::GamepadContext::new()?;
 
         // TODO: Clean up the bytes here a bit.
         let font_id = graphics_context.glyph_brush.add_font_bytes(
             &include_bytes!(concat!(
                 env!("CARGO_MANIFEST_DIR"),
-            "/resources/DejaVuSerif.ttf"
+                "/resources/DejaVuSerif.ttf"
             ))[..]
         );
         let default_font = graphics::Font::GlyphFont(font_id);
@@ -91,6 +95,7 @@ impl Context {
             timer_context,
             audio_context,
             keyboard_context,
+            gamepad_context,
             mouse_context,
 
             default_font: default_font,

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,9 +43,8 @@ pub enum GameError {
     VideoError(String),
     /// Something went wrong compiling shaders
     ShaderProgramError(gfx::shade::ProgramError),
-    // TODO: Document this better
     /// Something went wrong with Gilrs
-    GilrsError(gilrs::Error),
+    GilrsError(String),
     /// Something else happened; this is generally a bug.
     UnknownError(String),
 }
@@ -81,7 +80,7 @@ impl Error for GameError {
             GameError::FontError(_) => "Font error",
             GameError::VideoError(_) => "Video error",
             GameError::ShaderProgramError(_) => "Shader program error",
-            GameError::GilrsError(_) => "Gilrs error",
+            GameError::GilrsError(_) => "Gamepad error",
             GameError::UnknownError(_) => "Unknown error",
         }
     }
@@ -249,6 +248,7 @@ impl From<glutin::ContextError> for GameError {
 impl From<gilrs::Error> for GameError {
     // TODO: Better error type?
     fn from(s: gilrs::Error) -> GameError {
-        GameError::GilrsError(s)
+        let errstr = format!("Gamepad error: {}", s);
+        GameError::GilrsError(errstr)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ use glutin;
 use winit;
 
 use app_dirs2::AppDirsError;
+use gilrs;
 use image;
 use rodio::decoder::DecoderError;
 use toml;
@@ -40,8 +41,11 @@ pub enum GameError {
     FontError(String),
     /// Something went wrong applying video settings.
     VideoError(String),
-    /// Something went compiling shaders
+    /// Something went wrong compiling shaders
     ShaderProgramError(gfx::shade::ProgramError),
+    // TODO: Document this better
+    /// Something went wrong with Gilrs
+    GilrsError(gilrs::Error),
     /// Something else happened; this is generally a bug.
     UnknownError(String),
 }
@@ -77,6 +81,7 @@ impl Error for GameError {
             GameError::FontError(_) => "Font error",
             GameError::VideoError(_) => "Video error",
             GameError::ShaderProgramError(_) => "Shader program error",
+            GameError::GilrsError(_) => "Gilrs error",
             GameError::UnknownError(_) => "Unknown error",
         }
     }
@@ -238,5 +243,12 @@ impl From<glutin::CreationError> for GameError {
 impl From<glutin::ContextError> for GameError {
     fn from(s: glutin::ContextError) -> GameError {
         GameError::RenderError(format!("OpenGL context error: {}", s))
+    }
+}
+
+impl From<gilrs::Error> for GameError {
+    // TODO: Better error type?
+    fn from(s: gilrs::Error) -> GameError {
+        GameError::GilrsError(s)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ pub enum GameError {
     /// Something went wrong compiling shaders
     ShaderProgramError(gfx::shade::ProgramError),
     /// Something went wrong with Gilrs
-    GilrsError(String),
+    GamepadError(String),
     /// Something else happened; this is generally a bug.
     UnknownError(String),
 }
@@ -80,7 +80,7 @@ impl Error for GameError {
             GameError::FontError(_) => "Font error",
             GameError::VideoError(_) => "Video error",
             GameError::ShaderProgramError(_) => "Shader program error",
-            GameError::GilrsError(_) => "Gamepad error",
+            GameError::GamepadError(_) => "Gamepad error",
             GameError::UnknownError(_) => "Unknown error",
         }
     }
@@ -249,6 +249,6 @@ impl From<gilrs::Error> for GameError {
     // TODO: Better error type?
     fn from(s: gilrs::Error) -> GameError {
         let errstr = format!("Gamepad error: {}", s);
-        GameError::GilrsError(errstr)
+        GameError::GamepadError(errstr)
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -13,8 +13,8 @@
 //!
 //! See the `eventloop` example for an implementation.
 
-use winit;
 use gilrs;
+use winit;
 
 /// A key code.
 pub use winit::VirtualKeyCode as KeyCode;
@@ -39,8 +39,8 @@ use self::winit_event::*;
 /// `winit` event loop.
 pub use winit::EventsLoop;
 
-use GameResult;
 use context::Context;
+use GameResult;
 
 /// A trait defining event callbacks; your primary interface with
 /// `ggez`'s event loop.  Have a type implement this trait and
@@ -110,27 +110,14 @@ pub trait EventHandler {
     /// This is the intended way of facilitating text input.
     fn text_input_event(&mut self, _ctx: &mut Context, _character: char) {}
 
-    /// A controller button was pressed; instance_id identifies which controller.
-    fn controller_button_down_event(
-        &mut self,
-        _ctx: &mut Context,
-        _btn: Button,
-        _id: usize,
-    ) {
-    }
+    /// A controller button was pressed; id identifies which controller.
+    fn controller_button_down_event(&mut self, _ctx: &mut Context, _btn: Button, _id: usize) {}
 
     /// A controller button was released.
     fn controller_button_up_event(&mut self, _ctx: &mut Context, _btn: Button, _id: usize) {}
 
     /// A controller axis moved.
-    fn controller_axis_event(
-        &mut self,
-        _ctx: &mut Context,
-        _axis: Axis,
-        _value: f32,
-        _id: usize,
-    ) {
-    }
+    fn controller_axis_event(&mut self, _ctx: &mut Context, _axis: Axis, _value: f32, _id: usize) {}
 
     /// Called when the window is shown or hidden.
     fn focus_event(&mut self, _ctx: &mut Context, _gained: bool) {}
@@ -234,7 +221,7 @@ where
                 Event::Suspended(_) => unimplemented!(),
             }
         });
-        while let Some(gilrs::Event{id, event,..}) = ctx.gamepad_context.gilrs.next_event() {
+        while let Some(gilrs::Event { id, event, .. }) = ctx.gamepad_context.gilrs.next_event() {
             match event {
                 gilrs::EventType::ButtonPressed(button, _) => {
                     state.controller_button_down_event(ctx, button, id);

--- a/src/event.rs
+++ b/src/event.rs
@@ -14,6 +14,7 @@
 //! See the `eventloop` example for an implementation.
 
 use winit;
+use gilrs;
 
 /// A key code.
 pub use winit::VirtualKeyCode as KeyCode;
@@ -24,10 +25,9 @@ pub use winit::ModifiersState as KeyMods;
 pub use winit::MouseButton;
 
 /// An analog axis of some device (controller, joystick...).
-// TODO: verify. (probably useless; investigate `gilrs`)
-pub use winit::AxisId as Axis;
+pub use gilrs::Axis;
 /// A button of some device (controller, joystick...).
-pub use winit::ButtonId as Button;
+pub use gilrs::Button;
 
 /// `winit` events; nested in a module for re-export neatness.
 pub mod winit_event {
@@ -115,20 +115,20 @@ pub trait EventHandler {
         &mut self,
         _ctx: &mut Context,
         _btn: Button,
-        _instance_id: i32,
+        _id: usize,
     ) {
     }
 
     /// A controller button was released.
-    fn controller_button_up_event(&mut self, _ctx: &mut Context, _btn: Button, _instance_id: i32) {}
+    fn controller_button_up_event(&mut self, _ctx: &mut Context, _btn: Button, _id: usize) {}
 
     /// A controller axis moved.
     fn controller_axis_event(
         &mut self,
         _ctx: &mut Context,
         _axis: Axis,
-        _value: i16,
-        _instance_id: i32,
+        _value: f32,
+        _id: usize,
     ) {
     }
 
@@ -234,18 +234,20 @@ where
                 Event::Suspended(_) => unimplemented!(),
             }
         });
-        /*{ // TODO: Investigate `gilrs` for gamepad support.
-                ControllerButtonDown { button, which, .. } => {
-                    state.controller_button_down_event(ctx, button, which)
+        while let Some(gilrs::Event{id, event,..}) = ctx.gamepad_context.gilrs.next_event() {
+            match event {
+                gilrs::EventType::ButtonPressed(button, _) => {
+                    state.controller_button_down_event(ctx, button, id);
                 }
-                ControllerButtonUp { button, which, .. } => {
-                    state.controller_button_up_event(ctx, button, which)
+                gilrs::EventType::ButtonReleased(button, _) => {
+                    state.controller_button_up_event(ctx, button, id);
                 }
-                ControllerAxisMotion {
-                    axis, value, which, ..
-                } => state.controller_axis_event(ctx, axis, value, which),
+                gilrs::EventType::AxisChanged(axis, value, _) => {
+                    state.controller_axis_event(ctx, axis, value, id);
+                }
                 _ => {}
-            }*/
+            }
+        }
         state.update(ctx)?;
         state.draw(ctx)?;
     }

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -1,0 +1,32 @@
+// TODO: Documentation
+//! Gamepad utility functions.
+
+use std::fmt;
+
+use gilrs::{Gamepad, Gilrs};
+
+use context::Context;
+use GameResult;
+
+/// A structure that contains gamepad state.
+pub struct GamepadContext {
+    pub(crate) gilrs: Gilrs,
+}
+
+impl fmt::Debug for GamepadContext {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "<GamepadContext: {:p}>", self)
+    }
+}
+
+impl GamepadContext {
+    pub(crate) fn new() -> GameResult<GamepadContext> {
+        let gilrs = Gilrs::new()?;
+        Ok(GamepadContext { gilrs })
+    }
+}
+
+/// returns the `Gamepad` associated with an id.
+pub fn get_gamepad(ctx: &Context, id: usize) -> Option<&Gamepad> {
+    ctx.gamepad_context.gilrs.get(id)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ extern crate rodio;
 extern crate serde_derive;
 #[macro_use]
 extern crate smart_default;
+extern crate gilrs;
 extern crate toml;
 extern crate winit;
 extern crate zip;
@@ -127,6 +128,7 @@ mod context;
 pub mod error;
 pub mod event;
 pub mod filesystem;
+pub mod gamepad;
 pub mod graphics;
 pub mod keyboard;
 pub mod mouse;


### PR DESCRIPTION
This adds a `GamepadContext` struct like before, but uses `gilrs` instead of SDL2. 

There's still a little more work to be done.