### PR TITLE
Make GamepadContext a trait object.

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -288,6 +288,16 @@ impl NumSamples {
     }
 }
 
+/// Defines which submodules to enable in ggez.
+/// If one tries to use a submodule that is not enabled,
+/// it will panic.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, SmartDefault)]
+pub struct ModuleConf {
+    /// The gamepad input module.
+    #[default = r#"true"#]
+    pub gamepad: bool,
+}
+
 /// A structure containing configuration data
 /// for the game engine.
 ///
@@ -308,6 +318,8 @@ pub struct Conf {
     pub window_setup: WindowSetup,
     /// Backend configuration
     pub backend: Backend,
+    /// Which modules to enable.
+    pub modules: ModuleConf,
 }
 
 impl Conf {

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,7 +36,7 @@ pub struct Context {
     /// Mouse context
     pub mouse_context: mouse::MouseContext,
     /// Gamepad context
-    pub gamepad_context: gamepad::GamepadContext,
+    pub gamepad_context: Box<dyn gamepad::GamepadContext>,
 
     /// The Conf object the Context was created with
     pub conf: conf::Conf,
@@ -74,7 +74,11 @@ impl Context {
         )?;
         let mouse_context = mouse::MouseContext::new();
         let keyboard_context = keyboard::KeyboardContext::new();
-        let gamepad_context = gamepad::GamepadContext::new()?;
+        let gamepad_context: Box<dyn gamepad::GamepadContext> = if conf.modules.gamepad {
+            Box::new(gamepad::GilrsGamepadContext::new()?)
+        } else {
+            Box::new(gamepad::NullGamepadContext::default())
+        };
 
         let ctx = Context {
             conf,

--- a/src/event.rs
+++ b/src/event.rs
@@ -230,7 +230,7 @@ where
                 Event::Suspended(_) => (),
             }
         });
-        while let Some(gilrs::Event { id, event, .. }) = ctx.gamepad_context.gilrs.next_event() {
+        while let Some(gilrs::Event { id, event, .. }) = ctx.gamepad_context.next_event() {
             match event {
                 gilrs::EventType::ButtonPressed(button, _) => {
                     state.controller_button_down_event(ctx, button, id);

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -31,15 +31,16 @@
 //!
 //!     fn draw(&mut self, ctx: &mut Context) -> GameResult {
 //!         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
-//!         // Draw a circle at `position_x`.
-//!         graphics::circle(
+//!         // Create a circle at `position_x` and draw
+//!         let circle = graphics::Mesh::new_circle(
 //!             ctx,
-//!             graphics::WHITE,
 //!             graphics::DrawMode::Fill,
 //!             na::Point2::new(self.position_x, 380.0),
 //!             100.0,
 //!             2.0,
+//!             graphics::WHITE,
 //!         )?;
+//!         graphics::draw(ctx, &circle, graphics::DrawParam::default())?;
 //!         graphics::present(ctx)?;
 //!         timer::yield_now();
 //!         Ok(())
@@ -51,7 +52,7 @@
 //!             KeyCode::Q => {
 //!                 if mods.contains(KeyMods::SHIFT & KeyMods::CTRL) {
 //!                     println!("Terminating!");
-//!                     ctx.quit();
+//!                     ggez::quit(ctx);
 //!                 } else if mods.contains(KeyMods::SHIFT) || mods.contains(KeyMods::CTRL) {
 //!                     println!("You need to hold both Shift and Control to quit.");
 //!                 } else {


### PR DESCRIPTION
Contrast #481 

This should hopefully do the same thing more cleanly, allowing you to switch from `GilrsGamepadContext` to `NullGamepadContext` just by changing a flag in `Conf`.  Please test it and make sure it works properly, I don't have a mac to try it on!