### PR TITLE
chore: update to `glutin` v0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ gfx_glyph = "0.12"
 gfx_window_glutin = "0.27"
 glutin = "0.19"
 winit = { version = "0.18", features = ["icon_loading"] }
-image = {version = "0.19", default-features = false, features = ["gif_codec", "jpeg", "ico", "png_codec", "pnm",
+image = {version = "0.20.1", default-features = false, features = ["gif_codec", "jpeg", "ico", "png_codec", "pnm",
 "tga", "tiff", "webp", "bmp", "dxt", ] }
 rodio = "0.8"
 serde = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ app_dirs2 = "2"
 gfx = "0.17"
 gfx_device_gl = "0.15"
 gfx_glyph = "0.12"
-gfx_window_glutin = "0.26"
-glutin = "0.18"
+gfx_window_glutin = "0.27"
+glutin = "0.19"
+winit = { version = "0.18", features = ["icon_loading"] }
 image = {version = "0.19", default-features = false, features = ["gif_codec", "jpeg", "ico", "png_codec", "pnm",
 "tga", "tiff", "webp", "bmp", "dxt", ] }
 rodio = "0.8"
@@ -49,7 +50,6 @@ smart-default = "0.2"
 nalgebra = {version = "0.16", features = ["mint"] }
 # Has to be the same version of mint that nalgebra uses here.
 mint = "0.5"
-winit = { version = "0.17", features = ["icon_loading"] }
 gilrs = "0.6"
 
 [dev-dependencies]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,4 @@
-use winit;
-use winit::dpi;
+use winit::{self, dpi};
 
 use std::fmt;
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -16,8 +16,7 @@
 //! See the `eventloop` example for an implementation.
 
 use gilrs;
-use winit;
-use winit::dpi;
+use winit::{self, dpi};
 
 /// A mouse button.
 pub use winit::MouseButton;

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -83,7 +83,7 @@ where
 
     /// Create a new GraphicsContext
     pub(crate) fn new(
-        events_loop: &glutin::EventsLoop,
+        events_loop: &winit::EventsLoop,
         window_setup: &WindowSetup,
         window_mode: WindowMode,
         backend: B,
@@ -121,7 +121,7 @@ where
             .with_pixel_format(8, 8)
             .with_vsync(window_setup.vsync);
 
-        let mut window_builder = glutin::WindowBuilder::new()
+        let mut window_builder = winit::WindowBuilder::new()
             .with_title(window_setup.title.clone())
             .with_transparency(window_setup.transparent)
             .with_resizable(window_mode.resizable);
@@ -154,6 +154,7 @@ where
         {
             // TODO: improve.
             // Log a bunch of OpenGL state info pulled out of winit and gfx
+            use glutin::GlContext;
             let _api = window.get_api();
             let dpi::LogicalSize {
                 width: w,

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -16,7 +16,7 @@ use gfx::texture;
 use gfx::Device;
 use gfx::Factory;
 use gfx_device_gl;
-use glutin::{self, GlContext};
+use glutin;
 
 use crate::conf;
 use crate::conf::WindowMode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@ extern crate serde_derive;
 extern crate smart_default;
 extern crate gilrs;
 extern crate toml;
-extern crate winit;
 extern crate zip;
 
 pub mod audio;


### PR DESCRIPTION
Should fix #478 (for the `devel` branch)

This PR contains the initial changes required to update the `glutin` and `winit` dependencies.

Note that this won't compile because we need to wait on some dependencies:

* `gfx_window_glutin`: https://github.com/gfx-rs/gfx/pull/2468