### PR TITLE
Add docs to indicate that primitive draws are inefficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ More specifically, ggez is a lightweight cross-platform game framework
 for making 2D games with minimum friction.  It aims to implement an 
 API based on (a Rustified version of) the [LÖVE](https://love2d.org/) 
 game framework.  This means it contains basic and portable 2D
-drawing, sound, resource loading and event handling.
+drawing, sound, resource loading and event handling, but finer details
+like performance characteristics may be very different (e.g. ggez does
+*not* do automatic batching).
 
 ggez is not meant to be everything to everyone, but rather a good
 base upon which to build.  Thus it takes a fairly

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -2,6 +2,13 @@
 //! <https://www.youtube.com/watch?v=HCwMb0KslX8>
 //! to showcase ggez and how it relates/differs from piston.
 //!
+//! Note that this example is meant to highlight the general
+//! structure of a ggez game. Some of the details may need to
+//! be changed to scale the game. For example, if we needed to
+//! draw hundreds or thousands of shapes, a SpriteBatch is going
+//! to offer far better performance than the direct draw calls
+//! that this example uses.
+//!
 //! Author: @termhn
 //! Original repo: https://github.com/termhn/ggez_snake
 
@@ -203,6 +210,10 @@ impl Food {
     /// with the helpers in `ggez::graphics` to do drawing. We also return a
     /// `ggez::GameResult` so that we can use the `?` operator to bubble up
     /// failure of drawing.
+    ///
+    /// Note: this method of drawing does not scale. If you need to render
+    /// a large number of shapes, use a SpriteBatch. This approach is fine for
+    /// this example since there are a fairly limited number of calls.
     fn draw(&self, ctx: &mut Context) -> GameResult<()> {
         // First we set the color to draw with, in this case all food will be
         // colored blue.
@@ -318,6 +329,10 @@ impl Snake {
 
     /// Here we have the Snake draw itself. This is very similar to how we saw the Food
     /// draw itself earlier.
+    ///
+    /// Again, note that this approach to drawing is fine for the limited scope of this
+    /// example, but larger scale games will likely need a more optimized render path
+    /// using SpriteBatch or something similar that batches draw calls.
     fn draw(&self, ctx: &mut Context) -> GameResult<()> {
         // We first iterate through the body segments and draw them.
         for seg in self.body.iter() {

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -5,6 +5,14 @@
 //! This module also manages graphics state, coordinate systems, etc.
 //! The default coordinate system has the origin in the upper-left
 //! corner of the screen, with Y increasing downwards.
+//!
+//! This library differs significantly in performance characteristics from the
+//! love library that it is based on. Many operations that are batched by default
+//! in love (e.g. drawing primitives like rectangles or circles) are *not* batched
+//! in ggez, so render loops with a large number of draw calls can be very slow.
+//! The primary solution to efficiently rendering a large number of primitives is
+//! a `SpriteBatch`, which can be orders of magnitude more efficient than individual
+//! draw calls.
 
 use std::collections::HashMap;
 use std::convert::From;


### PR DESCRIPTION
The snake example is referenced from a youtube video and a blog post, so
I added documentation there because that's likely one of the first
places a new developer will interact with ggez and base projects on.

I noted in the graphics package that the draws are different from the
love project that it's based on since primitive draw calls seem to be
batched, whereas ggez does *not* do automatic batching. There may be
more places in the source where such notes are useful.

I also added a short note in the README that there may be performance differences between ggez and love. I feel like it would be nice to have a section that details gotchas coming from love. I personally don't have a *ton* of experience with love (or ggez for that matter), but my knee-jerk reaction in #440 was to test on love to see if I was making a fundamental mistake. Having a note in the README about high-level differences from love would be helpful.