### PR TITLE
Replace app_dirs2 with directories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ c_dependencies = ["bzip2", "mp3"]
 [dependencies]
 bitflags = "1.0"
 zip = { version = "0.5", default-features = false }
-app_dirs2 = "2"
+directories = "1.0.2"
 gfx = "0.18"
 gfx_core = "0.9"
 gfx_device_gl = "0.16"

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,6 @@ use gfx;
 use glutin;
 use winit;
 
-use app_dirs2::AppDirsError;
 use gilrs;
 use image;
 use lyon;
@@ -82,12 +81,6 @@ impl Error for GameError {
 /// A convenient result type consisting of a return type and a `GameError`
 pub type GameResult<T = ()> = Result<T, GameError>;
 
-impl From<AppDirsError> for GameError {
-    fn from(e: AppDirsError) -> GameError {
-        let errmessage = format!("{}", e);
-        GameError::FilesystemError(errmessage)
-    }
-}
 impl From<std::io::Error> for GameError {
     fn from(e: std::io::Error) -> GameError {
         GameError::IOError(e)


### PR DESCRIPTION
This patch replaces the use of the `app_dirs2` crate with the more
heavily-used `directories` crate.

Fixes #530 (original suggestion was to use the `dirs` crate, but my research suggests that `directories` seems more analogous).

Also, this is my first PR *ever*, so please let me know if there is something I can improve!