### PR TITLE
Only poll for gamepad events when the gamepad module is enabled

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -230,18 +230,20 @@ where
                 Event::Suspended(_) => (),
             }
         });
-        while let Some(gilrs::Event { id, event, .. }) = ctx.gamepad_context.next_event() {
-            match event {
-                gilrs::EventType::ButtonPressed(button, _) => {
-                    state.controller_button_down_event(ctx, button, id);
+        if ctx.conf.modules.gamepad {
+            while let Some(gilrs::Event { id, event, .. }) = ctx.gamepad_context.next_event() {
+                match event {
+                    gilrs::EventType::ButtonPressed(button, _) => {
+                        state.controller_button_down_event(ctx, button, id);
+                    }
+                    gilrs::EventType::ButtonReleased(button, _) => {
+                        state.controller_button_up_event(ctx, button, id);
+                    }
+                    gilrs::EventType::AxisChanged(axis, value, _) => {
+                        state.controller_axis_event(ctx, axis, value, id);
+                    }
+                    _ => {}
                 }
-                gilrs::EventType::ButtonReleased(button, _) => {
-                    state.controller_button_up_event(ctx, button, id);
-                }
-                gilrs::EventType::AxisChanged(axis, value, _) => {
-                    state.controller_axis_event(ctx, axis, value, id);
-                }
-                _ => {}
             }
         }
         state.update(ctx)?;


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/ggez/ggez/issues/486#issuecomment-433589897), trying to run the `devel` branch on OSX causes a panic even when the gamepad module is disabled:

```
thread 'main' panicked at 'Gamepad module disabled', /Users/maxdeviant/.cargo/git/checkouts/ggez-ed9d3cec31fdee53/c5c6dcb/src/input/gamepad.rs:59:9
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
   1: std::sys_common::backtrace::print
   2: std::panicking::default_hook::{{closure}}
   3: std::panicking::default_hook
   4: std::panicking::rust_panic_with_hook
   5: std::panicking::begin_panic
   6: <ggez::input::gamepad::NullGamepadContext as ggez::input::gamepad::GamepadContext>::next_event
   7: ggez::event::run
   8: hitheryon::main
   9: std::rt::lang_start::{{closure}}
  10: std::panicking::try::do_call
  11: __rust_maybe_catch_panic
  12: std::rt::lang_start_internal
  13: main
```

This PR checks if the gamepad module is enabled before polling for gamepad events.