### PR TITLE
Update keyboard context using `WindowEvent`s rather than `DeviceEvent`s

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -130,19 +130,16 @@ impl Context {
                     };
                     self.mouse_context.set_button(button, pressed);
                 }
-                _ => (),
-            },
-            winit_event::Event::DeviceEvent { event, .. } => match event {
-                winit_event::DeviceEvent::MouseMotion { delta: (x, y) } => {
-                    self.mouse_context
-                        .set_last_delta(Point2::new(x as f32, y as f32));
-                }
-                winit_event::DeviceEvent::Key(winit_event::KeyboardInput {
-                    state,
-                    virtual_keycode: Some(keycode),
-                    modifiers,
+                winit_event::WindowEvent::KeyboardInput {
+                    input:
+                        winit::KeyboardInput {
+                            state,
+                            virtual_keycode: Some(keycode),
+                            modifiers,
+                            ..
+                        },
                     ..
-                }) => {
+                } => {
                     let pressed = match state {
                         winit_event::ElementState::Pressed => true,
                         winit_event::ElementState::Released => false,
@@ -150,6 +147,13 @@ impl Context {
                     self.keyboard_context
                         .set_modifiers(keyboard::KeyMods::from(modifiers));
                     self.keyboard_context.set_key(keycode, pressed);
+                }
+                _ => (),
+            },
+            winit_event::Event::DeviceEvent { event, .. } => match event {
+                winit_event::DeviceEvent::MouseMotion { delta: (x, y) } => {
+                    self.mouse_context
+                        .set_last_delta(Point2::new(x as f32, y as f32));
                 }
                 _ => (),
             },


### PR DESCRIPTION
This PR updates the event processing to use `WindowEvent`s rather than `DeviceEvent`s for updating the keyboard context.

The motivation behind this is that the `DeviceEvent::Key` event only fires when a key is actually pressed or released, not held down. This was causing the key repeat calculation code to break, because it was never able to detect a key being held down repeatedly.

As an aside, I don't know if we should make the same change for mouse input.

From the [winit::DeviceEvent docs](https://docs.rs/winit/0.17.2/winit/enum.DeviceEvent.html):

>Represents raw hardware events that are not associated with any particular window.
>
>Useful for interactions that diverge significantly from a conventional 2D GUI, such as 3D camera or first-person game controls. Many physical actions, such as mouse movement, can produce both device and window events. Because window events typically arise from virtual devices (corresponding to GUI cursors and keyboard focus) the device IDs may not match.
>
>Note that these events are delivered regardless of input focus.

Fixes #503.