### PR TITLE
Expose module configuration through the ContextBuilder

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -301,6 +301,20 @@ pub struct ModuleConf {
     pub audio: bool,
 }
 
+impl ModuleConf {
+    /// Sets whether or not to enable the gamepad input module.
+    pub fn gamepad(mut self, gamepad: bool) -> Self {
+        self.gamepad = gamepad;
+        self
+    }
+
+    /// Sets whether or not to enable the audio module.
+    pub fn audio(mut self, audio: bool) -> Self {
+        self.audio = audio;
+        self
+    }
+}
+
 /// A structure containing configuration data
 /// for the game engine.
 ///

--- a/src/context.rs
+++ b/src/context.rs
@@ -208,6 +208,12 @@ impl ContextBuilder {
         self
     }
 
+    /// Sets the modules configuration.
+    pub fn modules(mut self, modules: conf::ModuleConf) -> Self {
+        self.conf.modules = modules;
+        self
+    }
+
     /// Sets all the config options, overriding any previous
     /// ones from `window_setup()`, `window_mode()` and `backend()`.
     pub fn conf(mut self, conf: conf::Conf) -> Self {


### PR DESCRIPTION
This PR exposes the ability to modify the module configuration via the `ContextBuilder`.

Related: #480