### PR TITLE
`keyboard` module improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ default = ["bzip2"]
 multithread-image-decoding = ["image/hdr", "image/jpeg_rayon"]
 
 [dependencies]
+bitflags = "1.0"
 zip = { version = "0.4", default-features = false }
 app_dirs2 = "2"
 gfx = "0.17"

--- a/src/context.rs
+++ b/src/context.rs
@@ -165,15 +165,13 @@ impl Context {
                     modifiers,
                     ..
                 }) => {
+                    let pressed = match *state {
+                        winit_event::ElementState::Pressed => true,
+                        winit_event::ElementState::Released => false,
+                    };
                     self.keyboard_context
                         .set_modifiers(keyboard::KeyMods::from(*modifiers));
-                    self.keyboard_context.set_key(
-                        *keycode,
-                        match *state {
-                            winit_event::ElementState::Pressed => true,
-                            winit_event::ElementState::Released => false,
-                        },
-                    );
+                    self.keyboard_context.set_key(*keycode, pressed);
                 }
                 _ => (),
             },

--- a/src/event.rs
+++ b/src/event.rs
@@ -18,8 +18,7 @@ use winit;
 /// A key code.
 pub use winit::VirtualKeyCode as KeyCode;
 
-/// A struct that holds the state of keyboard modifier buttons such as ctrl or shift.
-pub use winit::ModifiersState as KeyMods;
+pub use keyboard::KeyMods;
 /// A mouse button.
 pub use winit::MouseButton;
 
@@ -31,16 +30,18 @@ pub use winit::ButtonId as Button;
 
 /// `winit` events; nested in a module for re-export neatness.
 pub mod winit_event {
-    pub use super::winit::{DeviceEvent, ElementState, Event, KeyboardInput, MouseScrollDelta,
-                           TouchPhase, WindowEvent};
+    pub use super::winit::{
+        DeviceEvent, ElementState, Event, KeyboardInput, ModifiersState, MouseScrollDelta,
+        TouchPhase, WindowEvent,
+    };
 }
 
 use self::winit_event::*;
 /// `winit` event loop.
 pub use winit::EventsLoop;
 
-use GameResult;
 use context::Context;
+use GameResult;
 
 /// A trait defining event callbacks; your primary interface with
 /// `ggez`'s event loop.  Have a type implement this trait and
@@ -192,10 +193,10 @@ where
                     } => match element_state {
                         ElementState::Pressed => {
                             let repeat = keyboard::is_repeated(ctx, keycode);
-                            state.key_down_event(ctx, keycode, modifiers, repeat);
+                            state.key_down_event(ctx, keycode, modifiers.into(), repeat);
                         }
                         ElementState::Released => {
-                            state.key_up_event(ctx, keycode, modifiers);
+                            state.key_up_event(ctx, keycode, modifiers.into());
                         }
                     },
                     WindowEvent::MouseWheel { delta, .. } => {

--- a/src/event.rs
+++ b/src/event.rs
@@ -192,7 +192,7 @@ where
                         ..
                     } => match element_state {
                         ElementState::Pressed => {
-                            let repeat = keyboard::is_repeated(ctx, keycode);
+                            let repeat = keyboard::is_key_repeated(ctx);
                             state.key_down_event(ctx, keycode, modifiers.into(), repeat);
                         }
                         ElementState::Released => {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -85,22 +85,6 @@ bitflags! {
     }
 }
 
-impl KeyMods {
-    /// Amount of flags set (Kernighan/Wegner/Lehmer method).
-    pub fn count(&self) -> usize {
-        let mut num_set = 0;
-        let mut bits = self.bits();
-        loop {
-            if num_set >= bits {
-                break;
-            }
-            bits &= bits - 1;
-            num_set += 1;
-        }
-        num_set as usize
-    }
-}
-
 impl From<ModifiersState> for KeyMods {
     fn from(state: ModifiersState) -> Self {
         let mut keymod = KeyMods::empty();
@@ -299,20 +283,6 @@ mod tests {
                 logo: false,
             })
         );
-    }
-
-    #[test]
-    fn key_mod_set_bit_count() {
-        assert_eq!(KeyMods::empty().count(), 0);
-        assert_eq!(KeyMods::SHIFT.count(), 1);
-        assert_eq!(KeyMods::CTRL.count(), 1);
-        assert_eq!(KeyMods::ALT.count(), 1);
-        assert_eq!(KeyMods::LOGO.count(), 1);
-        assert_eq!((KeyMods::SHIFT | KeyMods::CTRL).count(), 2);
-        assert_eq!((KeyMods::SHIFT | KeyMods::LOGO).count(), 2);
-        assert_eq!((KeyMods::LOGO | KeyMods::SHIFT).count(), 2);
-        assert_eq!((KeyMods::LOGO | KeyMods::SHIFT | KeyMods::ALT).count(), 3);
-        assert_eq!((!KeyMods::ALT).count(), 3);
     }
 
     #[test]

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -215,7 +215,7 @@ pub fn is_key_repeated(ctx: &Context) -> bool {
     ctx.keyboard_context.is_key_repeated()
 }
 
-/// Returns a slice with currently held keys.
+/// Returns a slice with currently pressed down keys.
 pub fn get_pressed_keys(ctx: &Context) -> &[KeyCode] {
     ctx.keyboard_context.get_pressed_keys()
 }
@@ -319,12 +319,16 @@ mod tests {
     fn pressed_keys_tracking() {
         let mut keyboard = KeyboardContext::new();
         assert_eq!(keyboard.get_pressed_keys(), &[]);
+        assert!(!keyboard.is_key_pressed(KeyCode::A));
         keyboard.set_key(KeyCode::A, true);
         assert_eq!(keyboard.get_pressed_keys(), &[KeyCode::A]);
+        assert!(keyboard.is_key_pressed(KeyCode::A));
         keyboard.set_key(KeyCode::A, false);
         assert_eq!(keyboard.get_pressed_keys(), &[]);
+        assert!(!keyboard.is_key_pressed(KeyCode::A));
         keyboard.set_key(KeyCode::A, true);
         assert_eq!(keyboard.get_pressed_keys(), &[KeyCode::A]);
+        assert!(keyboard.is_key_pressed(KeyCode::A));
         keyboard.set_key(KeyCode::A, true);
         assert_eq!(keyboard.get_pressed_keys(), &[KeyCode::A]);
         keyboard.set_key(KeyCode::B, true);

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -2,6 +2,59 @@
 
 use context::Context;
 use event::KeyCode;
+use event::winit_event::ModifiersState;
+
+bitflags! {
+    /// Bitflags describing state of keyboard modifiers such as ctrl or shift.
+    #[derive(Default)]
+    pub struct KeyMods: u8 {
+        /// No modifiers; equivalent to `KeyMods::default()` and `KeyMods::empty()`.
+        const NONE  = 0b00000000;
+        /// Left or right Shift key.
+        const SHIFT = 0b00000001;
+        /// Left or right Control key.
+        const CTRL  = 0b00000010;
+        /// Left or right Alt key.
+        const ALT   = 0b00000100;
+        /// Left or right Win/Cmd/equivalent key.
+        const LOGO  = 0b00001000;
+    }
+}
+
+impl KeyMods {
+    /// Amount of flags set (Kernighan/Wegner/Lehmer method).
+    pub fn count(&self) -> u8 {
+        let mut num_set = 0;
+        let mut bits = self.bits();
+        loop {
+            if num_set >= bits {
+                break;
+            }
+            bits &= bits - 1;
+            num_set += 1;
+        }
+        num_set
+    }
+}
+
+impl From<ModifiersState> for KeyMods {
+    fn from(state: ModifiersState) -> Self {
+        let mut keymod = KeyMods::empty();
+        if state.shift {
+            keymod |= Self::SHIFT;
+        }
+        if state.ctrl {
+            keymod |= Self::CTRL;
+        }
+        if state.alt {
+            keymod |= Self::ALT;
+        }
+        if state.logo {
+            keymod |= Self::LOGO;
+        }
+        keymod
+    }
+}
 
 /// Tracks last key pressed, to distinguish if the system
 /// is sending repeat events when a key is held down.
@@ -39,4 +92,90 @@ pub fn is_repeated(ctx: &mut Context, key: KeyCode) -> bool {
     let result = ctx.keyboard_context.last_pressed == key;
     ctx.keyboard_context.last_pressed = key;
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_mod_conversions() {
+        assert_eq!(
+            KeyMods::empty(),
+            KeyMods::from(ModifiersState {
+                shift: false,
+                ctrl: false,
+                alt: false,
+                logo: false,
+            })
+        );
+        assert_eq!(
+            KeyMods::SHIFT,
+            KeyMods::from(ModifiersState {
+                shift: true,
+                ctrl: false,
+                alt: false,
+                logo: false,
+            })
+        );
+        assert_eq!(
+            KeyMods::SHIFT | KeyMods::ALT,
+            KeyMods::from(ModifiersState {
+                shift: true,
+                ctrl: false,
+                alt: true,
+                logo: false,
+            })
+        );
+        assert_eq!(
+            KeyMods::SHIFT | KeyMods::ALT | KeyMods::CTRL,
+            KeyMods::from(ModifiersState {
+                shift: true,
+                ctrl: true,
+                alt: true,
+                logo: false,
+            })
+        );
+        assert_eq!(
+            KeyMods::SHIFT - KeyMods::ALT,
+            KeyMods::from(ModifiersState {
+                shift: true,
+                ctrl: false,
+                alt: false,
+                logo: false,
+            })
+        );
+        assert_eq!(
+            (KeyMods::SHIFT | KeyMods::ALT) - KeyMods::ALT,
+            KeyMods::from(ModifiersState {
+                shift: true,
+                ctrl: false,
+                alt: false,
+                logo: false,
+            })
+        );
+        assert_eq!(
+            KeyMods::SHIFT - (KeyMods::ALT | KeyMods::SHIFT),
+            KeyMods::from(ModifiersState {
+                shift: false,
+                ctrl: false,
+                alt: false,
+                logo: false,
+            })
+        );
+    }
+
+    #[test]
+    fn key_mod_set_bit_count() {
+        assert_eq!(KeyMods::empty().count(), 0);
+        assert_eq!(KeyMods::SHIFT.count(), 1);
+        assert_eq!(KeyMods::CTRL.count(), 1);
+        assert_eq!(KeyMods::ALT.count(), 1);
+        assert_eq!(KeyMods::LOGO.count(), 1);
+        assert_eq!((KeyMods::SHIFT | KeyMods::CTRL).count(), 2);
+        assert_eq!((KeyMods::SHIFT | KeyMods::LOGO).count(), 2);
+        assert_eq!((KeyMods::LOGO | KeyMods::SHIFT).count(), 2);
+        assert_eq!((KeyMods::LOGO | KeyMods::SHIFT | KeyMods::ALT).count(), 3);
+        assert_eq!((!KeyMods::ALT).count(), 3);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,8 @@
 // TODO: Enable this.
 // #![deny(unused_results)]
 
+#[macro_use]
+extern crate bitflags;
 extern crate app_dirs2;
 #[macro_use]
 extern crate gfx;


### PR DESCRIPTION
Resolves #404.

`keyboard` module now exposes functions:

- `get_active_mods()` - returns currently active keyboard modifiers.
- `get_pressed_keys()` - returns a slice with currently pressed down keys.
- `is_key_pressed()` - checks if a key is currently pressed down.
- `is_key_repeated()` - checks if the last keystroke sent by the system is repeated, like when a key is held down for a period of time.
- `is_mod_active()` - checks if keyboard modifier (or several) is active.

`KeyMods` is now a local bitflags struct, can be converted from `winit::ModifiersState` - this allows neat matching and keybinds (not included); and, this is how we had it with `sdl2`.

It has an extra method, `KeyMods::count()` - returns amount of flags set; this is useful for mapping modifier+modifier+key in a non-exclusive way ([example](https://github.com/Ratysz/spelspell/blob/master/src/input.rs)).