### PR TITLE
Fix variable naming consistency in tutorial

### DIFF
--- a/docs/guides/HelloGgez.md
+++ b/docs/guides/HelloGgez.md
@@ -113,7 +113,7 @@ But, we're not going to write any bugs right? 😉
 In your main, you will need to create an instance of `State`.
 ```rust
 pub fn main() {
-    let s = &mut State { };
+    let state = &mut State { };
 }
 ```
 


### PR DESCRIPTION
Currently the code snipper to initialize state assigns it to `s` but later it's referred to as `state`. This PR changes it to be initialized as `state` as well.