### PR TITLE
Fixed double-borrow in text.rs

### DIFF
--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -352,9 +352,8 @@ impl Text {
     /// TODO: Should these return f32 rather than u32?
     pub fn dimensions(&self, context: &Context) -> (u32, u32) {
         if let Ok(metrics) = self.cached_metrics.read() {
-            match (metrics.width, metrics.height) {
-                (Some(width), Some(height)) => return (width, height),
-                _ => {}
+            if let (Some(width), Some(height)) = (metrics.width, metrics.height) {
+                return (width, height);
             }
         }
         self.calculate_dimensions(context)


### PR DESCRIPTION
`self.calculate_dimensions` hangs on a `.write()` to `self.cached_metrics` without this fix due to a double-borrow.