### PR TITLE
Drawable::dimensions()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ nalgebra = {version = "0.16", features = ["mint"] }
 # Has to be the same version of mint that nalgebra uses here.
 mint = "0.5"
 gilrs = "0.6"
+approx = "0.3"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -126,6 +126,9 @@ impl Drawable for Canvas {
         self.image.draw(ctx, flipped_param)?;
         Ok(())
     }
+    fn dimensions(&self, _: &mut Context) -> Option<Rect> {
+        Some(self.image.dimensions())
+    }
     fn set_blend_mode(&mut self, mode: Option<BlendMode>) {
         self.image.blend_mode = mode;
     }

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -8,6 +8,7 @@ use crate::context::{Context, DebugId};
 use crate::error::GameError;
 use crate::error::GameResult;
 use crate::filesystem;
+use crate::graphics;
 use crate::graphics::shader::*;
 use crate::graphics::*;
 
@@ -363,6 +364,10 @@ impl Drawable for Image {
             gfx.set_blend_mode(mode)?;
         }
         Ok(())
+    }
+
+    fn dimensions(&self, _: &mut Context) -> Option<graphics::Rect> {
+        Some(self.dimensions())
     }
 
     fn set_blend_mode(&mut self, mode: Option<BlendMode>) {

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -990,51 +990,93 @@ pub fn transform_rect(rect: Rect, param: DrawParam) -> Rect {
 
 #[cfg(test)]
 mod tests {
-    use std::f32::consts::PI;
+    use crate::graphics::{transform_rect, DrawParam, Rect};
     use approx::assert_relative_eq;
-    use crate::graphics::{DrawParam, Rect, transform_rect};
+    use std::f32::consts::PI;
 
     #[test]
     fn headless_test_transform_rect() {
         {
-            let r = Rect { x: 0.0, y: 0.0, w: 1.0, h: 1.0 };
+            let r = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 1.0,
+            };
             let param = DrawParam::new();
             let real = transform_rect(r, param);
             let expected = r;
             assert_relative_eq!(real, expected);
         }
         {
-            let r = Rect { x: -1.0, y: -1.0, w: 2.0, h: 1.0 };
-            let param = DrawParam::new()
-                .scale([0.5, 0.5]);
+            let r = Rect {
+                x: -1.0,
+                y: -1.0,
+                w: 2.0,
+                h: 1.0,
+            };
+            let param = DrawParam::new().scale([0.5, 0.5]);
             let real = transform_rect(r, param);
-            let expected = Rect { x: -0.5, y: -0.5, w: 1.0, h: 0.5 };
+            let expected = Rect {
+                x: -0.5,
+                y: -0.5,
+                w: 1.0,
+                h: 0.5,
+            };
             assert_relative_eq!(real, expected);
         }
         {
-            let r = Rect { x: -1.0, y: -1.0, w: 1.0, h: 1.0 };
-            let param = DrawParam::new()
-                .offset([0.5, 0.5]);
+            let r = Rect {
+                x: -1.0,
+                y: -1.0,
+                w: 1.0,
+                h: 1.0,
+            };
+            let param = DrawParam::new().offset([0.5, 0.5]);
             let real = transform_rect(r, param);
-            let expected = Rect { x: -1.5, y: -1.5, w: 1.0, h: 1.0 };
+            let expected = Rect {
+                x: -1.5,
+                y: -1.5,
+                w: 1.0,
+                h: 1.0,
+            };
             assert_relative_eq!(real, expected);
         }
         {
-            let r = Rect { x: 1.0, y: 0.0, w: 2.0, h: 1.0 };
-            let param = DrawParam::new()
-                .rotation(PI * 0.5);
+            let r = Rect {
+                x: 1.0,
+                y: 0.0,
+                w: 2.0,
+                h: 1.0,
+            };
+            let param = DrawParam::new().rotation(PI * 0.5);
             let real = transform_rect(r, param);
-            let expected = Rect { x: -1.0, y: 1.0, w: 1.0, h: 2.0 };
+            let expected = Rect {
+                x: -1.0,
+                y: 1.0,
+                w: 1.0,
+                h: 2.0,
+            };
             assert_relative_eq!(real, expected);
         }
         {
-            let r = Rect { x: -1.0, y: -1.0, w: 2.0, h: 1.0 };
+            let r = Rect {
+                x: -1.0,
+                y: -1.0,
+                w: 2.0,
+                h: 1.0,
+            };
             let param = DrawParam::new()
                 .scale([0.5, 0.5])
                 .offset([0.0, 1.0])
                 .rotation(PI * 0.5);
             let real = transform_rect(r, param);
-            let expected = Rect { x: 0.5, y: -0.5, w: 0.5, h: 1.0 };
+            let expected = Rect {
+                x: 0.5,
+                y: -0.5,
+                w: 0.5,
+                h: 1.0,
+            };
             assert_relative_eq!(real, expected);
         }
     }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -956,6 +956,12 @@ pub trait Drawable {
     /// ALSO TODO: Expand docs
     fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult;
 
+    /// Returns a bounding box in the form of `Rect`.
+    ///
+    /// It returns `Option` because some `Drawable`s may have no bbox
+    /// (an empty `SpriteBatch` for example).
+    fn dimensions(&self, ctx: &mut Context) -> Option<Rect>;
+
     /// Sets the blend mode to be used when drawing this drawable.
     /// This overrides the general [`graphics::set_blend_mode()`](fn.set_blend_mode.html).
     /// If `None` is set, defers to the blend mode set by
@@ -966,5 +972,70 @@ pub trait Drawable {
     fn blend_mode(&self) -> Option<BlendMode>;
 }
 
+/// Applies `DrawParam` to `Rect`.
+pub fn transform_rect(rect: Rect, param: DrawParam) -> Rect {
+    let w = param.src.w * param.scale.x * rect.w;
+    let h = param.src.h * param.scale.y * rect.h;
+    let offset = Vector2::new(w * param.offset.x, h * param.offset.y);
+    let dest = param.dest - offset;
+    let mut r = Rect {
+        w,
+        h,
+        x: dest.x + rect.x * param.scale.x,
+        y: dest.y + rect.y * param.scale.y,
+    };
+    r.rotate(param.rotation);
+    r
+}
+
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use std::f32::consts::PI;
+    use approx::assert_relative_eq;
+    use crate::graphics::{DrawParam, Rect, transform_rect};
+
+    #[test]
+    fn headless_test_transform_rect() {
+        {
+            let r = Rect { x: 0.0, y: 0.0, w: 1.0, h: 1.0 };
+            let param = DrawParam::new();
+            let real = transform_rect(r, param);
+            let expected = r;
+            assert_relative_eq!(real, expected);
+        }
+        {
+            let r = Rect { x: -1.0, y: -1.0, w: 2.0, h: 1.0 };
+            let param = DrawParam::new()
+                .scale([0.5, 0.5]);
+            let real = transform_rect(r, param);
+            let expected = Rect { x: -0.5, y: -0.5, w: 1.0, h: 0.5 };
+            assert_relative_eq!(real, expected);
+        }
+        {
+            let r = Rect { x: -1.0, y: -1.0, w: 1.0, h: 1.0 };
+            let param = DrawParam::new()
+                .offset([0.5, 0.5]);
+            let real = transform_rect(r, param);
+            let expected = Rect { x: -1.5, y: -1.5, w: 1.0, h: 1.0 };
+            assert_relative_eq!(real, expected);
+        }
+        {
+            let r = Rect { x: 1.0, y: 0.0, w: 2.0, h: 1.0 };
+            let param = DrawParam::new()
+                .rotation(PI * 0.5);
+            let real = transform_rect(r, param);
+            let expected = Rect { x: -1.0, y: 1.0, w: 1.0, h: 2.0 };
+            assert_relative_eq!(real, expected);
+        }
+        {
+            let r = Rect { x: -1.0, y: -1.0, w: 2.0, h: 1.0 };
+            let param = DrawParam::new()
+                .scale([0.5, 0.5])
+                .offset([0.0, 1.0])
+                .rotation(PI * 0.5);
+            let real = transform_rect(r, param);
+            let expected = Rect { x: 0.5, y: -0.5, w: 0.5, h: 1.0 };
+            assert_relative_eq!(real, expected);
+        }
+    }
+}

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -197,14 +197,16 @@ impl graphics::Drawable for SpriteBatch {
             return None;
         }
         let dimensions = self.image.dimensions();
-        self.sprites.iter().map(|&param| transform_rect(dimensions, param))
-        .fold(None, |acc: Option<Rect>, rect| {
-            Some(if let Some(acc) = acc {
-                acc.combine_with(rect)
-            } else {
-                rect
+        self.sprites
+            .iter()
+            .map(|&param| transform_rect(dimensions, param))
+            .fold(None, |acc: Option<Rect>, rect| {
+                Some(if let Some(acc) = acc {
+                    acc.combine_with(rect)
+                } else {
+                    rect
+                })
             })
-        })
     }
     fn set_blend_mode(&mut self, mode: Option<BlendMode>) {
         self.blend_mode = mode;

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -15,7 +15,7 @@ use crate::error;
 use crate::error::GameResult;
 use crate::graphics::shader::BlendMode;
 use crate::graphics::types::FilterMode;
-use crate::graphics::{self, BackendSpec, DrawParam, DrawTransform};
+use crate::graphics::{self, transform_rect, BackendSpec, DrawParam, DrawTransform, Rect};
 use gfx;
 use gfx::Factory;
 
@@ -191,6 +191,20 @@ impl graphics::Drawable for SpriteBatch {
         gfx.calculate_transform_matrix();
         gfx.update_globals()?;
         Ok(())
+    }
+    fn dimensions(&self, _ctx: &mut Context) -> Option<Rect> {
+        if self.sprites.is_empty() {
+            return None;
+        }
+        let dimensions = self.image.dimensions();
+        self.sprites.iter().map(|&param| transform_rect(dimensions, param))
+        .fold(None, |acc: Option<Rect>, rect| {
+            Some(if let Some(acc) = acc {
+                acc.combine_with(rect)
+            } else {
+                rect
+            })
+        })
     }
     fn set_blend_mode(&mut self, mode: Option<BlendMode>) {
         self.blend_mode = mode;

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -365,6 +365,16 @@ impl Drawable for Text {
         draw_queued_text(ctx, param)
     }
 
+    fn dimensions(&self, ctx: &mut Context) -> Option<Rect> {
+        let (w, h) = self.dimensions(ctx);
+        Some(Rect {
+            w: w as _,
+            h: h as _,
+            x: 0.0,
+            y: 0.0,
+        })
+    }
+
     fn set_blend_mode(&mut self, mode: Option<BlendMode>) {
         self.blend_mode = mode;
     }

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -174,10 +174,10 @@ impl approx::AbsDiffEq for Rect {
     }
 
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        f32::abs_diff_eq(&self.x, &other.x,  epsilon)
-            && f32::abs_diff_eq(&self.y, &other.y,  epsilon)
-            && f32::abs_diff_eq(&self.w, &other.w,  epsilon)
-            && f32::abs_diff_eq(&self.h, &other.h,  epsilon)
+        f32::abs_diff_eq(&self.x, &other.x, epsilon)
+            && f32::abs_diff_eq(&self.y, &other.y, epsilon)
+            && f32::abs_diff_eq(&self.w, &other.w, epsilon)
+            && f32::abs_diff_eq(&self.h, &other.h, epsilon)
     }
 }
 
@@ -186,11 +186,16 @@ impl approx::RelativeEq for Rect {
         f32::default_max_relative()
     }
 
-    fn relative_eq(&self, other: &Self, epsilon: Self::Epsilon, max_relative: Self::Epsilon) -> bool {
-        f32::relative_eq(&self.x, &other.x,  epsilon, max_relative)
-            && f32::relative_eq(&self.y, &other.y,  epsilon, max_relative)
-            && f32::relative_eq(&self.w, &other.w,  epsilon, max_relative)
-            && f32::relative_eq(&self.h, &other.h,  epsilon, max_relative)
+    fn relative_eq(
+        &self,
+        other: &Self,
+        epsilon: Self::Epsilon,
+        max_relative: Self::Epsilon,
+    ) -> bool {
+        f32::relative_eq(&self.x, &other.x, epsilon, max_relative)
+            && f32::relative_eq(&self.y, &other.y, epsilon, max_relative)
+            && f32::relative_eq(&self.w, &other.w, epsilon, max_relative)
+            && f32::relative_eq(&self.h, &other.h, epsilon, max_relative)
     }
 }
 
@@ -485,9 +490,9 @@ pub use gfx::texture::WrapMode;
 
 #[cfg(test)]
 mod tests {
-    use std::f32::consts::PI;
-    use approx::assert_relative_eq;
     use super::*;
+    use approx::assert_relative_eq;
+    use std::f32::consts::PI;
 
     #[test]
     fn headless_test_color_conversions() {
@@ -575,24 +580,64 @@ mod tests {
     #[test]
     fn headless_test_rect_combine_with() {
         {
-            let a = Rect { x: 0.0, y: 0.0, w: 1.0, h: 1.0 };
-            let b = Rect { x: 0.0, y: 0.0, w: 1.0, h: 1.0 };
+            let a = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 1.0,
+            };
+            let b = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 1.0,
+            };
             let c = a.combine_with(b);
             assert_relative_eq!(a, b);
             assert_relative_eq!(a, c);
         }
         {
-            let a = Rect { x: 0.0, y: 0.0, w: 1.0, h: 2.0 };
-            let b = Rect { x: 0.0, y: 0.0, w: 2.0, h: 1.0 };
+            let a = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 2.0,
+            };
+            let b = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 2.0,
+                h: 1.0,
+            };
             let real = a.combine_with(b);
-            let expected = Rect { x: 0.0, y: 0.0, w: 2.0, h: 2.0 };
+            let expected = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 2.0,
+                h: 2.0,
+            };
             assert_relative_eq!(real, expected);
         }
         {
-            let a = Rect { x: -1.0, y: 0.0, w: 2.0, h: 2.0 };
-            let b = Rect { x: 0.0, y: -1.0, w: 1.0, h: 1.0 };
+            let a = Rect {
+                x: -1.0,
+                y: 0.0,
+                w: 2.0,
+                h: 2.0,
+            };
+            let b = Rect {
+                x: 0.0,
+                y: -1.0,
+                w: 1.0,
+                h: 1.0,
+            };
             let real = a.combine_with(b);
-            let expected = Rect { x: -1.0, y: -1.0, w: 2.0, h: 3.0 };
+            let expected = Rect {
+                x: -1.0,
+                y: -1.0,
+                w: 2.0,
+                h: 3.0,
+            };
             assert_relative_eq!(real, expected);
         }
     }
@@ -600,33 +645,78 @@ mod tests {
     #[test]
     fn headless_test_rect_rotate() {
         {
-            let mut r = Rect { x: -0.5, y: -0.5, w: 1.0, h: 1.0 };
+            let mut r = Rect {
+                x: -0.5,
+                y: -0.5,
+                w: 1.0,
+                h: 1.0,
+            };
             let expected = r;
             r.rotate(PI * 2.0);
             assert_relative_eq!(r, expected);
         }
         {
-            let mut r = Rect { x: 0.0, y: 0.0, w: 1.0, h: 2.0 };
+            let mut r = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 2.0,
+            };
             r.rotate(PI * 0.5);
-            let expected = Rect { x: -2.0, y: 0.0, w: 2.0, h: 1.0 };
+            let expected = Rect {
+                x: -2.0,
+                y: 0.0,
+                w: 2.0,
+                h: 1.0,
+            };
             assert_relative_eq!(r, expected);
         }
         {
-            let mut r = Rect { x: 0.0, y: 0.0, w: 1.0, h: 2.0 };
+            let mut r = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 2.0,
+            };
             r.rotate(PI);
-            let expected = Rect { x: -1.0, y: -2.0, w: 1.0, h: 2.0 };
+            let expected = Rect {
+                x: -1.0,
+                y: -2.0,
+                w: 1.0,
+                h: 2.0,
+            };
             assert_relative_eq!(r, expected);
         }
         {
-            let mut r = Rect { x: -0.5, y: -0.5, w: 1.0, h: 1.0 };
+            let mut r = Rect {
+                x: -0.5,
+                y: -0.5,
+                w: 1.0,
+                h: 1.0,
+            };
             r.rotate(PI * 0.5);
-            let expected = Rect { x: -0.5, y: -0.5, w: 1.0, h: 1.0 };
+            let expected = Rect {
+                x: -0.5,
+                y: -0.5,
+                w: 1.0,
+                h: 1.0,
+            };
             assert_relative_eq!(r, expected);
         }
         {
-            let mut r = Rect { x: 1.0, y: 1.0, w: 0.5, h: 2.0 };
+            let mut r = Rect {
+                x: 1.0,
+                y: 1.0,
+                w: 0.5,
+                h: 2.0,
+            };
             r.rotate(PI * 0.5);
-            let expected = Rect { x: -3.0, y: 1.0, w: 2.0, h: 0.5 };
+            let expected = Rect {
+                x: -3.0,
+                y: 1.0,
+                w: 2.0,
+                h: 0.5,
+            };
             assert_relative_eq!(r, expected);
         }
     }

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -155,6 +155,15 @@ impl Rect {
             y: y_min,
         }
     }
+
+    /// Returns a new `Rect` that includes all points of these two `Rect`s.
+    pub fn combine_with(self, other: Rect) -> Rect {
+        let x = f32::min(self.x, other.x);
+        let y = f32::min(self.y, other.y);
+        let w = f32::max(self.right(), other.right()) - x;
+        let h = f32::max(self.bottom(), other.bottom()) - y;
+        Rect { x, y, w, h }
+    }
 }
 
 impl approx::AbsDiffEq for Rect {
@@ -561,6 +570,31 @@ mod tests {
         let r2 = Rect::new(64.0, 64.0, 64.0, 64.0);
         r1.move_to(Point2::new(64.0, 64.0));
         assert!(r1 == r2);
+    }
+
+    #[test]
+    fn headless_test_rect_combine_with() {
+        {
+            let a = Rect { x: 0.0, y: 0.0, w: 1.0, h: 1.0 };
+            let b = Rect { x: 0.0, y: 0.0, w: 1.0, h: 1.0 };
+            let c = a.combine_with(b);
+            assert_relative_eq!(a, b);
+            assert_relative_eq!(a, c);
+        }
+        {
+            let a = Rect { x: 0.0, y: 0.0, w: 1.0, h: 2.0 };
+            let b = Rect { x: 0.0, y: 0.0, w: 2.0, h: 1.0 };
+            let real = a.combine_with(b);
+            let expected = Rect { x: 0.0, y: 0.0, w: 2.0, h: 2.0 };
+            assert_relative_eq!(real, expected);
+        }
+        {
+            let a = Rect { x: -1.0, y: 0.0, w: 2.0, h: 2.0 };
+            let b = Rect { x: 0.0, y: -1.0, w: 1.0, h: 1.0 };
+            let real = a.combine_with(b);
+            let expected = Rect { x: -1.0, y: -1.0, w: 2.0, h: 3.0 };
+            assert_relative_eq!(real, expected);
+        }
     }
 
     #[test]

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -125,6 +125,34 @@ impl Rect {
     }
 }
 
+impl approx::AbsDiffEq for Rect {
+    type Epsilon = f32;
+
+    fn default_epsilon() -> Self::Epsilon {
+        f32::default_epsilon()
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        f32::abs_diff_eq(&self.x, &other.x,  epsilon)
+            && f32::abs_diff_eq(&self.y, &other.y,  epsilon)
+            && f32::abs_diff_eq(&self.w, &other.w,  epsilon)
+            && f32::abs_diff_eq(&self.h, &other.h,  epsilon)
+    }
+}
+
+impl approx::RelativeEq for Rect {
+    fn default_max_relative() -> Self::Epsilon {
+        f32::default_max_relative()
+    }
+
+    fn relative_eq(&self, other: &Self, epsilon: Self::Epsilon, max_relative: Self::Epsilon) -> bool {
+        f32::relative_eq(&self.x, &other.x,  epsilon, max_relative)
+            && f32::relative_eq(&self.y, &other.y,  epsilon, max_relative)
+            && f32::relative_eq(&self.w, &other.w,  epsilon, max_relative)
+            && f32::relative_eq(&self.h, &other.h,  epsilon, max_relative)
+    }
+}
+
 impl From<[f32; 4]> for Rect {
     fn from(val: [f32; 4]) -> Self {
         Rect::new(val[0], val[1], val[2], val[3])


### PR DESCRIPTION
This PR:

- Adds an `approx::RelativeEq` impl for `Rect`;
- Adds a `fn rotate(&mut self, rotation: f32)` method to `Rect;
- Adds a `fn combine_with(self, other: Rect) -> Rect` method to `Rect`;
- Adds a `fn dimensions(&self, _: &mut Context) -> Option<Rect>` method to the `Drawable` trait;

Notes:
- I don't like that `dimensions` method requires `Context` - it's required only for `Text`s implementation. It can be solved by storing a `dimensions: Rect` field in `Text` during `Text`'s creation, but it increases the costs of this operation which may be not desirable.
- I really hope that I haven't messed up the math too much. The basic tests seem to be ok, but it needs some staring review.
- Also, I'm not sure that `combine_with` is a descriptive name but can't think out anything better.
- It'd be cool to remove the code duplication between `bbox_for_vertices` and `rotate`, but I don't see how it can be done since they work with different point types.

Closes #557 

_([Here's a branch of Zemeroth with a draft port to GGEZ 0.5.alpha.0 + this PR](https://github.com/ozkriff/zemeroth/tree/wip_i409_ggez_0_5_alpha_0))_
