### PR TITLE
Change `use` statement so it compiles

### DIFF
--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use std::path;
 
 use gfx;
-use image;
+use ::image;
 
 use crate::context::{Context, DebugId};
 use crate::error::GameError;


### PR DESCRIPTION
I couldn't compile this before because rust 2018 messed this up.