### PR TITLE
Add graphics::present() to starting boilerplate in GenerativeArt.md

### DIFF
--- a/docs/guides/GenerativeArt.md
+++ b/docs/guides/GenerativeArt.md
@@ -24,6 +24,7 @@ impl ggez::event::EventHandler for State {
       Ok(())
   }
   fn draw(&mut self, _ctx: &mut Context) -> GameResult {
+      graphics::present(ctx)?;
       Ok(())
   }
 }
@@ -80,6 +81,7 @@ fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::WHITE,
     )?;
     graphics::draw(ctx, &circle, graphics::DrawParam::default())?;
+    graphics::present(ctx)?
     Ok(())
 }
 ```
@@ -116,6 +118,7 @@ fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::WHITE,
     )?;
     graphics::draw(ctx, &circle, graphics::DrawParam::default())?;
+    graphics::present(ctx)?;
     Ok(())
 }
 ```
@@ -157,6 +160,7 @@ fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::WHITE,
     )?;
     graphics::draw(ctx, &rect, graphics::DrawParam::default())?;
+    graphics::present(ctx)?;
     Ok(())
 }
 ```
@@ -238,6 +242,7 @@ fn draw(&mut self, ctx: &mut Context) -> GameResult {
         // ...and then draw it.
         graphics::draw(ctx, &mesh, graphics::DrawParam::default())?;
     }
+    graphics::present(ctx)?;
     Ok(())
 }
 ```


### PR DESCRIPTION
Since graphics::present() is required at the end of draw() in order to see the results of previous draw operations, I've gone ahead and added it to the starting boilerplate for the GenerativeArt tutorial.

It might be useful to call out the method specifically in the tutorial text, but I'll leave that to someone more familiar with the library.