### PR TITLE
Mount paths before searching for conf file in ContextBuilder

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -277,15 +277,15 @@ impl ContextBuilder {
         let sdl_context = sdl2::init()?;
         let mut fs = Filesystem::new(self.game_id, self.author)?;
 
+        for path in &self.paths {
+            fs.mount(path, true);
+        }
+
         let config = if self.load_conf_file {
             fs.read_config().unwrap_or(self.conf)
         } else {
             self.conf
         };
-
-        for path in &self.paths {
-            fs.mount(path, true);
-        }
 
         Context::from_conf(config, fs, sdl_context)
     }


### PR DESCRIPTION
I was trying to set up a `conf.toml` file in a `resources/` directory next to my `Cargo.toml`, and I noticed that it was not being loaded by ggez.

It seems that `ContextBuilder` tries to load a conf file before mounting any paths that have been added to it, missing any confs that may be in those paths.