### PR TITLE
Fix a bunch of clippy warnings

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -37,7 +37,7 @@ impl AudioContext {
                 "Could not initialize sound system (for some reason)",
             ))
         })?;
-        Ok(AudioContext { device: device })
+        Ok(AudioContext { device })
     }
 }
 

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -57,8 +57,8 @@ impl Canvas {
         let color_format = ctx.gfx_context.color_format();
         let factory = &mut ctx.gfx_context.factory;
         let texture_create_info = gfx::texture::Info {
-            kind: kind,
-            levels: levels,
+            kind,
+            levels,
             format: color_format.0,
             bind: Bind::SHADER_RESOURCE | Bind::RENDER_TARGET | Bind::TRANSFER_SRC,
             usage: Usage::Data,

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -440,22 +440,24 @@ where
         window.set_maximized(mode.maximized);
 
         // TODO: find out if single-dimension constraints are possible.
-        let mut min_dimensions = None;
-        if mode.min_width > 0.0 && mode.min_height > 0.0 {
-            min_dimensions = Some(dpi::LogicalSize {
+        let min_dimensions = if mode.min_width > 0.0 && mode.min_height > 0.0 {
+            Some(dpi::LogicalSize {
                 width: mode.min_width.into(),
                 height: mode.min_height.into(),
-            });
-        }
+            })
+        } else {
+            None
+        };
         window.set_min_dimensions(min_dimensions);
 
-        let mut max_dimensions = None;
-        if mode.max_width > 0.0 && mode.max_height > 0.0 {
-            max_dimensions = Some(dpi::LogicalSize {
+        let max_dimensions = if mode.max_width > 0.0 && mode.max_height > 0.0 {
+            Some(dpi::LogicalSize {
                 width: mode.max_width.into(),
                 height: mode.max_height.into(),
-            });
-        }
+            })
+        } else {
+            None
+        };
         window.set_max_dimensions(max_dimensions);
 
         let monitor = window.get_current_monitor();
@@ -548,7 +550,7 @@ where
     /// and turns it into the equivalent in PhysicalScale, allowing us to
     /// override the DPI if necessary.
     pub(crate) fn to_physical_dpi(&self, x: f32, y: f32) -> (f32, f32) {
-        let logical = dpi::LogicalPosition::new(x as f64, y as f64);
+        let logical = dpi::LogicalPosition::new(f64::from(x), f64::from(y));
         let physical = dpi::PhysicalPosition::from_logical(logical, self.hidpi_factor.into());
         (physical.x as f32, physical.y as f32)
     }

--- a/src/graphics/drawparam.rs
+++ b/src/graphics/drawparam.rs
@@ -276,7 +276,7 @@ impl DrawTransform {
             col2: mat[1],
             col3: mat[2],
             col4: mat[3],
-            color: color,
+            color,
         }
     }
 }

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -76,7 +76,7 @@ where
         use gfx::memory::Bind;
         let gfx::format::Format(surface_format, channel_type) = color_format;
         let texinfo = gfx::texture::Info {
-            kind: kind,
+            kind,
             levels: 1,
             format: surface_format,
             bind: Bind::SHADER_RESOURCE | Bind::RENDER_TARGET | Bind::TRANSFER_SRC,
@@ -107,8 +107,8 @@ where
             texture_handle: raw_tex,
             sampler_info: *sampler_info,
             blend_mode: None,
-            width: width,
-            height: height,
+            width,
+            height,
             debug_id,
         })
     }
@@ -241,7 +241,7 @@ impl Image {
         let color_format = image::ColorType::RGBA(8);
         match format {
             ImageFormat::Png => image::png::PNGEncoder::new(writer)
-                .encode(&data, self.width as u32, self.height as u32, color_format)
+                .encode(&data, u32::from(self.width), u32::from(self.height), color_format)
                 .map_err(|e| e.into()),
         }
     }
@@ -286,7 +286,7 @@ impl Image {
 
     /// Returns the dimensions of the image.
     pub fn get_dimensions(&self) -> Rect {
-        Rect::new(0.0, 0.0, self.width() as f32, self.height() as f32)
+        Rect::new(0.0, 0.0, f32::from(self.width()), f32::from(self.height()))
     }
 
     /// Gets the `Image`'s `WrapMode` along the X and Y axes.
@@ -331,8 +331,8 @@ impl Drawable for Image {
         // be its-unit-size-in-pixels.
         use nalgebra;
         let real_scale = nalgebra::Vector3::new(
-            src_width * self.width as f32,
-            src_height * self.height as f32,
+            src_width * f32::from(self.width),
+            src_height * f32::from(self.height),
             1.0,
         );
         let new_param = param.mul(Matrix4::new_nonuniform_scaling(&real_scale));

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -384,7 +384,7 @@ where
     T: Into<DrawTransform>,
 {
     let params = params.into();
-    drawable.draw(ctx, DrawTransform::from(params))
+    drawable.draw(ctx, params)
 }
 
 /// Tells the graphics system to actually put everything on the screen.

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -89,8 +89,8 @@ impl SpriteBatch {
                 let src_width = param.src.w;
                 let src_height = param.src.h;
                 let real_scale = graphics::Vector2::new(
-                    src_width * param.scale.x * image.width as f32,
-                    src_height * param.scale.y * image.height as f32,
+                    src_width * param.scale.x * f32::from(image.width),
+                    src_height * param.scale.y * f32::from(image.height),
                 );
                 new_param.scale = real_scale;
                 // If we have no color, our color is white.

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -155,11 +155,11 @@ impl Clone for Text {
     fn clone(&self) -> Self {
         Text {
             fragments: self.fragments.clone(),
-            blend_mode: self.blend_mode.clone(),
-            bounds: self.bounds.clone(),
-            layout: self.layout.clone(),
-            font_id: self.font_id.clone(),
-            font_scale: self.font_scale.clone(),
+            blend_mode: self.blend_mode,
+            bounds: self.bounds,
+            layout: self.layout,
+            font_id: self.font_id,
+            font_scale: self.font_scale,
             cached_metrics: Arc::new(RwLock::new(CachedMetrics::default())),
         }
     }
@@ -236,11 +236,11 @@ impl Text {
     }
 
     /// Converts `Text` to a type `gfx_glyph` can understand and queue.
-    fn generate_varied_section<'a>(
-        &'a self,
+    fn generate_varied_section(
+        &self,
         relative_dest: Point2,
         color: Option<Color>,
-    ) -> VariedSection<'a> {
+    ) -> VariedSection {
         let mut sections = Vec::with_capacity(self.fragments.len());
         for fragment in &self.fragments {
             let color = match fragment.color {
@@ -419,7 +419,7 @@ impl Font {
         let font_id = context.gfx_context.glyph_brush.add_font_bytes(v);
 
         Ok(Font {
-            font_id: font_id,
+            font_id,
         })
     }
 

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -75,15 +75,15 @@ bitflags! {
     #[derive(Default)]
     pub struct KeyMods: u8 {
         /// No modifiers; equivalent to `KeyMods::default()` and `KeyMods::empty()`.
-        const NONE  = 0b00000000;
+        const NONE  = 0b0000_0000;
         /// Left or right Shift key.
-        const SHIFT = 0b00000001;
+        const SHIFT = 0b0000_0001;
         /// Left or right Control key.
-        const CTRL  = 0b00000010;
+        const CTRL  = 0b0000_0010;
         /// Left or right Alt key.
-        const ALT   = 0b00000100;
+        const ALT   = 0b0000_0100;
         /// Left or right Win/Cmd/equivalent key.
-        const LOGO  = 0b00001000;
+        const LOGO  = 0b0000_1000;
     }
 }
 
@@ -214,8 +214,7 @@ impl KeyboardContext {
                 } else {
                     None
                 }
-            })
-            .collect()
+            }).collect()
     }
 
     pub(crate) fn active_mods(&self) -> KeyMods {
@@ -368,9 +367,15 @@ mod tests {
         }));
 
         // these test the workaround for https://github.com/tomaka/winit/issues/600
-        assert_eq!(keyboard.active_mods(), KeyMods::SHIFT | KeyMods::CTRL | KeyMods::ALT | KeyMods::LOGO);
+        assert_eq!(
+            keyboard.active_mods(),
+            KeyMods::SHIFT | KeyMods::CTRL | KeyMods::ALT | KeyMods::LOGO
+        );
         keyboard.set_key(KeyCode::LControl, false);
-        assert_eq!(keyboard.active_mods(), KeyMods::SHIFT | KeyMods::ALT | KeyMods::LOGO);
+        assert_eq!(
+            keyboard.active_mods(),
+            KeyMods::SHIFT | KeyMods::ALT | KeyMods::LOGO
+        );
         keyboard.set_key(KeyCode::RAlt, false);
         assert_eq!(keyboard.active_mods(), KeyMods::SHIFT | KeyMods::LOGO);
         keyboard.set_key(KeyCode::LWin, false);

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -104,8 +104,8 @@ pub fn set_position(ctx: &mut Context, point: Point2) -> GameResult<()> {
     ctx.mouse_context.last_position = point;
     graphics::get_window(ctx)
         .set_cursor_position(dpi::LogicalPosition {
-            x: point.x as f64,
-            y: point.y as f64,
+            x: f64::from(point.x),
+            y: f64::from(point.y),
         })
         .map_err(|_| GameError::WindowError("Couldn't set mouse cursor position!".to_owned()))
 }


### PR DESCRIPTION
Please look through this before merging, I made a couple of style choices based on clippy that may or may not be desirable.

This fixes a good number of the lint warnings. The ones remaining are:

- type_complexity
- trivially_copy_pass_by_ref (I left these out since it's an API change)
- too_many_arguments
- new_ret_no_self
- unnecessary mut (looks like it's a work in progress)

I'm not sure if the goal should be 100% clippy pass, but I think the `type_complexity` ones should be looked at.