### PR TITLE
Tiny typo

### DIFF
--- a/docs/guides/GenerativeArt.md
+++ b/docs/guides/GenerativeArt.md
@@ -23,7 +23,7 @@ impl ggez::event::EventHandler for State {
   fn update(&mut self, _ctx: &mut Context) -> GameResult {
       Ok(())
   }
-  fn draw(&mut self, _ctx: &mut Context) -> GameResult {
+  fn draw(&mut self, ctx: &mut Context) -> GameResult {
       graphics::present(ctx)?;
       Ok(())
   }


### PR DESCRIPTION
Fixed a tiny typo in the first block of code.