### PR TITLE
Adds a new feature sdl2-bundled.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ bzip2 = ["zip/bzip2"]
 default = ["bzip2"]
 mint = ["nalgebra/mint"]
 multithread-image-decoding = ["image/hdr", "image/jpeg_rayon"]
+# Enables the sdl2 bundled mode.
+# This allows the user not to install sdl2 via the package manager
+# having cargo compile it from sources instead.
+sdl2-bundled = ["sdl2/bundled"]
 
 [dependencies]
 rusttype = "0.5"

--- a/docs/BuildingForEveryPlatform.md
+++ b/docs/BuildingForEveryPlatform.md
@@ -50,6 +50,16 @@ on!
 
 # Linux
 
+## All versions (bundled mode)
+
+The SDL crate provides a feature to download and compile the correct version of SDL.
+To do this, it is sufficient to enable the sdl2-bundled feature:
+
+```toml
+[dependencies]
+ggez = {version = "0.4", features = ["sdl2-bundled"]}
+```
+
 ## Debian
 
 Very easy, just install the required dev packages:


### PR DESCRIPTION
This enables the sdl2 bundled feature which allows cargo to
automatically download and build sdl2 from source, forgoing the need to
install native dependencies.