### PR TITLE
Fixes problem with not being able to set the volume before playing a sound

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -473,6 +473,10 @@ impl SpatialSource {
         // fine because the `RodioAudioContext` uses the default device too,
         // but it may cause problems in the future if devices become
         // customizable.
+
+        // We also need to carry over information from the previous sink.
+        let volume = self.volume();
+
         let device = rodio::default_output_device().unwrap();
         self.sink = rodio::SpatialSink::new(
             &device,
@@ -481,6 +485,9 @@ impl SpatialSource {
             self.right_ear.into(),
         );
         self.play_time.store(0, Ordering::SeqCst);
+
+        // Restore information from the previous sink.
+        self.set_volume(volume);
     }
 
     /// Returns whether or not the source is stopped

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -272,9 +272,16 @@ impl Source {
         // fine because the `RodioAudioContext` uses the default device too,
         // but it may cause problems in the future if devices become
         // customizable.
+
+        // We also need to carry over information from the previous sink.
+        let volume = self.volume();
+
         let device = rodio::default_output_device().unwrap();
         self.sink = rodio::Sink::new(&device);
         self.play_time.store(0, Ordering::SeqCst);
+
+        // Restore information from the previous link.
+        self.set_volume(volume);
     }
 
     /// Returns whether or not the source is stopped

--- a/src/tests/audio.rs
+++ b/src/tests/audio.rs
@@ -15,3 +15,55 @@ fn audio_load() {
     // let mut sound = audio::Source::new(c, "/player.png").unwrap();
     // sound.play().unwrap();
 }
+
+#[test]
+fn volume_persists_after_stop() {
+    let (c, _e) = &mut tests::make_context();
+    {
+        let volume = 0.8;
+        let mut sound = audio::Source::new(c, "/pew.ogg").unwrap();
+        sound.set_volume(volume);
+        assert_eq!(sound.volume(), volume);
+        sound.stop();
+        assert_eq!(sound.volume(), volume);
+    }
+}
+
+#[test]
+fn volume_persists_after_stop_for_spatial_source() {
+    let (c, _e) = &mut tests::make_context();
+    {
+        let volume = 0.8;
+        let mut sound = audio::SpatialSource::new(c, "/pew.ogg").unwrap();
+        sound.set_volume(volume);
+        assert_eq!(sound.volume(), volume);
+        sound.stop();
+        assert_eq!(sound.volume(), volume);
+    }
+}
+
+#[test]
+fn volume_persists_after_play() {
+    let (c, _e) = &mut tests::make_context();
+    {
+        let volume = 0.8;
+        let mut sound = audio::Source::new(c, "/pew.ogg").unwrap();
+        sound.set_volume(volume);
+        assert_eq!(sound.volume(), volume);
+        sound.play().unwrap();
+        assert_eq!(sound.volume(), volume);
+    }
+}
+
+#[test]
+fn volume_persists_after_play_for_spatial_source() {
+    let (c, _e) = &mut tests::make_context();
+    {
+        let volume = 0.8;
+        let mut sound = audio::SpatialSource::new(c, "/pew.ogg").unwrap();
+        sound.set_volume(volume);
+        assert_eq!(sound.volume(), volume);
+        sound.play().unwrap();
+        assert_eq!(sound.volume(), volume);
+    }
+}


### PR DESCRIPTION
Fixes issue #573 

The problem lies in how the `stop` function works. `stop` works by dropping the current sink and replacing it with a new one. However, it doesn't carry over the volume setting from the old sink. This matters because `play` calls `stop` to restart a sound, if need be. The fix is to hold on to the volume for the old sink before dropping it then re-applying that volume setting.