### PR TITLE
Remove the generic argument from Drawable::draw

### DIFF
--- a/examples/01_super_simple.rs
+++ b/examples/01_super_simple.rs
@@ -3,7 +3,7 @@
 extern crate ggez;
 
 use ggez::event;
-use ggez::graphics::{self, Drawable};
+use ggez::graphics;
 use ggez::nalgebra as na;
 use ggez::{Context, GameResult};
 
@@ -27,15 +27,15 @@ impl event::EventHandler for MainState {
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
-        graphics::Mesh::new_circle(
+        let circle = graphics::Mesh::new_circle(
             ctx,
             graphics::DrawMode::Fill,
             na::Point2::new(self.pos_x, 380.0),
             100.0,
             2.0,
             graphics::WHITE,
-        )?
-        .draw(ctx, (na::Point2::new(0.0, 0.0),))?;
+        )?;
+        graphics::draw(ctx, &circle, (na::Point2::new(0.0, 0.0),))?;
 
         graphics::present(ctx)?;
         Ok(())

--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -20,7 +20,6 @@ extern crate rand;
 // Next we need to actually `use` the pieces of ggez that we are going
 // to need frequently.
 use ggez::event::{KeyCode, KeyMods};
-use ggez::graphics::Drawable;
 use ggez::{event, graphics, Context, GameResult};
 
 // We'll bring in some things from `std` to help us in the future.
@@ -225,8 +224,9 @@ impl Food {
         // since we implemented `From<GridPosition>` for `Rect` earlier.
         // graphics::rectangle(ctx, color, graphics::DrawMode::Fill, self.pos.into())
 
-        graphics::Mesh::new_rectangle(ctx, graphics::DrawMode::Fill, self.pos.into(), color)?
-            .draw(ctx, (ggez::mint::Point2 { x: 0.0, y: 0.0 },))
+        let rectangle =
+            graphics::Mesh::new_rectangle(ctx, graphics::DrawMode::Fill, self.pos.into(), color)?;
+        graphics::draw(ctx, &rectangle, (ggez::mint::Point2 { x: 0.0, y: 0.0 },))
     }
 }
 
@@ -345,23 +345,23 @@ impl Snake {
             // TODO: Fix colors
             // graphics::set_color(ctx, )?;
             // and then draw the Rect that we convert that Segment's position into
-            graphics::Mesh::new_rectangle(
+            let rectangle = graphics::Mesh::new_rectangle(
                 ctx,
                 graphics::DrawMode::Fill,
                 seg.pos.into(),
                 [1.0, 0.5, 0.0, 1.0].into(),
-            )?
-            .draw(ctx, (ggez::mint::Point2 { x: 0.0, y: 0.0 },))?;
+            )?;
+            graphics::draw(ctx, &rectangle, (ggez::mint::Point2 { x: 0.0, y: 0.0 },))?;
         }
         // And then we do the same for the head, instead making it fully red to distinguish it.
         // TODO: Fix colors
-        graphics::Mesh::new_rectangle(
+        let rectangle = graphics::Mesh::new_rectangle(
             ctx,
             graphics::DrawMode::Fill,
             self.head.pos.into(),
             [1.0, 0.5, 0.0, 1.0].into(),
-        )?
-        .draw(ctx, (ggez::mint::Point2 { x: 0.0, y: 0.0 },))?;
+        )?;
+        graphics::draw(ctx, &rectangle, (ggez::mint::Point2 { x: 0.0, y: 0.0 },))?;
         Ok(())
     }
 }

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -59,16 +59,15 @@ pub fn main() -> GameResult {
 
         // Draw
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
-        use ggez::graphics::Drawable;
-        graphics::Mesh::new_circle(
+        let circle = graphics::Mesh::new_circle(
             ctx,
             DrawMode::Fill,
             cgmath::Point2::new(0.0, 0.0),
             100.0,
             2.0,
             graphics::WHITE,
-        )?
-        .draw(ctx, (cgmath::Point2::new(position, 380.0),))?;
+        )?;
+        graphics::draw(ctx, &circle, (cgmath::Point2::new(position, 380.0),))?;
         graphics::present(ctx)?;
         ggez::timer::yield_now();
     }

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -9,7 +9,7 @@ extern crate structopt;
 
 use ggez::conf;
 use ggez::event::{self, KeyCode, KeyMods};
-use ggez::graphics::{self, DrawMode, Drawable};
+use ggez::graphics::{self, DrawMode};
 use ggez::timer;
 use ggez::{Context, GameResult};
 use structopt::StructOpt;

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -5,7 +5,7 @@ extern crate rand;
 use ggez::audio;
 use ggez::event;
 use ggez::filesystem;
-use ggez::graphics::{self, Color, Drawable};
+use ggez::graphics::{self, Color};
 use ggez::timer;
 use ggez::{Context, GameResult};
 use std::env;
@@ -96,13 +96,13 @@ impl event::EventHandler for MainState {
         graphics::draw(ctx, &self.text, (dest_point, 0.0, color))?;
 
         let dest_point2 = cgmath::Point2::new(0.0, 256.0);
-        graphics::Mesh::new_rectangle(
+        let rectangle = graphics::Mesh::new_rectangle(
             ctx,
             graphics::DrawMode::Fill,
             graphics::Rect::new(0.0, 256.0, 500.0, 32.0),
             Color::from((0, 0, 0, 255)),
-        )?
-        .draw(ctx, (ggez::nalgebra::Point2::new(0.0, 0.0),))?;
+        )?;
+        graphics::draw(ctx, &rectangle, (ggez::nalgebra::Point2::new(0.0, 0.0),))?;
         graphics::draw(
             ctx,
             &self.pixel_sized_text,

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -4,7 +4,7 @@ extern crate cgmath;
 extern crate ggez;
 
 use ggez::event::{self, Axis, Button, KeyCode, KeyMods, MouseButton};
-use ggez::graphics::{self, DrawMode, Drawable};
+use ggez::graphics::{self, DrawMode};
 use ggez::input;
 use ggez::{Context, GameResult};
 
@@ -41,7 +41,7 @@ impl event::EventHandler for MainState {
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
-        graphics::Mesh::new_rectangle(
+        let rectangle = graphics::Mesh::new_rectangle(
             ctx,
             DrawMode::Fill,
             graphics::Rect {
@@ -51,8 +51,8 @@ impl event::EventHandler for MainState {
                 h: 300.0,
             },
             graphics::WHITE,
-        )?
-        .draw(ctx, (ggez::nalgebra::Point2::new(0.0, 0.0),))?;
+        )?;
+        graphics::draw(ctx, &rectangle, (ggez::nalgebra::Point2::new(0.0, 0.0),))?;
         graphics::present(ctx)?;
         Ok(())
     }

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -6,7 +6,7 @@ extern crate cgmath;
 extern crate ggez;
 
 use ggez::event;
-use ggez::graphics::{self, DrawMode, Drawable};
+use ggez::graphics::{self, DrawMode};
 use ggez::timer;
 use ggez::{Context, GameResult};
 use std::env;
@@ -47,39 +47,39 @@ impl event::EventHandler for MainState {
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
-        graphics::Mesh::new_circle(
+        let circle = graphics::Mesh::new_circle(
             ctx,
             DrawMode::Fill,
             cgmath::Point2::new(100.0, 300.0),
             100.0,
             2.0,
             graphics::WHITE,
-        )?
-        .draw(ctx, (cgmath::Point2::new(0.0, 0.0),))?;
+        )?;
+        graphics::draw(ctx, &circle, (cgmath::Point2::new(0.0, 0.0),))?;
 
         {
             let _lock = graphics::use_shader(ctx, &self.shader);
             self.shader.send(ctx, self.dim)?;
-            graphics::Mesh::new_circle(
+            let circle = graphics::Mesh::new_circle(
                 ctx,
                 DrawMode::Fill,
                 cgmath::Point2::new(400.0, 300.0),
                 100.0,
                 2.0,
                 graphics::WHITE,
-            )?
-            .draw(ctx, (cgmath::Point2::new(0.0, 0.0),))?;
+            )?;
+            graphics::draw(ctx, &circle, (cgmath::Point2::new(0.0, 0.0),))?;
         }
 
-        graphics::Mesh::new_circle(
+        let circle = graphics::Mesh::new_circle(
             ctx,
             DrawMode::Fill,
             cgmath::Point2::new(700.0, 300.0),
             100.0,
             2.0,
             graphics::WHITE,
-        )?
-        .draw(ctx, (cgmath::Point2::new(0.0, 0.0),))?;
+        )?;
+        graphics::draw(ctx, &circle, (cgmath::Point2::new(0.0, 0.0),))?;
 
         graphics::present(ctx)?;
         Ok(())

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -116,11 +116,7 @@ impl Canvas {
 }
 
 impl Drawable for Canvas {
-    fn draw<D>(&self, ctx: &mut Context, param: D) -> GameResult
-    where
-        D: Into<DrawParam>,
-    {
-        let param = param.into();
+    fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult {
         self.debug_id.assert(ctx);
         // Gotta flip the image on the Y axis here
         // to account for OpenGL's origin being at the bottom-left.

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -320,11 +320,7 @@ impl fmt::Debug for Image {
 }
 
 impl Drawable for Image {
-    fn draw<D>(&self, ctx: &mut Context, param: D) -> GameResult
-    where
-        D: Into<DrawParam>,
-    {
-        let param = param.into();
+    fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult {
         self.debug_id.assert(ctx);
 
         let gfx = &mut ctx.gfx_context;

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -640,11 +640,7 @@ impl Mesh {
 }
 
 impl Drawable for Mesh {
-    fn draw<D>(&self, ctx: &mut Context, param: D) -> GameResult
-    where
-        D: Into<DrawParam>,
-    {
-        let param = param.into();
+    fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult {
         self.debug_id.assert(ctx);
         let gfx = &mut ctx.gfx_context;
         gfx.update_instance_properties(param.into())?;

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -954,9 +954,7 @@ pub trait Drawable {
     /// Draws the drawable onto the rendering target.
     ///
     /// ALSO TODO: Expand docs
-    fn draw<D>(&self, ctx: &mut Context, param: D) -> GameResult
-    where
-        D: Into<DrawParam>;
+    fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult;
 
     /// Sets the blend mode to be used when drawing this drawable.
     /// This overrides the general [`graphics::set_blend_mode()`](fn.set_blend_mode.html).

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -151,11 +151,7 @@ impl SpriteBatch {
 }
 
 impl graphics::Drawable for SpriteBatch {
-    fn draw<D>(&self, ctx: &mut Context, param: D) -> GameResult
-    where
-        D: Into<DrawParam>,
-    {
-        let param = param.into();
+    fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult {
         // Awkwardly we must update values on all sprites and such.
         // Also awkwardly we have this chain of colors with differing priorities.
         self.flush(ctx, &self.image)?;

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -359,11 +359,7 @@ impl Text {
 }
 
 impl Drawable for Text {
-    fn draw<D>(&self, ctx: &mut Context, param: D) -> GameResult
-    where
-        D: Into<DrawParam>,
-    {
-        let param = param.into();
+    fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult {
         // Converts fraction-of-bounding-box to screen coordinates, as required by `draw_queued()`.
         queue_text(ctx, self, Point2::new(0.0, 0.0), Some(param.color));
         draw_queued_text(ctx, param)


### PR DESCRIPTION
Closes #556 

Un-nested mesh creation calls because of the conflicting `ctx` arguments:

```text
227 |         graphics::draw(
    |         -------------- first borrow later used by call
228 |             ctx,
    |             --- first mutable borrow occurs here
229 |             &graphics::Mesh::new_rectangle(ctx, graphics::DrawMode::Fill, self.pos.into(), color)?,
    |                                            ^^^ second mutable borrow occurs here
```

What do you think?