### PR TITLE
Update README.md with a mention of the 'hello ggez' guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ or `Conf` object, and then call `event::run()` with
 the `Context` and an instance of your `EventHandler` to run your game's
 main loop.
 
+## Getting started
+
+For a quick tutorial on ggez, see the [Hello ggez](https://github.com/ggez/ggez/blob/master/docs/guides/HelloGgez.md) guide in the `docs/` directory.
+
 ## Examples
 
 See the `examples/` directory in the source.  Most examples show off


### PR DESCRIPTION
Added a suggestion to read the `hello ggez` guide for new users. It's better to let the to-be users immediately know that there exists a 'getting started' tutorial such as this. It may be hard to find otherwise, as it requires manually looking at the `docs/` folder to find it.