### PR TITLE
Fundamental work needed to make graphics context generic

### DIFF
--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -128,7 +128,10 @@ impl event::EventHandler for MainState {
 }
 
 pub fn main() -> GameResult {
-    let c = conf::Conf::new();
+    let mut c = conf::Conf::new();
+    c.backend = conf::Backend::OpenGL {
+        major: 3, minor: 2, srgb: false
+    };
     let (ctx, events_loop) = &mut Context::load_from_conf("drawing", "ggez", c)?;
 
     // We add the CARGO_MANIFEST_DIR/resources do the filesystems paths so

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -222,6 +222,9 @@ pub enum Backend {
         /// OpenGL minor version
         #[default = r#"2"#]
         minor: u8,
+        /// Whether or not to enable sRGB (gamma corrected color)
+        #[default = r#"true"#]
+        srgb: bool,
     },
 }
 
@@ -264,7 +267,7 @@ impl NumSamples {
 /// Conf {
 ///     window_mode: WindowMode::default(),
 ///     window_setup: WindowSetup::default(),
-///     backend: Backend::OpenGL(3, 2),
+///     backend: Backend::OpenGL{ major: 3, minor: 2, srgb: true},
 /// }
 /// ```
 #[derive(Serialize, Deserialize, Debug, PartialEq, SmartDefault)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -13,6 +13,8 @@ use mouse;
 use timer;
 use GameResult;
 
+
+use gfx;
 /// A `Context` is an object that holds on to global resources.
 /// It basically tracks hardware state such as the screen, audio
 /// system, timers, and so on.  Generally this type is **not** thread-
@@ -23,13 +25,13 @@ use GameResult;
 /// drawing things, playing sounds, or loading resources (which then
 /// need to be transformed into a format the hardware likes) will need
 /// to access the `Context`.
-pub struct Context{
+pub struct Context {
     /// The Conf object the Context was created with
     pub conf: conf::Conf,
     /// Filesystem state
     pub filesystem: Filesystem,
     /// Graphics state
-    pub(crate) gfx_context: graphics::GraphicsContext,
+    pub(crate) gfx_context: graphics::GraphicsContext<gfx::format::Srgba8>,
     /// Controls whether or not the events loop should be running.
     pub continuing: bool,
     /// Timer state

--- a/src/context.rs
+++ b/src/context.rs
@@ -31,7 +31,7 @@ pub struct Context {
     /// Filesystem state
     pub filesystem: Filesystem,
     /// Graphics state
-    pub(crate) gfx_context: graphics::GraphicsContext<gfx::format::Srgba8>,
+    pub(crate) gfx_context: graphics::GraphicsContext,
     /// Controls whether or not the events loop should be running.
     pub continuing: bool,
     /// Timer state

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -37,7 +37,7 @@ where
 /// in order to do things like saving to an image file or creating cool effects
 /// by using shaders that render to an image.
 /// If you just want to draw multiple things efficiently, look at `SpriteBatch`.
-pub type Canvas = CanvasGeneric<GlBackendSpec>;
+pub type Canvas = CanvasGeneric<GlBackendSpecSrgb>;
 
 impl Canvas {
     /// Create a new canvas with the given size and number of samples.

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -37,7 +37,7 @@ where
 /// in order to do things like saving to an image file or creating cool effects
 /// by using shaders that render to an image.
 /// If you just want to draw multiple things efficiently, look at `SpriteBatch`.
-pub type Canvas = CanvasGeneric<GlBackendSpecSrgb>;
+pub type Canvas = CanvasGeneric<GlBackendSpec>;
 
 impl Canvas {
     /// Create a new canvas with the given size and number of samples.

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -61,15 +61,6 @@ where
     available_monitors: Vec<glutin::MonitorId>,
 }
 
-impl<B, C> GraphicsContextGeneric<B, C>
-where
-    B: BackendSpec<SurfaceType = C>,
-    C: gfx::format::Formatted,
-{
-    pub(crate) fn get_format() -> gfx::format::Format {
-        C::get_format()
-    }
-}
 
 impl<B, C> fmt::Debug for GraphicsContextGeneric<B, C>
 where
@@ -82,8 +73,8 @@ where
 }
 
 /// A concrete graphics context for GL rendering.
-pub(crate) type GraphicsContext =
-    GraphicsContextGeneric<GlBackendSpecSrgb, <GlBackendSpecSrgb as BackendSpec>::SurfaceType>;
+pub(crate) type GraphicsContext<C> =
+    GraphicsContextGeneric<GlBackendSpec<C>, <GlBackendSpec<C> as BackendSpec>::SurfaceType>;
 
 
 trait GraphicsBackend {}
@@ -92,6 +83,13 @@ impl<B, C> GraphicsContextGeneric<B, C>
 where
     B: BackendSpec<SurfaceType = C> + 'static,
     C: gfx::format::Formatted<View=[<gfx::format::Float as gfx::format::ChannelTyped>::ShaderType; 4]> {
+
+
+    pub(crate) fn get_format() -> gfx::format::Format {
+        C::get_format()
+    }
+
+
     /// Create a new GraphicsContext
     pub(crate) fn new(
         events_loop: &glutin::EventsLoop,

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -3,9 +3,7 @@ use std::rc::Rc;
 
 use gfx::traits::FactoryExt;
 use gfx::Factory;
-use gfx_device_gl;
 use gfx_glyph::{GlyphBrush, GlyphBrushBuilder};
-use gfx_window_glutin;
 use glutin;
 
 use conf::{FullscreenType, MonitorId, WindowMode, WindowSetup};
@@ -30,6 +28,8 @@ where
     pub(crate) white_image: ImageGeneric<B>,
     pub(crate) screen_rect: Rect,
     pub(crate) color_format: gfx::format::Format,
+    // TODO: is this needed?
+    #[allow(unused)]
     pub(crate) depth_format: gfx::format::Format,
 
     // TODO: is this needed?
@@ -83,12 +83,8 @@ where
 
 /// A concrete graphics context for GL rendering.
 pub(crate) type GraphicsContext =
-    GraphicsContextGeneric<GlBackendSpec, <GlBackendSpec as BackendSpec>::SurfaceType>;
+    GraphicsContextGeneric<GlBackendSpecSrgb, <GlBackendSpecSrgb as BackendSpec>::SurfaceType>;
 
-/*
-pub(crate) type GraphicsContextRgb =
-    GraphicsContextGeneric<GlBackendSpecRgb, <GlBackendSpecRgb as BackendSpec>::SurfaceType>;
-*/
 
 trait GraphicsBackend {}
 

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -79,8 +79,6 @@ pub(crate) type GraphicsContext =
 impl<B> GraphicsContextGeneric<B>
 where
     B: BackendSpec + 'static {
-
-
     /// TODO: This is redundant with Backend::color_format() or whatever.
     pub(crate) fn get_format(&self) -> gfx::format::Format {
         B::color_format()

--- a/src/graphics/drawparam.rs
+++ b/src/graphics/drawparam.rs
@@ -260,4 +260,23 @@ impl PrimitiveDrawParam {
             ..self
         }
     }
+
+
+    pub(crate) fn to_instance_properties(&self, srgb: bool) -> InstanceProperties {
+        let mat: [[f32; 4]; 4] = self.matrix.into();
+        let color: [f32;4] = if srgb {
+            let linear_color: types::LinearColor = self.color.into();
+            linear_color.into()
+        } else {
+            self.color.into()
+        };
+        InstanceProperties {
+            src: self.src.into(),
+            col1: mat[0],
+            col2: mat[1],
+            col3: mat[2],
+            col4: mat[3],
+            color: color,
+        }
+    }
 }

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -68,12 +68,7 @@ impl<B> ImageGeneric<B>  where B: BackendSpec{
         }
         let kind = gfx::texture::Kind::D2(width, height, gfx::texture::AaMode::Single);
         use gfx::memory::Bind;
-        type SurfaceType =
-            <super::BuggoSurfaceFormat as gfx::format::Formatted>::Surface;
-        type ChannelType =
-            <super::BuggoSurfaceFormat as gfx::format::Formatted>::Channel;
-        let channel_type = ChannelType::get_channel_type();
-        let surface_format = SurfaceType::get_surface_type();
+        let gfx::format::Format(surface_format, channel_type) = B::color_format();
         let texinfo = gfx::texture::Info {
             kind: kind,
             levels: 1,

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -36,7 +36,7 @@ where
 /// Under the hood this is just an `Arc`'ed texture handle and
 /// some metadata, so cloning it is fairly cheap; it doesn't
 /// make another copy of the underlying image data.
-pub type Image = ImageGeneric<GlBackendSpec>;
+pub type Image = ImageGeneric<GlBackendSpecSrgb>;
 
 /// The supported formats for saving an image.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -50,7 +50,7 @@ where
     B: BackendSpec, {
 
     /* TODO: Needs generic Context to work.
-    
+
     /// Load a new image from the file at the given path.
     pub fn new<P: AsRef<path::Path>>(context: &mut Context, path: P) -> GameResult<Self> {
         let img = {
@@ -191,9 +191,9 @@ where
         let kind = gfx::texture::Kind::D2(width, height, gfx::texture::AaMode::Single);
         use gfx::memory::Bind;
         type SurfaceType =
-            <<GlBackendSpec as BackendSpec>::SurfaceType as gfx::format::Formatted>::Surface;
+            <<GlBackendSpecSrgb as BackendSpec>::SurfaceType as gfx::format::Formatted>::Surface;
         type ChannelType =
-            <<GlBackendSpec as BackendSpec>::SurfaceType as gfx::format::Formatted>::Channel;
+            <<GlBackendSpecSrgb as BackendSpec>::SurfaceType as gfx::format::Formatted>::Channel;
         let channel_type = ChannelType::get_channel_type();
         let surface_format = SurfaceType::get_surface_type();
         let texinfo = gfx::texture::Info {
@@ -325,7 +325,7 @@ impl Drawable for Image {
         let sampler = gfx.samplers
             .get_or_insert(self.sampler_info, gfx.factory.as_mut());
         gfx.data.vbuf = gfx.quad_vertex_buffer.clone();
-        let typed_thingy = super::GlBackendSpec::raw_to_typed_shader_resource(self.texture.clone());
+        let typed_thingy = super::GlBackendSpecSrgb::raw_to_typed_shader_resource(self.texture.clone());
         gfx.data.tex = (typed_thingy, sampler);
         let previous_mode: Option<BlendMode> = if let Some(mode) = self.blend_mode {
             let current_mode = gfx.get_blend_mode();

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -309,7 +309,7 @@ impl Drawable for Image {
     fn draw_primitive(&self, ctx: &mut Context, param: PrimitiveDrawParam) -> GameResult {
         self.debug_id.assert(ctx);
 
-        println!("Matrix: {:#?}", param.matrix);
+        // println!("Matrix: {:#?}", param.matrix);
         let gfx = &mut ctx.gfx_context;
         let src_width = param.src.w;
         let src_height = param.src.h;

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -44,6 +44,7 @@ impl<B> ImageGeneric<B>  where B: BackendSpec{
         width: u16,
         height: u16,
         rgba: &[u8],
+        color_format: gfx::format::Format,
         debug_id: DebugId,
     ) -> GameResult<Self> {
         if width == 0 || height == 0 {
@@ -68,7 +69,7 @@ impl<B> ImageGeneric<B>  where B: BackendSpec{
         }
         let kind = gfx::texture::Kind::D2(width, height, gfx::texture::AaMode::Single);
         use gfx::memory::Bind;
-        let gfx::format::Format(surface_format, channel_type) = B::color_format();
+        let gfx::format::Format(surface_format, channel_type) = color_format;
         let texinfo = gfx::texture::Info {
             kind: kind,
             levels: 1,
@@ -155,6 +156,7 @@ impl Image {
             width,
             height,
             rgba,
+            context.gfx_context.backend_spec.color_format(),
             debug_id,
         )
     }

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -30,13 +30,97 @@ where
     pub(crate) debug_id: DebugId,
 }
 
+impl<B> ImageGeneric<B>  where B: BackendSpec{
+
+    /// A helper function that just takes a factory directly so we can make an image
+    /// without needing the full context object, so we can create an Image while still
+    /// creating the GraphicsContext.
+    /// 
+    /// BUGGO TODO: It really doesn't seem to be able to put two and two together regarding
+    /// the gfx_device_gl::Factory equalling its factory...
+    pub(crate) fn make_raw(
+        factory: &mut <B as BackendSpec>::Factory,
+        sampler_info: &texture::SamplerInfo,
+        width: u16,
+        height: u16,
+        rgba: &[u8],
+        debug_id: DebugId,
+    ) -> GameResult<Self> {
+        if width == 0 || height == 0 {
+            let msg = format!(
+                "Tried to create a texture of size {}x{}, each dimension must
+                be >0",
+                width, height
+            );
+            return Err(GameError::ResourceLoadError(msg));
+        }
+        // TODO: Check for overflow on 32-bit systems here
+        let expected_bytes = width as usize * height as usize * 4;
+        if expected_bytes != rgba.len() {
+            let msg = format!(
+                "Tried to create a texture of size {}x{}, but gave {} bytes of data (expected {})",
+                width,
+                height,
+                rgba.len(),
+                expected_bytes
+            );
+            return Err(GameError::ResourceLoadError(msg));
+        }
+        let kind = gfx::texture::Kind::D2(width, height, gfx::texture::AaMode::Single);
+        use gfx::memory::Bind;
+        type SurfaceType =
+            <super::BuggoSurfaceFormat as gfx::format::Formatted>::Surface;
+        type ChannelType =
+            <super::BuggoSurfaceFormat as gfx::format::Formatted>::Channel;
+        let channel_type = ChannelType::get_channel_type();
+        let surface_format = SurfaceType::get_surface_type();
+        let texinfo = gfx::texture::Info {
+            kind: kind,
+            levels: 1,
+            format: surface_format,
+            bind: Bind::SHADER_RESOURCE | Bind::RENDER_TARGET | Bind::TRANSFER_SRC,
+            usage: gfx::memory::Usage::Data,
+        };
+        let raw_tex = factory.create_texture_raw(
+            texinfo,
+            Some(channel_type),
+            Some((&[rgba], gfx::texture::Mipmap::Provided)),
+        )?;
+        let resource_desc = gfx::texture::ResourceDesc {
+            channel: channel_type,
+            layer: None,
+            min: 0,
+            max: raw_tex.get_info().levels - 1,
+            swizzle: gfx::format::Swizzle::new(),
+        };
+        let raw_view = factory.view_texture_as_shader_resource_raw(&raw_tex, resource_desc)?;
+        // gfx::memory::Typed is UNDOCUMENTED, aiee!
+        // However there doesn't seem to be an official way to turn a raw tex/view into a typed
+        // one; this API oversight would probably get fixed, except gfx is moving to a new
+        // API model.  So, that also fortunately means that undocumented features like this
+        // probably won't go away on pre-ll gfx...
+        // let tex = gfx::memory::Typed::new(raw_tex);
+        // let view = gfx::memory::Typed::new(raw_view);
+        Ok(Self {
+            texture: raw_view,
+            texture_handle: raw_tex,
+            sampler_info: *sampler_info,
+            blend_mode: None,
+            width: u32::from(width),
+            height: u32::from(height),
+            debug_id,
+        })
+    }
+
+}
+
 /// In-GPU-memory image data available to be drawn on the screen,
 /// using the OpenGL backend.
 ///
 /// Under the hood this is just an `Arc`'ed texture handle and
 /// some metadata, so cloning it is fairly cheap; it doesn't
 /// make another copy of the underlying image data.
-pub type Image = ImageGeneric<GlBackendSpecSrgb>;
+pub type Image = ImageGeneric<GlBackendSpec>;
 
 /// The supported formats for saving an image.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -45,11 +129,10 @@ pub enum ImageFormat {
     Png,
 }
 
-impl<B> ImageGeneric<B> 
-where
-    B: BackendSpec, {
+impl Image {
 
     /* TODO: Needs generic Context to work.
+    */
 
     /// Load a new image from the file at the given path.
     pub fn new<P: AsRef<path::Path>>(context: &mut Context, path: P) -> GameResult<Self> {
@@ -72,7 +155,7 @@ where
     ) -> GameResult<Self> {
         let debug_id = DebugId::get(context);
         Self::make_raw(
-            &mut context.gfx_context.factory,
+            &mut *context.gfx_context.factory,
             &context.gfx_context.default_sampler_info,
             width,
             height,
@@ -90,17 +173,17 @@ where
         let gfx = &mut ctx.gfx_context;
         let w = self.width;
         let h = self.height;
-        type SurfaceData = <<B::SurfaceType as Formatted>::Surface as SurfaceTyped>::DataType;
 
         // Note: In the GFX example, the download buffer is created ahead of time
         // and updated on screen resize events. This may be preferable, but then
         // the buffer also needs to be updated when we switch to/from a canvas.
         let dl_buffer = gfx.factory
         // Unsure of the performance impact of creating this as it is needed.
-            .create_download_buffer::<SurfaceData>(w as usize * h as usize)?;
+            .create_download_buffer::<[u8; 4]>(w as usize * h as usize)?;
 
-        let mut local_encoder: B::get_encoder();
+        let mut local_encoder = gfx.new_encoder();
 
+        // let gfx::format::Format(color_format, _) = gfx.get_format();
         local_encoder.copy_texture_to_buffer_raw(
             &self.texture_handle,
             None,
@@ -111,7 +194,7 @@ where
                 width: w as u16,
                 height: h as u16,
                 depth: 0,
-                format: SurfaceData::get_format(),
+                format: gfx.get_format(),
                 mipmap: 0,
             },
             dl_buffer.raw(),
@@ -154,84 +237,6 @@ where
                 .encode(&data, self.width, self.height, color_format)
                 .map_err(|e| e.into()),
         }
-    }
-    */
-
-    /// A helper function that just takes a factory directly so we can make an image
-    /// without needing the full context object, so we can create an Image while still
-    /// creating the GraphicsContext.
-    pub(crate) fn make_raw(
-        factory: &mut B::Factory,
-        sampler_info: &texture::SamplerInfo,
-        width: u16,
-        height: u16,
-        rgba: &[u8],
-        debug_id: DebugId,
-    ) -> GameResult<Self> {
-        if width == 0 || height == 0 {
-            let msg = format!(
-                "Tried to create a texture of size {}x{}, each dimension must
-                be >0",
-                width, height
-            );
-            return Err(GameError::ResourceLoadError(msg));
-        }
-        // TODO: Check for overflow on 32-bit systems here
-        let expected_bytes = width as usize * height as usize * 4;
-        if expected_bytes != rgba.len() {
-            let msg = format!(
-                "Tried to create a texture of size {}x{}, but gave {} bytes of data (expected {})",
-                width,
-                height,
-                rgba.len(),
-                expected_bytes
-            );
-            return Err(GameError::ResourceLoadError(msg));
-        }
-        let kind = gfx::texture::Kind::D2(width, height, gfx::texture::AaMode::Single);
-        use gfx::memory::Bind;
-        type SurfaceType =
-            <<GlBackendSpecSrgb as BackendSpec>::SurfaceType as gfx::format::Formatted>::Surface;
-        type ChannelType =
-            <<GlBackendSpecSrgb as BackendSpec>::SurfaceType as gfx::format::Formatted>::Channel;
-        let channel_type = ChannelType::get_channel_type();
-        let surface_format = SurfaceType::get_surface_type();
-        let texinfo = gfx::texture::Info {
-            kind: kind,
-            levels: 1,
-            format: surface_format,
-            bind: Bind::SHADER_RESOURCE | Bind::RENDER_TARGET | Bind::TRANSFER_SRC,
-            usage: gfx::memory::Usage::Data,
-        };
-        let raw_tex = factory.create_texture_raw(
-            texinfo,
-            Some(channel_type),
-            Some((&[rgba], gfx::texture::Mipmap::Provided)),
-        )?;
-        let resource_desc = gfx::texture::ResourceDesc {
-            channel: channel_type,
-            layer: None,
-            min: 0,
-            max: raw_tex.get_info().levels - 1,
-            swizzle: gfx::format::Swizzle::new(),
-        };
-        let raw_view = factory.view_texture_as_shader_resource_raw(&raw_tex, resource_desc)?;
-        // gfx::memory::Typed is UNDOCUMENTED, aiee!
-        // However there doesn't seem to be an official way to turn a raw tex/view into a typed
-        // one; this API oversight would probably get fixed, except gfx is moving to a new
-        // API model.  So, that also fortunately means that undocumented features like this
-        // probably won't go away on pre-ll gfx...
-        // let tex = gfx::memory::Typed::new(raw_tex);
-        // let view = gfx::memory::Typed::new(raw_view);
-        Ok(Self {
-            texture: raw_view,
-            texture_handle: raw_tex,
-            sampler_info: *sampler_info,
-            blend_mode: None,
-            width: u32::from(width),
-            height: u32::from(height),
-            debug_id,
-        })
     }
 
     /* TODO: Needs generic context
@@ -325,7 +330,7 @@ impl Drawable for Image {
         let sampler = gfx.samplers
             .get_or_insert(self.sampler_info, gfx.factory.as_mut());
         gfx.data.vbuf = gfx.quad_vertex_buffer.clone();
-        let typed_thingy = super::GlBackendSpecSrgb::raw_to_typed_shader_resource(self.texture.clone());
+        let typed_thingy = gfx.backend_spec.raw_to_typed_shader_resource(self.texture.clone());
         gfx.data.tex = (typed_thingy, sampler);
         let previous_mode: Option<BlendMode> = if let Some(mode) = self.blend_mode {
             let current_mode = gfx.get_blend_mode();

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -444,7 +444,7 @@ impl Drawable for Mesh {
         gfx.data.vbuf = self.buffer.clone();
         let texture = gfx.white_image.texture.clone();
 
-        let typed_thingy = super::GlBackendSpec::raw_to_typed_shader_resource(texture);
+        let typed_thingy = super::GlBackendSpecSrgb::raw_to_typed_shader_resource(texture);
         gfx.data.tex.0 = typed_thingy;
 
         gfx.draw(Some(&self.slice))?;

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -444,7 +444,7 @@ impl Drawable for Mesh {
         gfx.data.vbuf = self.buffer.clone();
         let texture = gfx.white_image.texture.clone();
 
-        let typed_thingy = super::GlBackendSpecSrgb::raw_to_typed_shader_resource(texture);
+        let typed_thingy = gfx.backend_spec.raw_to_typed_shader_resource(texture);
         gfx.data.tex.0 = typed_thingy;
 
         gfx.draw(Some(&self.slice))?;

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -234,31 +234,8 @@ impl<C> BackendSpec for GlBackendSpec<C> where C: gfx::format::Formatted + Debug
 }
 
 type GlBackendSpecSrgb = GlBackendSpec<gfx::format::Srgba8>;
+type GlBackendSpecRgb = GlBackendSpec<gfx::format::Rgba8>;
 
-/*
-/// Same as `GlBackendSpec` but specifies a RGB framebuffer
-/// instead of sRGB.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, SmartDefault, Hash)]
-pub struct GlBackendSpecRgb {
-    #[default = r#"3"#]
-    major: u8,
-    #[default = r#"2"#]
-    minor: u8,
-}
-
-
-impl BackendSpec for GlBackendSpecRgb {
-    type SurfaceType = gfx::format::Rgba8;
-    type Resources = gfx_device_gl::Resources;
-    type Factory = gfx_device_gl::Factory;
-    type CommandBuffer = gfx_device_gl::CommandBuffer;
-    type Device = gfx_device_gl::Device;
-
-    fn version_tuple(&self) -> (u8, u8) {
-        (self.major, self.minor)
-    }
-}
-*/
 
 const QUAD_VERTS: [Vertex; 4] = [
     Vertex {
@@ -315,8 +292,14 @@ gfx_defines!{
         tex: gfx::TextureSampler<[f32; 4]> = "t_Texture",
         globals: gfx::ConstantBuffer<Globals> = "Globals",
         rect_instance_properties: gfx::InstanceBuffer<InstanceProperties> = (),
+        // The default values here are overwritten by the
+        // pipeline init values in `shader::create_shader()`.
         out: gfx::RawRenderTarget =
-          ("Target0", GraphicsContext::get_format(), gfx::state::ColorMask::all(), Some(gfx::preset::blend::ALPHA)),
+          ("Target0", 
+           gfx::format::Format(gfx::format::SurfaceType::R8_G8_B8_A8, gfx::format::ChannelType::Srgb), 
+           gfx::state::ColorMask::all(), Some(gfx::preset::blend::ALPHA)
+          ),
+        // out: gfx::RawRenderTarget = "Target0",
     }
 }
 

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -48,6 +48,7 @@ pub use self::text::*;
 pub use self::types::*;
 
 type BuggoSurfaceFormat = gfx::format::Srgba8;
+type ShaderResourceType = [f32;4];
 
 /// A marker trait saying that something is a label for a particular backend,
 /// with associated gfx-rs types for that backend.
@@ -70,11 +71,11 @@ pub trait BackendSpec: fmt::Debug {
         texture_view: gfx::handle::RawShaderResourceView<Self::Resources>,
     ) -> gfx::handle::ShaderResourceView<
         <Self as BackendSpec>::Resources,
-        <BuggoSurfaceFormat as gfx::format::Formatted>::View,
+        ShaderResourceType,
     > {
         let typed_view: gfx::handle::ShaderResourceView<
             _,
-            <BuggoSurfaceFormat as gfx::format::Formatted>::View,
+            ShaderResourceType,
         > = gfx::memory::Typed::new(texture_view);
         typed_view
     }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -654,8 +654,9 @@ pub fn get_default_filter(ctx: &Context) -> FilterMode {
 /// information out of it!
 pub fn get_renderer_info(ctx: &Context) -> GameResult<String> {
     Ok(format!(
-        "Requested GL {}.{} Core profile, actually got GL ?.? ? profile.",
+        "Requested GL {}.{} Core profile with sRGB {}, actually got GL ?.? ? profile with sRGB {:?}.",
         ctx.gfx_context.backend_spec.major, ctx.gfx_context.backend_spec.minor,
+        ctx.gfx_context.backend_spec.srgb, ctx.gfx_context.backend_spec.color_format()
     ))
 }
 

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -396,7 +396,7 @@ pub fn clear(ctx: &mut Context, color: Color) {
 
 /// Draws the given `Drawable` object to the screen by calling its
 /// `draw()` method.
-pub fn draw<D, T>(ctx: &mut Context, drawable: D, params: T) -> GameResult
+pub fn draw<D, T>(ctx: &mut Context, drawable: &D, params: T) -> GameResult
 where
     D: Drawable,
     T: Into<DrawParam>,

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -2,6 +2,7 @@
 //! with ggez for cool and spooky effects. See the `shader` and `shadows`
 //! examples for a taste.
 
+use gfx::format;
 use gfx::handle::*;
 use gfx::preset::blend;
 use gfx::pso::buffer::*;
@@ -206,7 +207,7 @@ where
             graphics::pipe::Init {
                 out: (
                     "Target0",
-                    graphics::GraphicsContext::get_format(),
+                    Spec::color_format(),
                     ColorMask::all(),
                     Some((*mode).into()),
                 ),

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -174,7 +174,7 @@ pub struct ShaderGeneric<Spec: graphics::BackendSpec, C: Structure<ConstFormat>>
 
 /// A `Shader` represents a handle to a user-defined shader that can be used
 /// with a ggez graphics context
-pub type Shader<C> = ShaderGeneric<graphics::GlBackendSpec, C>;
+pub type Shader<C> = ShaderGeneric<graphics::GlBackendSpecSrgb, C>;
 
 pub(crate) fn create_shader<C, S, Spec>(
     vertex_source: &[u8],

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -175,7 +175,7 @@ pub struct ShaderGeneric<Spec: graphics::BackendSpec, C: Structure<ConstFormat>>
 
 /// A `Shader` represents a handle to a user-defined shader that can be used
 /// with a ggez graphics context
-pub type Shader<C> = ShaderGeneric<graphics::GlBackendSpecSrgb, C>;
+pub type Shader<C> = ShaderGeneric<graphics::GlBackendSpec, C>;
 
 pub(crate) fn create_shader<C, S, Spec>(
     vertex_source: &[u8],

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -186,6 +186,7 @@ pub(crate) fn create_shader<C, S, Spec>(
     factory: &mut Spec::Factory,
     multisample_samples: u8,
     blend_modes: Option<&[BlendMode]>,
+    color_format: format::Format,
     debug_id: DebugId,
 ) -> GameResult<(ShaderGeneric<Spec, C>, Box<dyn ShaderHandle<Spec>>)>
 where
@@ -207,7 +208,7 @@ where
             graphics::pipe::Init {
                 out: (
                     "Target0",
-                    Spec::color_format(),
+                    color_format,
                     ColorMask::all(),
                     Some((*mode).into()),
                 ),
@@ -308,6 +309,7 @@ where
         blend_modes: Option<&[BlendMode]>,
     ) -> GameResult<Shader<C>> {
         let debug_id = DebugId::get(ctx);
+        use graphics::BackendSpec;
         let (mut shader, draw) = create_shader(
             vertex_source,
             pixel_source,
@@ -317,6 +319,7 @@ where
             &mut *ctx.gfx_context.factory,
             ctx.gfx_context.multisample_samples,
             blend_modes,
+            ctx.gfx_context.backend_spec.color_format(),
             debug_id,
         )?;
         shader.id = ctx.gfx_context.shaders.len();
@@ -325,21 +328,24 @@ where
         Ok(shader)
     }
 
-    /* TODO: Needs generic graphics context to work.
+    /// Gets the shader ID for the `Shader` which is used by the
+    /// `GraphicsContext` for identifying shaders in its cache
+    pub fn shader_id(&self) -> ShaderId {
+        self.id
+    }
+}
 
+
+impl<C> Shader<C>
+where
+    C: 'static + Pod + Structure<ConstFormat> + Clone + Copy,
+{
     /// Send data to the GPU for use with the `Shader`
     pub fn send(&self, ctx: &mut Context, consts: C) -> GameResult {
         ctx.gfx_context
             .encoder
             .update_buffer(&self.buffer, &[consts], 0)?;
         Ok(())
-    }
-    */
-
-    /// Gets the shader ID for the `Shader` which is used by the
-    /// `GraphicsContext` for identifying shaders in its cache
-    pub fn shader_id(&self) -> ShaderId {
-        self.id
     }
 }
 

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -99,7 +99,7 @@ impl SpriteBatch {
                 // with graphics::set_color(); this just inherits from that.
                 new_param.color = new_param.color;
                 let primitive_param = graphics::PrimitiveDrawParam::from(new_param);
-                graphics::InstanceProperties::from(primitive_param)
+                primitive_param.to_instance_properties(ctx.gfx_context.backend_spec.is_heckin_srgb())
             })
             .collect::<Vec<_>>();
 

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -153,7 +153,7 @@ impl graphics::Drawable for SpriteBatch {
         let sampler = gfx.samplers
             .get_or_insert(self.image.sampler_info, gfx.factory.as_mut());
         gfx.data.vbuf = gfx.quad_vertex_buffer.clone();
-        let typed_thingy = GlBackendSpec::raw_to_typed_shader_resource(self.image.texture.clone());
+        let typed_thingy = graphics::GlBackendSpecSrgb::raw_to_typed_shader_resource(self.image.texture.clone());
         gfx.data.tex = (typed_thingy, sampler);
 
         let mut slice = gfx.quad_slice.clone();

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -153,7 +153,7 @@ impl graphics::Drawable for SpriteBatch {
         let sampler = gfx.samplers
             .get_or_insert(self.image.sampler_info, gfx.factory.as_mut());
         gfx.data.vbuf = gfx.quad_vertex_buffer.clone();
-        let typed_thingy = graphics::GlBackendSpecSrgb::raw_to_typed_shader_resource(self.image.texture.clone());
+        let typed_thingy = gfx.backend_spec.raw_to_typed_shader_resource(self.image.texture.clone());
         gfx.data.tex = (typed_thingy, sampler);
 
         let mut slice = gfx.quad_slice.clone();

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -594,7 +594,7 @@ where
     );
 
     // Typed() is an Undocumented Feature of gfx
-    type ColorFormat = <GlBackendSpecSrgb as BackendSpec>::SurfaceType;
+    type ColorFormat = super::BuggoSurfaceFormat;
     let typed_render_target: gfx::handle::RenderTargetView<
         gfx_device_gl::Resources,
         ColorFormat,

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -594,7 +594,7 @@ where
     );
 
     // Typed() is an Undocumented Feature of gfx
-    type ColorFormat = <GlBackendSpec as BackendSpec>::SurfaceType;
+    type ColorFormat = <GlBackendSpecSrgb as BackendSpec>::SurfaceType;
     let typed_render_target: gfx::handle::RenderTargetView<
         gfx_device_gl::Resources,
         ColorFormat,


### PR DESCRIPTION
Basically all color type values need to be ENTIRELY at runtime with no compile-time types anywhere.  This isn't complete yet but there's only a couple places where Srgba8 is still assumed due to gfx or gfx_glyph API's not being compatible; they should be marked with the placeholder BuggoSurfaceFormat type.