### PR TITLE
Get examples to compile and run on macOS.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -36,7 +36,7 @@ pub struct Context {
     /// Mouse context
     pub mouse_context: mouse::MouseContext,
     /// Gamepad context
-    pub gamepad_context: gamepad::GamepadContext,
+    pub gamepad_context: Option<gamepad::GamepadContext>,
 
     /// The Conf object the Context was created with
     pub conf: conf::Conf,
@@ -74,7 +74,7 @@ impl Context {
         )?;
         let mouse_context = mouse::MouseContext::new();
         let keyboard_context = keyboard::KeyboardContext::new();
-        let gamepad_context = gamepad::GamepadContext::new()?;
+        let gamepad_context: Option<gamepad::GamepadContext> = None; //gamepad::GamepadContext::new()?;
 
         let ctx = Context {
             conf,

--- a/src/event.rs
+++ b/src/event.rs
@@ -230,20 +230,27 @@ where
                 Event::Suspended(_) => (),
             }
         });
-        while let Some(gilrs::Event { id, event, .. }) = ctx.gamepad_context.gilrs.next_event() {
-            match event {
-                gilrs::EventType::ButtonPressed(button, _) => {
-                    state.controller_button_down_event(ctx, button, id);
-                }
-                gilrs::EventType::ButtonReleased(button, _) => {
-                    state.controller_button_up_event(ctx, button, id);
-                }
-                gilrs::EventType::AxisChanged(axis, value, _) => {
-                    state.controller_axis_event(ctx, axis, value, id);
-                }
-                _ => {}
+
+        let mut events = Vec::new();
+        let _ = ctx.gamepad_context.as_mut().map(|gamepad_context| {
+            while let Some(gilrs::Event { id, event, .. }) = gamepad_context.gilrs.next_event() {
+                events.push((event, id));
             }
-        }
+        });
+
+        events.iter().for_each(|(event, id)| match event {
+            gilrs::EventType::ButtonPressed(button, _) => {
+                state.controller_button_down_event(ctx, *button, *id);
+            }
+            gilrs::EventType::ButtonReleased(button, _) => {
+                state.controller_button_up_event(ctx, *button, *id);
+            }
+            gilrs::EventType::AxisChanged(axis, value, _) => {
+                state.controller_axis_event(ctx, *axis, *value, *id);
+            }
+            _ => {}
+        });
+
         state.update(ctx)?;
         state.draw(ctx)?;
     }

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -31,7 +31,11 @@ impl GamepadContext {
 
 /// returns the `Gamepad` associated with an id.
 pub fn gamepad(ctx: &Context, id: usize) -> Option<&Gamepad> {
-    ctx.gamepad_context.gilrs.get(id)
+    if let Some(gamepad_context) = &ctx.gamepad_context {
+        gamepad_context.gilrs.get(id)
+    } else {
+        None
+    }
 }
 
 // Properties gamepads might want:


### PR DESCRIPTION
By making `game_pad` optional. 