### PR TITLE
Fix typos in input_test.rs

### DIFF
--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -140,8 +140,8 @@ pub fn main() {
     let c = conf::Conf::new();
     let ctx = &mut Context::load_from_conf("input_test", "ggez", c).unwrap();
 
-    // We add the CARGO_MANIFEST_DIR/resources do the filesystems paths so
-    // we we look in the cargo project for files.
+    // We add the CARGO_MANIFEST_DIR/resources to the filesystem paths so
+    // that ggez will look in our cargo project directory for files.
     if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");


### PR DESCRIPTION
I used the same wording as in `hello_world.rs` file.