### PR TITLE
Rename ALL getters from `get_foo()` to `foo()`.

### DIFF
--- a/docs/guides/HelloGgez.md
+++ b/docs/guides/HelloGgez.md
@@ -227,10 +227,10 @@ let state = &mut State { dt: std::time::Duration::new(0, 0) };
 ```
 
 So now that we have state to update, let's update it in our `update` callback!
-We'll use [`timer::get_delta`](https://docs.rs/ggez/0.4.0/ggez/timer/fn.get_delta.html) to get the delta time.
+We'll use [`timer::delta`](https://docs.rs/ggez/0.4.0/ggez/timer/fn.delta.html) to get the delta time.
 ```rust
 fn update(&mut self, ctx: &mut Context) -> GameResult<()> {
-    self.dt = timer::get_delta(ctx);
+    self.dt = timer::delta(ctx);
     Ok(())
 }
 ```
@@ -243,7 +243,7 @@ fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
 }
 ```
 Every frame, print out `Hello ggez! dt = {}ns`. This will print once a frame. Which is going to be a lot.
-  
+
 ### ✔ Check Program
 
 And yet again, run `cargo run`.

--- a/examples/canvas_subframe.rs
+++ b/examples/canvas_subframe.rs
@@ -46,7 +46,7 @@ impl MainState {
         graphics::clear(ctx, graphics::WHITE);
 
         // Freeze the animation so things are easier to see.
-        // let time = (timer::duration_to_f64(timer::get_time_since_start(ctx)) * 1000.0) as u32;
+        // let time = (timer::duration_to_f64(timer::time_since_start(ctx)) * 1000.0) as u32;
         let time = 2000;
         let cycle = 10_000;
         for x in 0..150 {
@@ -88,13 +88,13 @@ impl MainState {
 
 impl event::EventHandler for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if timer::get_ticks(ctx) % 100 == 0 {
-            println!("Delta frame time: {:?} ", timer::get_delta(ctx));
-            println!("Average FPS: {}", timer::get_fps(ctx));
+        if timer::ticks(ctx) % 100 == 0 {
+            println!("Delta frame time: {:?} ", timer::delta(ctx));
+            println!("Average FPS: {}", timer::fps(ctx));
         }
 
         // Bounce the rect if necessary
-        let (w, h) = graphics::get_size(ctx);
+        let (w, h) = graphics::size(ctx);
         if self.draw_pt.x + (w as f32 / 2.0) > (w as f32) || self.draw_pt.x < 0.0 {
             self.draw_vec.x *= -1.0;
         }

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -79,9 +79,9 @@ struct MainState {
 
 impl MainState {
     fn new(ctx: &mut Context) -> Self {
-        let color_view = graphics::get_screen_render_target(ctx);
-        let depth_view = graphics::get_depth_view(ctx);
-        let factory = graphics::get_factory(ctx);
+        let color_view = graphics::screen_render_target(ctx);
+        let depth_view = graphics::depth_view(ctx);
+        let factory = graphics::factory(ctx);
 
         // Shaders.
         let vs = br#"#version 150 core
@@ -212,7 +212,7 @@ impl event::EventHandler for MainState {
         // Do gfx-rs drawing
         {
             let (_factory, device, encoder, _depthview, _colorview) =
-                graphics::get_gfx_objects(ctx);
+                graphics::gfx_objects(ctx);
             encoder.clear(&self.data.out_color, [0.1, 0.1, 0.1, 1.0]);
 
             let rotation = na::Matrix4::from_scaled_axis(na::Vector3::z() * self.rotation);
@@ -250,7 +250,7 @@ impl event::EventHandler for MainState {
         graphics::present(ctx)?;
         self.frames += 1;
         if (self.frames % 10) == 0 {
-            println!("FPS: {}", ggez::timer::get_fps(ctx));
+            println!("FPS: {}", ggez::timer::fps(ctx));
         }
         Ok(())
     }

--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -164,7 +164,7 @@ pub fn main() -> GameResult {
 
     let (ctx, events_loop) = &mut cb.build()?;
 
-    println!("{}", graphics::get_renderer_info(ctx)?);
+    println!("{}", graphics::renderer_info(ctx)?);
     let state = &mut MainState::new(ctx).unwrap();
     event::run(ctx, events_loop, state)
 }

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -69,7 +69,7 @@ impl event::EventHandler for MainState {
 
             /*
             if self.window_settings.window_size_toggle {
-                let resolutions = ggez::graphics::get_fullscreen_modes(ctx, 0)?;
+                let resolutions = ggez::graphics::fullscreen_modes(ctx, 0)?;
                 let (width, height) = resolutions[self.window_settings.resolution_index];
 
                 ggez::graphics::set_resolution(ctx, width, height)?;
@@ -83,13 +83,14 @@ impl event::EventHandler for MainState {
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::clear(ctx, graphics::BLACK);
-        let rotation = timer::get_ticks(ctx) % 1000;
+        let rotation = timer::ticks(ctx) % 1000;
         let circle = graphics::Mesh::new_circle(
             ctx,
             DrawMode::Line(3.0),
             Point2::new(0.0, 0.0),
             100.0,
             4.0,
+            graphics::WHITE
         )?;
         graphics::draw(
             ctx,
@@ -160,7 +161,7 @@ impl event::EventHandler for MainState {
             KeyCode::Up => {
                 self.zoom += 0.1;
                 println!("Zoom is now {}", self.zoom);
-                let (w, h) = graphics::get_size(ctx);
+                let (w, h) = graphics::size(ctx);
                 let new_rect =
                     graphics::Rect::new(0.0, 0.0, w as f32 * self.zoom, h as f32 * self.zoom);
                 graphics::set_screen_coordinates(ctx, new_rect).unwrap();
@@ -168,7 +169,7 @@ impl event::EventHandler for MainState {
             KeyCode::Down => {
                 self.zoom -= 0.1;
                 println!("Zoom is now {}", self.zoom);
-                let (w, h) = graphics::get_size(ctx);
+                let (w, h) = graphics::size(ctx);
                 let new_rect =
                     graphics::Rect::new(0.0, 0.0, w as f32 * self.zoom, h as f32 * self.zoom);
                 graphics::set_screen_coordinates(ctx, new_rect).unwrap();

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -85,7 +85,7 @@ impl event::EventHandler for MainState {
         // Drawables are drawn from their top-left corner.
         self.frames += 1;
         if (self.frames % 100) == 0 {
-            println!("FPS: {}", ggez::timer::get_fps(ctx));
+            println!("FPS: {}", ggez::timer::fps(ctx));
         }
 
         Ok(())

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -49,7 +49,7 @@ impl event::EventHandler for MainState {
 
         self.frames += 1;
         if (self.frames % 100) == 0 {
-            println!("FPS: {}", ggez::timer::get_fps(ctx));
+            println!("FPS: {}", ggez::timer::fps(ctx));
         }
 
         Ok(())
@@ -81,7 +81,7 @@ pub fn main() -> GameResult {
         ;
     let (ctx, event_loop) = &mut cb.build()?;
 
-    println!("HIDPI: {}", graphics::get_hidpi_factor(ctx));
+    println!("HIDPI: {}", graphics::hidpi_factor(ctx));
 
     let state = &mut MainState::new(ctx)?;
     event::run(ctx, event_loop, state)

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -77,8 +77,8 @@ impl event::EventHandler for MainState {
             if self.a > 250 || self.a <= 0 {
                 self.direction *= -1;
 
-                println!("Delta frame time: {:?} ", timer::get_delta(ctx));
-                println!("Average FPS: {}", timer::get_fps(ctx));
+                println!("Delta frame time: {:?} ", timer::delta(ctx));
+                println!("Average FPS: {}", timer::fps(ctx));
             }
         }
         Ok(())

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -43,7 +43,7 @@ impl FileLogger {
         debug!(
             "Created log file {:?} in {:?}",
             path,
-            filesystem::get_user_config_dir(ctx)
+            filesystem::user_config_dir(ctx)
         );
         Ok(FileLogger { file, receiver })
     }

--- a/examples/render_to_image.rs
+++ b/examples/render_to_image.rs
@@ -41,7 +41,7 @@ impl event::EventHandler for MainState {
 
         // now lets render our scene once in the top right and in the bottom
         // right
-        let window_size = graphics::get_size(ctx);
+        let window_size = graphics::size(ctx);
         let scale = Vector2::new(
             0.5 * window_size.0 as f32 / self.canvas.image().width() as f32,
             0.5 * window_size.1 as f32 / self.canvas.image().height() as f32,

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -40,7 +40,7 @@ impl MainState {
 
 impl event::EventHandler for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        self.dim.rate = 0.5 + (((timer::get_ticks(ctx) as f32) / 100.0).cos() / 2.0);
+        self.dim.rate = 0.5 + (((timer::ticks(ctx) as f32) / 100.0).cos() / 2.0);
         Ok(())
     }
 

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -203,7 +203,7 @@ impl MainState {
             graphics::Text::new(("SHADOWS...", font, 48.0))
         };
         let screen_size = {
-            let size = graphics::get_drawable_size(ctx);
+            let size = graphics::drawable_size(ctx);
             [size.0 as f32, size.1 as f32]
         };
         let torch = Light {
@@ -214,7 +214,7 @@ impl MainState {
             glow: 0.0,
             strength: LIGHT_STRENGTH,
         };
-        let (w, h) = graphics::get_size(ctx);
+        let (w, h) = graphics::size(ctx);
         let (x, y) = (100.0 / w as f32, 1.0 - 75.0 / h as f32);
         let static_light = Light {
             pos: [x, y],
@@ -279,7 +279,7 @@ impl MainState {
         origin: DrawParam,
         canvas_origin: DrawParam,
     ) -> GameResult {
-        let size = graphics::get_size(ctx);
+        let size = graphics::size(ctx);
         // Now we want to run the occlusions shader to calculate our 1D shadow
         // distances into the `occlusions` canvas.
         graphics::set_canvas(ctx, Some(&self.occlusions));
@@ -321,23 +321,23 @@ impl MainState {
 
 impl event::EventHandler for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if timer::get_ticks(ctx) % 100 == 0 {
-            println!("Average FPS: {}", timer::get_fps(ctx));
+        if timer::ticks(ctx) % 100 == 0 {
+            println!("Average FPS: {}", timer::fps(ctx));
         }
 
         self.torch.glow =
-            LIGHT_GLOW_FACTOR * ((timer::get_ticks(ctx) as f32) / LIGHT_GLOW_RATE).cos();
+            LIGHT_GLOW_FACTOR * ((timer::ticks(ctx) as f32) / LIGHT_GLOW_RATE).cos();
         self.static_light.glow =
-            LIGHT_GLOW_FACTOR * ((timer::get_ticks(ctx) as f32) / LIGHT_GLOW_RATE * 0.75).sin();
+            LIGHT_GLOW_FACTOR * ((timer::ticks(ctx) as f32) / LIGHT_GLOW_RATE * 0.75).sin();
         Ok(())
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        let size = graphics::get_size(ctx);
+        let size = graphics::size(ctx);
         let origin = DrawParam::new().dest(Point2::new(0.0, 0.0));
         // for re-rendering canvases, we need to take the DPI into account
         let dpiscale = {
-            let dsize = graphics::get_drawable_size(ctx);
+            let dsize = graphics::drawable_size(ctx);
             Vector2::new(
                 size.0 as f32 / dsize.0 as f32,
                 size.1 as f32 / dsize.1 as f32,
@@ -409,7 +409,7 @@ impl event::EventHandler for MainState {
     }
 
     fn mouse_motion_event(&mut self, ctx: &mut Context, x: f32, y: f32, _xrel: f32, _yrel: f32) {
-        let (w, h) = graphics::get_size(ctx);
+        let (w, h) = graphics::size(ctx);
         let (x, y) = (x / w as f32, 1.0 - y / h as f32);
         self.torch.pos = [x, y];
     }

--- a/examples/spritebatch.rs
+++ b/examples/spritebatch.rs
@@ -28,9 +28,9 @@ impl MainState {
 
 impl event::EventHandler for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if timer::get_ticks(ctx) % 100 == 0 {
-            println!("Delta frame time: {:?} ", timer::get_delta(ctx));
-            println!("Average FPS: {}", timer::get_fps(ctx));
+        if timer::ticks(ctx) % 100 == 0 {
+            println!("Delta frame time: {:?} ", timer::delta(ctx));
+            println!("Average FPS: {}", timer::fps(ctx));
         }
         Ok(())
     }
@@ -38,7 +38,7 @@ impl event::EventHandler for MainState {
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::clear(ctx, graphics::BLACK);
 
-        let time = (timer::duration_to_f64(timer::get_time_since_start(ctx)) * 1000.0) as u32;
+        let time = (timer::duration_to_f64(timer::time_since_start(ctx)) * 1000.0) as u32;
         let cycle = 10_000;
         for x in 0..150 {
             for y in 0..150 {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -133,7 +133,7 @@ impl event::EventHandler for App {
         // `Text` can be used in "immediate mode", but it's slightly less efficient
         // in most cases, and horrifically less efficient in a few select ones
         // (using `.width()` or `.height()`, for example).
-        let fps = timer::get_fps(ctx);
+        let fps = timer::fps(ctx);
         let fps_display = Text::new(format!("FPS: {}", fps));
         // When drawing through these calls, `DrawParam` will work as they are documented.
         graphics::draw(

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -30,7 +30,7 @@ impl MainState {
             for y in 0..Self::GRID_SIZE {
                 let point = na::Point2::new(x as f32 * Self::GRID_INTERVAL, y as f32 * Self::GRID_INTERVAL);
                 gridmesh_builder
-                    .circle(DrawMode::Fill, point, Self::GRID_POINT_RADIUS, 2.0);
+                    .circle(DrawMode::Fill, point, Self::GRID_POINT_RADIUS, 2.0, graphics::WHITE);
             }
         }
         let gridmesh = gridmesh_builder.build(ctx)?;

--- a/src/event.rs
+++ b/src/event.rs
@@ -204,7 +204,7 @@ where
                         button,
                         ..
                     } => {
-                        let position = mouse::get_position(ctx);
+                        let position = mouse::position(ctx);
                         match element_state {
                             ElementState::Pressed => {
                                 state.mouse_button_down_event(ctx, button, position.x, position.y)
@@ -215,8 +215,8 @@ where
                         }
                     }
                     WindowEvent::CursorMoved { .. } => {
-                        let position = mouse::get_position(ctx);
-                        let delta = mouse::get_delta(ctx);
+                        let position = mouse::position(ctx);
+                        let delta = mouse::delta(ctx);
                         state.mouse_motion_event(ctx, position.x, position.y, delta.x, delta.y);
                     }
                     x => {

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -384,18 +384,18 @@ pub fn is_dir<P: AsRef<path::Path>>(ctx: &Context, path: P) -> bool {
 }
 
 /// Return the full path to the user data directory
-pub fn get_user_data_dir(ctx: &Context) -> &path::Path {
+pub fn user_data_dir(ctx: &Context) -> &path::Path {
     &ctx.filesystem.user_data_path
 }
 
 /// Return the full path to the user config directory
-pub fn get_user_config_dir(ctx: &Context) -> &path::Path {
+pub fn user_config_dir(ctx: &Context) -> &path::Path {
     &ctx.filesystem.user_config_path
 }
 
 /// Returns the full path to the resource directory
 /// (even if it doesn't exist)
-pub fn get_resources_dir(ctx: &Context) -> &path::Path {
+pub fn resources_dir(ctx: &Context) -> &path::Path {
     &ctx.filesystem.resources_path
 }
 

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -96,7 +96,7 @@ impl Canvas {
     /// Create a new canvas with the current window dimensions.
     pub fn with_window_size(ctx: &mut Context) -> GameResult<Canvas> {
         use graphics;
-        let (w, h) = graphics::get_drawable_size(ctx);
+        let (w, h) = graphics::drawable_size(ctx);
         // Default to no multisampling
         // TODO: Use winit's into() to translate f64's more accurately
         Canvas::new(ctx, w as u16, h as u16, conf::NumSamples::One)

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -40,10 +40,11 @@ pub use self::t::{FillOptions, FillRule, LineCap, LineJoin, StrokeOptions};
 ///                 na::Point2::new(0.0, 0.0),
 ///             ],
 ///             1.0,
+///             graphics::WHITE,
 ///         )
 ///         // Add vertices for an exclamation mark!
-///         .ellipse(DrawMode::Fill, na::Point2::new(0.0, 25.0), 2.0, 15.0, 2.0)
-///         .circle(DrawMode::Fill, na::Point2::new(0.0, 45.0), 2.0, 2.0)
+///         .ellipse(DrawMode::Fill, na::Point2::new(0.0, 25.0), 2.0, 15.0, 2.0, graphics::WHITE,)
+///         .circle(DrawMode::Fill, na::Point2::new(0.0, 45.0), 2.0, 2.0, graphics::WHITE,)
 ///         // Finalize then unwrap. Unwrapping via `?` operator either yields the final `Mesh`,
 ///         // or propagates the error (note return type).
 ///         .build(ctx)?;

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -585,7 +585,7 @@ pub fn rectangle(ctx: &mut Context, color: Color, mode: DrawMode, rect: Rect) ->
 // **********************************************************************
 
 /// Get the default filter mode for new images.
-pub fn get_default_filter(ctx: &Context) -> FilterMode {
+pub fn default_filter(ctx: &Context) -> FilterMode {
     let gfx = &ctx.gfx_context;
     gfx.default_sampler_info.filter.into()
 }
@@ -593,7 +593,7 @@ pub fn get_default_filter(ctx: &Context) -> FilterMode {
 /// Returns a string that tells a little about the obtained rendering mode.
 /// It is supposed to be human-readable and will change; do not try to parse
 /// information out of it!
-pub fn get_renderer_info(ctx: &Context) -> GameResult<String> {
+pub fn renderer_info(ctx: &Context) -> GameResult<String> {
     let backend_info = ctx.gfx_context.backend_spec.info(&*ctx.gfx_context.device);
     Ok(format!(
         "Requested OpenGL {}.{} Core profile, actually got {}.",
@@ -607,7 +607,7 @@ pub fn get_renderer_info(ctx: &Context) -> GameResult<String> {
 ///
 /// If the Y axis increases downwards, the `height` of the Rect
 /// will be negative.
-pub fn get_screen_coordinates(ctx: &Context) -> Rect {
+pub fn screen_coordinates(ctx: &Context) -> Rect {
     ctx.gfx_context.screen_rect
 }
 
@@ -662,7 +662,7 @@ pub fn mul_projection(context: &mut Context, transform: Matrix4) {
 }
 
 /// Gets a copy of the context's raw projection matrix
-pub fn get_projection(context: &Context) -> Matrix4 {
+pub fn projection(context: &Context) -> Matrix4 {
     let gfx = &context.gfx_context;
     gfx.projection()
 }
@@ -712,7 +712,7 @@ pub fn set_transform(context: &mut Context, transform: Matrix4) {
 }
 
 /// Gets a copy of the context's current transform matrix
-pub fn get_transform(context: &Context) -> Matrix4 {
+pub fn transform(context: &Context) -> Matrix4 {
     let gfx = &context.gfx_context;
     gfx.transform()
 }
@@ -810,7 +810,7 @@ pub fn set_window_title(context: &Context, title: &str) {
 /// Ideally you should not need to use this because ggez
 /// would provide all the functions you need without having
 /// to dip into SDL itself.  But life isn't always ideal.
-pub fn get_window(context: &Context) -> &glutin::Window {
+pub fn window(context: &Context) -> &glutin::Window {
     let gfx = &context.gfx_context;
     &gfx.window
 }
@@ -820,7 +820,7 @@ pub fn get_window(context: &Context) -> &glutin::Window {
 /// Returns zeros if window doesn't exist.
 /// TODO: Rename, since get_drawable_size is usually what we
 /// actually want
-pub fn get_size(context: &Context) -> (f64, f64) {
+pub fn size(context: &Context) -> (f64, f64) {
     let gfx = &context.gfx_context;
     gfx.window
         .get_outer_size()
@@ -832,19 +832,19 @@ pub fn get_size(context: &Context) -> (f64, f64) {
 /// is currently using.  If  `conf::WindowMode::hidpi`
 /// is true this is equal to `get_os_hidpi_factor()`,
 /// otherwise it is `1.0`.
-pub fn get_hidpi_factor(context: &Context) -> f32 {
+pub fn hidpi_factor(context: &Context) -> f32 {
     context.gfx_context.hidpi_factor
 }
 
 /// Returns the hidpi pixel scaling factor that the operating
 /// system says that ggez should be using.
-pub fn get_os_hidpi_factor(context: &Context) -> f32 {
+pub fn os_hidpi_factor(context: &Context) -> f32 {
     context.gfx_context.os_hidpi_factor
 }
 
 /// Returns the size of the window's underlying drawable in pixels as (width, height).
 /// Returns zeros if window doesn't exist.
-pub fn get_drawable_size(context: &Context) -> (f64, f64) {
+pub fn drawable_size(context: &Context) -> (f64, f64) {
     let gfx = &context.gfx_context;
     gfx.window
         .get_inner_size()
@@ -853,19 +853,19 @@ pub fn get_drawable_size(context: &Context) -> (f64, f64) {
 }
 
 /// Returns the gfx-rs `Factory` object for ggez's rendering context.
-pub fn get_factory(context: &mut Context) -> &mut gfx_device_gl::Factory {
+pub fn factory(context: &mut Context) -> &mut gfx_device_gl::Factory {
     let gfx = &mut context.gfx_context;
     &mut gfx.factory
 }
 
 /// Returns the gfx-rs `Device` object for ggez's rendering context.
-pub fn get_device(context: &mut Context) -> &mut gfx_device_gl::Device {
+pub fn device(context: &mut Context) -> &mut gfx_device_gl::Device {
     let gfx = &mut context.gfx_context;
     gfx.device.as_mut()
 }
 
 /// Returns the gfx-rs `Encoder` object for ggez's rendering context.
-pub fn get_encoder(
+pub fn encoder(
     context: &mut Context,
 ) -> &mut gfx::Encoder<gfx_device_gl::Resources, gfx_device_gl::CommandBuffer> {
     let gfx = &mut context.gfx_context;
@@ -873,7 +873,7 @@ pub fn get_encoder(
 }
 
 /// Returns the gfx-rs depth target object for ggez's rendering context.
-pub fn get_depth_view(
+pub fn depth_view(
     context: &mut Context,
 ) -> gfx::handle::RawDepthStencilView<gfx_device_gl::Resources> {
     let gfx = &mut context.gfx_context;
@@ -881,7 +881,7 @@ pub fn get_depth_view(
 }
 
 /// Returns the gfx-rs color target object for ggez's rendering context.
-pub fn get_screen_render_target(
+pub fn screen_render_target(
     context: &Context,
 ) -> gfx::handle::RawRenderTargetView<gfx_device_gl::Resources> {
     let gfx = &context.gfx_context;
@@ -894,7 +894,7 @@ pub fn get_screen_render_target(
 /// Returns all the relevant objects at once;
 /// getting them one by one is awkward 'cause it tends to create double-borrows
 /// on the Context object.
-pub fn get_gfx_objects(
+pub fn gfx_objects(
     context: &mut Context,
 ) -> (
     &mut <GlBackendSpec as BackendSpec>::Factory,

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -477,7 +477,7 @@ where
     D: Into<DrawTransform>,
 {
     let param: DrawTransform = param.into();
-    let screen_rect = get_screen_coordinates(context);
+    let screen_rect = screen_coordinates(context);
 
     let (screen_x, screen_y, screen_w, screen_h) = (screen_rect.x, screen_rect.y, screen_rect.w, screen_rect.h);
     let scale_x = screen_w / 2.0;
@@ -547,15 +547,15 @@ mod tests {
     #[test]
     fn test_metrics() {
         let f = Font::default_font().expect("Could not get default font");
-        assert_eq!(f.get_height(), 17);
-        assert_eq!(f.get_width("Foo!"), 33);
+        assert_eq!(f.height(), 17);
+        assert_eq!(f.width("Foo!"), 33);
 
         // http://www.catipsum.com/index.php
         let text_to_wrap = "Walk on car leaving trail of paw prints on hood and windshield sniff \
                             other cat's butt and hang jaw half open thereafter for give attitude. \
                             Annoy kitten\nbrother with poking. Mrow toy mouse squeak roll over. \
                             Human give me attention meow.";
-        let (len, v) = f.get_wrap(text_to_wrap, 250);
+        let (len, v) = f.wrap(text_to_wrap, 250);
         println!("{} {:?}", len, v);
         assert_eq!(len, 249);
 
@@ -600,7 +600,7 @@ mod tests {
                             Annoy kitten\nbrother with poking. Mrow toy mouse squeak roll over. \
                             Human give me attention meow.";
         let wrap_length = 250;
-        let (len, v) = font.get_wrap(text_to_wrap, wrap_length);
+        let (len, v) = font.wrap(text_to_wrap, wrap_length);
         assert!(len < wrap_length);
         for line in &v {
             let t = Text::new(ctx, line, &font).unwrap();

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -30,7 +30,7 @@ impl GamepadContext {
 }
 
 /// returns the `Gamepad` associated with an id.
-pub fn get_gamepad(ctx: &Context, id: usize) -> Option<&Gamepad> {
+pub fn gamepad(ctx: &Context, id: usize) -> Option<&Gamepad> {
     ctx.gamepad_context.gilrs.get(id)
 }
 
@@ -47,11 +47,11 @@ pub fn list_gamepads() {
 }
 
 /// Returns the state of the given axis on a gamepad.
-pub fn get_axis() {
+pub fn axis() {
     unimplemented!()
 }
 
 /// Returns the state of the given button on a gamepad.
-pub fn get_button_pressed() {
+pub fn button_pressed() {
     unimplemented!()
 }

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -240,7 +240,7 @@ pub fn is_key_repeated(ctx: &Context) -> bool {
 }
 
 /// Returns a Vec with currently pressed keys.
-pub fn get_pressed_keys(ctx: &Context) -> Vec<KeyCode> {
+pub fn pressed_keys(ctx: &Context) -> Vec<KeyCode> {
     ctx.keyboard_context.pressed_keys()
 }
 
@@ -250,7 +250,7 @@ pub fn is_mod_active(ctx: &Context, keymods: KeyMods) -> bool {
 }
 
 /// Returns currently active keyboard modifiers.
-pub fn get_active_mods(ctx: &Context) -> KeyMods {
+pub fn active_mods(ctx: &Context) -> KeyMods {
     ctx.keyboard_context.active_mods()
 }
 

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -57,44 +57,44 @@ impl Default for MouseContext {
 }
 
 /// Returns the current mouse cursor type of the window.
-pub fn get_cursor_type(ctx: &Context) -> MouseCursor {
+pub fn cursor_type(ctx: &Context) -> MouseCursor {
     ctx.mouse_context.cursor_type
 }
 
 /// Modifies the mouse cursor type of the window.
 pub fn set_cursor_type(ctx: &mut Context, cursor_type: MouseCursor) {
     ctx.mouse_context.cursor_type = cursor_type;
-    graphics::get_window(ctx).set_cursor(cursor_type);
+    graphics::window(ctx).set_cursor(cursor_type);
 }
 
 /// Get whether or not the mouse is grabbed (confined to the window)
-pub fn get_cursor_grabbed(ctx: &Context) -> bool {
+pub fn cursor_grabbed(ctx: &Context) -> bool {
     ctx.mouse_context.cursor_grabbed
 }
 
 /// Set whether or not the mouse is grabbed (confined to the window)
 pub fn set_cursor_grabbed(ctx: &mut Context, grabbed: bool) -> GameResult<()> {
     ctx.mouse_context.cursor_grabbed = grabbed;
-    graphics::get_window(ctx)
+    graphics::window(ctx)
         .grab_cursor(grabbed)
         .map_err(|e| GameError::WindowError(e.to_string()))
 }
 
 /// Set whether or not the mouse is hidden (invisible)
-pub fn get_cursor_hidden(ctx: &Context) -> bool {
+pub fn cursor_hidden(ctx: &Context) -> bool {
     ctx.mouse_context.cursor_hidden
 }
 
 /// Set whether or not the mouse is hidden (invisible).
 pub fn set_cursor_hidden(ctx: &mut Context, hidden: bool) {
     ctx.mouse_context.cursor_hidden = hidden;
-    graphics::get_window(ctx).hide_cursor(hidden)
+    graphics::window(ctx).hide_cursor(hidden)
 }
 
 /// Get the current position of the mouse cursor, in pixels.
 /// Complement to `set_position()`.
 /// Uses strictly window-only coordinates.
-pub fn get_position(ctx: &Context) -> Point2 {
+pub fn position(ctx: &Context) -> Point2 {
     ctx.mouse_context.last_position
 }
 
@@ -102,7 +102,7 @@ pub fn get_position(ctx: &Context) -> Point2 {
 /// Uses strictly window-only coordinates.
 pub fn set_position(ctx: &mut Context, point: Point2) -> GameResult<()> {
     ctx.mouse_context.last_position = point;
-    graphics::get_window(ctx)
+    graphics::window(ctx)
         .set_cursor_position(dpi::LogicalPosition {
             x: f64::from(point.x),
             y: f64::from(point.y),
@@ -111,19 +111,19 @@ pub fn set_position(ctx: &mut Context, point: Point2) -> GameResult<()> {
 }
 
 /// Get the distance the cursor was moved during last frame, in pixels.
-pub fn get_delta(ctx: &Context) -> Point2 {
+pub fn delta(ctx: &Context) -> Point2 {
     ctx.mouse_context.last_delta
 }
 
 /// Returns whether or not the given mouse button is pressed.
-pub fn get_button_pressed(ctx: &Context, button: MouseButton) -> bool {
+pub fn button_pressed(ctx: &Context, button: MouseButton) -> bool {
     ctx.mouse_context.button_pressed(button)
 }
 
 /// TODO: Can we implement this?  Check with Winit peoples.
 /// Winit doesn't implement it itself, we can do it by locking
 /// the cursor to the window and resetting it to center each frame?
-pub fn get_relative_mode() -> bool {
+pub fn relative_mode() -> bool {
     unimplemented!()
 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -126,14 +126,14 @@ impl Default for TimeContext {
 
 /// Get the time between the start of the last frame and the current one;
 /// in other words, the length of the last frame.
-pub fn get_delta(ctx: &Context) -> time::Duration {
+pub fn delta(ctx: &Context) -> time::Duration {
     let tc = &ctx.timer_context;
     tc.frame_durations.latest()
 }
 
 /// Gets the average time of a frame, averaged
 /// over the last 200 frames.
-pub fn get_average_delta(ctx: &Context) -> time::Duration {
+pub fn average_delta(ctx: &Context) -> time::Duration {
     let tc = &ctx.timer_context;
     let init = time::Duration::new(0, 0);
     let sum = tc.frame_durations
@@ -176,15 +176,15 @@ fn fps_as_duration(fps: u32) -> time::Duration {
 
 /// Gets the FPS of the game, averaged over the last
 /// 200 frames.
-pub fn get_fps(ctx: &Context) -> f64 {
-    let duration_per_frame = get_average_delta(ctx);
+pub fn fps(ctx: &Context) -> f64 {
+    let duration_per_frame = average_delta(ctx);
     let seconds_per_frame = duration_to_f64(duration_per_frame);
     1.0 / seconds_per_frame
 }
 
 /// Returns the time since the game was initialized,
 /// as reported by the system clock.
-pub fn get_time_since_start(ctx: &Context) -> time::Duration {
+pub fn time_since_start(ctx: &Context) -> time::Duration {
     let tc = &ctx.timer_context;
     time::Instant::now() - tc.init_instant
 }
@@ -225,14 +225,14 @@ pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
 /// by  `check_update_time()`.  For example, if the desired
 /// update frame time is 40 ms (25 fps), and 45 ms have
 /// passed since the last frame, `check_update_time()` will
-/// return `true` and `get_remaining_update_time()` will
+/// return `true` and `remaining_update_time()` will
 /// return 5 ms -- the amount of time "overflowing" from one
 /// frame to the next.
 ///
 /// The intention is for it to be called in your `draw()` callback
 /// to interpolate phyisics states for smooth rendering.
 /// (see <http://gafferongames.com/game-physics/fix-your-timestep/>)
-pub fn get_remaining_update_time(ctx: &mut Context) -> time::Duration {
+pub fn remaining_update_time(ctx: &mut Context) -> time::Duration {
     ctx.timer_context.residual_update_dt
 }
 
@@ -255,6 +255,6 @@ pub fn yield_now() {
 ///
 /// Specifically, the number of times that `TimeContext::tick()` has been
 /// called by it.
-pub fn get_ticks(ctx: &Context) -> usize {
+pub fn ticks(ctx: &Context) -> usize {
     ctx.timer_context.frame_count
 }

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -23,7 +23,7 @@ fn test_calculated_text_width() {
 
     let text = "Hello There";
 
-    let expected_width = font.get_width(text);
+    let expected_width = font.width(text);
     let rendered_width = graphics::Text::new((text, font, 24)).unwrap().width();
 
     println!("Text: {:?}, expected: {}, rendered: {}", text, expected_width, rendered_width);
@@ -40,10 +40,10 @@ fn test_monospace_text_is_actually_monospace() {
     let text3 = "Hello 3";
     let text4 = "Hello 4";
 
-    let width1 = font.get_width(text1);
-    let width2 = font.get_width(text2);
-    let width3 = font.get_width(text3);
-    let width4 = font.get_width(text4);
+    let width1 = font.width(text1);
+    let width2 = font.width(text2);
+    let width3 = font.width(text3);
+    let width4 = font.width(text4);
 
     assert_eq!(width1, width2);
     assert_eq!(width2, width3);


### PR DESCRIPTION
See issue #425 for discussion.

So far I rather like this change but it's going to live in its own branch for a little because it's VERY far-reaching.

I tried having builder structs use `with_foo()` instead of `foo()` but I find I like that rather less, even if it conflates the meanings a little.

This is also very search-and-replace-y so there may be errors or typos.

API docs for this change are available for now at https://alopex.li/temp/ggez/ggez/