### PR TITLE
[WIP] Implement errors using `failure` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ multithread-image-decoding = ["image/hdr", "image/jpeg_rayon"]
 bitflags = "1.0"
 zip = { version = "0.4", default-features = false }
 app_dirs2 = "2"
+failure = "0.1"
+failure_derive = "0.1"
 gfx = "0.17"
 gfx_device_gl = "0.15"
 gfx_glyph = "0.12"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,13 +2,14 @@
 
 use std;
 use std::error::Error;
-use std::fmt;
+use std::fmt::{self, Display};
 
 use gfx;
 use glutin;
 use winit;
 
 use app_dirs2::AppDirsError;
+use failure::{self, Backtrace, Fail};
 use gilrs;
 use image;
 use lyon;
@@ -16,68 +17,124 @@ use rodio::decoder::DecoderError;
 use toml;
 use zip;
 
-/// An enum containing all kinds of game framework errors.
 #[derive(Debug)]
-pub enum GameError {
+pub struct GameError {
+    inner: failure::Context<GameErrorKind>,
+}
+
+impl GameError {
+    pub fn kind(&self) -> GameErrorKind {
+        *self.inner.get_context()
+    }
+}
+
+impl Fail for GameError {
+    fn cause(&self) -> Option<&dyn Fail> {
+        self.inner.cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
+    }
+}
+
+impl Display for GameError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.inner, f)
+    }
+}
+
+impl From<GameErrorKind> for GameError {
+    fn from(kind: GameErrorKind) -> Self {
+        Self {
+            inner: failure::Context::new(kind),
+        }
+    }
+}
+
+impl From<failure::Context<GameErrorKind>> for GameError {
+    fn from(inner: failure::Context<GameErrorKind>) -> Self {
+        Self { inner }
+    }
+}
+
+/// An enum containing all kinds of game framework errors.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+pub enum GameErrorKind {
     /// An error in the filesystem layout
-    FilesystemError(String),
+    #[fail(display = "A filesystem error occurred.")]
+    FilesystemError,
     /// An error in the config file
-    ConfigError(String),
+    #[fail(display = "A configuration error occurred.")]
+    ConfigError,
     /// Happens when an `EventsLoopProxy` attempts to
     /// wake up an `EventsLoop` that no longer exists.
-    EventLoopError(String),
+    #[fail(display = "An event loop error occurred.")]
+    EventLoopError,
     /// An error trying to load a resource, such as getting an invalid image file.
-    ResourceLoadError(String),
+    #[fail(display = "A resource load error occurred.")]
+    ResourceLoadError,
     /// Unable to find a resource; the Vec is the paths it searched for and associated errors
-    ResourceNotFound(String, Vec<(std::path::PathBuf, GameError)>),
+    #[fail(display = "An resource not found error occurred.")]
+    ResourceNotFound,
     /// Something went wrong in the renderer
-    RenderError(String),
+    #[fail(display = "A render error occurred.")]
+    RenderError,
     /// Something went wrong in the audio playback
-    AudioError(String),
+    #[fail(display = "An audio error occurred.")]
+    AudioError,
     /// Something went wrong trying to set or get window properties.
-    WindowError(String),
+    #[fail(display = "A window error occurred.")]
+    WindowError,
     /// Something went wrong trying to create a window
-    WindowCreationError(glutin::CreationError),
+    #[fail(display = "A window creation error occurred.")]
+    WindowCreationError,
     /// Something went wrong trying to read from a file
-    IOError(std::io::Error),
+    #[fail(display = "An IO error occurred.")]
+    IOError,
     /// Something went wrong trying to load/render a font
-    FontError(String),
+    #[fail(display = "A font error occurred.")]
+    FontError,
     /// Something went wrong applying video settings.
-    VideoError(String),
+    #[fail(display = "A video error occurred.")]
+    VideoError,
     /// Something went wrong compiling shaders
-    ShaderProgramError(gfx::shade::ProgramError),
+    #[fail(display = "A shader program error occurred.")]
+    ShaderProgramError,
     /// Something went wrong with Gilrs
-    GamepadError(String),
+    #[fail(display = "A gamepad error occurred.")]
+    GamepadError,
     /// Something went wrong with the `lyon` shape-tesselation library.
-    LyonError(String),
+    #[fail(display = "A lyon error occurred.")]
+    LyonError,
 }
 
-impl fmt::Display for GameError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            GameError::ConfigError(ref s) => write!(f, "Config error: {}", s),
-            GameError::ResourceLoadError(ref s) => write!(f, "Error loading resource: {}", s),
-            GameError::ResourceNotFound(ref s, ref paths) => write!(
-                f,
-                "Resource not found: {}, searched in paths {:?}",
-                s, paths
-            ),
-            GameError::WindowError(ref e) => write!(f, "Window creation error: {}", e),
-            _ => write!(f, "GameError {:?}", self),
-        }
-    }
-}
+// impl fmt::Display for GameError {
+//     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//         match *self {
+//             GameError::ConfigError(ref s) => write!(f, "Config error: {}", s),
+//             GameError::ResourceLoadError(ref s) => write!(f, "Error loading resource: {}", s),
+//             GameError::ResourceNotFound(ref s, ref paths) => write!(
+//                 f,
+//                 "Resource not found: {}, searched in paths {:?}",
+//                 s, paths
+//             ),
+//             GameError::WindowError(ref e) => write!(f, "Window creation error: {}", e),
+//             _ => write!(f, "GameError {:?}", self),
+//         }
+//     }
+// }
 
-impl Error for GameError {
-    fn cause(&self) -> Option<&dyn Error> {
-        match *self {
-            GameError::WindowCreationError(ref e) => Some(e),
-            GameError::IOError(ref e) => Some(e),
-            GameError::ShaderProgramError(ref e) => Some(e),
-            _ => None,
-        }
-    }
-}
+// impl Error for GameError {
+//     fn cause(&self) -> Option<&dyn Error> {
+//         match *self {
+//             GameError::WindowCreationError(ref e) => Some(e),
+//             GameError::IOError(ref e) => Some(e),
+//             GameError::ShaderProgramError(ref e) => Some(e),
+//             _ => None,
+//         }
+//     }
+// }
 
 /// A convenient result type consisting of a return type and a `GameError`
 pub type GameResult<T = ()> = Result<T, GameError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,9 @@
 #[macro_use]
 extern crate bitflags;
 extern crate app_dirs2;
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 #[macro_use]
 extern crate gfx;
 extern crate gfx_device_gl;


### PR DESCRIPTION
# :construction: WORK IN PROGRESS :construction: 

This PR makes use of the [`failure`](https://rust-lang-nursery.github.io/failure/intro.html) crate for handling errors.

Closes #421.