### PR TITLE
Mount paths before searching for conf file in ContextBuilder

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -260,15 +260,15 @@ impl ContextBuilder {
     pub fn build(self) -> GameResult<(Context, winit::EventsLoop)> {
         let mut fs = Filesystem::new(self.game_id, self.author)?;
 
+        for path in &self.paths {
+            fs.mount(path, true);
+        }
+
         let config = if self.load_conf_file {
             fs.read_config().unwrap_or(self.conf)
         } else {
             self.conf
         };
-
-        for path in &self.paths {
-            fs.mount(path, true);
-        }
 
         Context::from_conf(config, fs)
     }


### PR DESCRIPTION
Same as #448 but on the right branch this time.