### PR TITLE
Add Mandelbrot Exploror to examples, using custom shader 

### DIFF
--- a/examples/shader_brot/direction.rs
+++ b/examples/shader_brot/direction.rs
@@ -1,0 +1,20 @@
+use ggez::event::KeyCode;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Direction {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+impl Direction {
+    pub fn from_keycode(key: KeyCode) -> Option<Direction> {
+        match key {
+            KeyCode::Up => Some(Direction::Up),
+            KeyCode::Down => Some(Direction::Down),
+            KeyCode::Left => Some(Direction::Left),
+            KeyCode::Right => Some(Direction::Right),
+            _ => None,
+        }
+    }
+}

--- a/examples/shader_brot/main.rs
+++ b/examples/shader_brot/main.rs
@@ -1,0 +1,211 @@
+#[macro_use]
+extern crate gfx;
+extern crate cgmath;
+
+use ggez::graphics::{self, DrawParam, Canvas};
+use ggez::Context;
+use ggez::event::{ KeyCode, KeyMods };
+use ggez::GameResult;
+
+use std::path;
+
+mod direction;
+use direction::*;
+
+const SPEED_SCALE: f64 = 0.3;
+
+gfx_defines! {
+
+    // DONE set it up so that you can idiomatically select for mandel or julia
+    // TODO refactor so more idiomatic in the code structure
+    constant MandelShaderUniforms {
+        center: [f32; 2] = "u_Center",
+        dimension: [f32; 2] = "u_Dimension",
+        resolution: [f32; 2] = "u_Resolution",
+        position: [f32; 2] = "u_MousePos",
+        time: f32 = "u_Time",
+        max_iter: i32 = "u_MaxIteration",
+        is_mandel: i32 = "u_IsMandel",
+    }
+}
+
+impl MandelShaderUniforms {
+    fn new(ctx: &Context) -> Self {
+        Self {
+            // DONE varify that these uniforms are set in cpu only
+            // TODO delegate operations on these uniforms
+            position: [0.0, 0.0],
+            center: [-0.5, -0.0],
+            dimension: [3.0, 2.0],
+            time: 0.0,
+            max_iter: 120,
+            resolution: [graphics::size(ctx).0 as f32, graphics::size(ctx).1 as f32],
+            is_mandel: 1,
+        }
+    }
+
+}
+
+
+#[derive (Debug)]
+struct MainState {
+    // TODO collect these items in a refactor
+    canvas_render_target: Canvas,
+
+    uniforms_for_shader: MandelShaderUniforms,
+    shader: graphics::Shader<MandelShaderUniforms>,
+}
+
+
+const ITER_STEP: i32 = 5;
+
+impl MainState {
+    fn new(ctx: &mut Context) -> GameResult<Self> {
+
+        let canvas_render_target = Canvas::with_window_size(ctx)?;
+
+        // We need to hava a data struct to send to the shader.
+        let uniforms_for_shader = MandelShaderUniforms::new(ctx);
+
+        let shader = graphics::Shader::from_u8(
+            ctx,
+            // Import vertex and fragment shader source-code at compile time
+            include_bytes!("../../resources/basic_150.glslv"),
+            include_bytes!("../../resources/fractal.glslf"),
+            uniforms_for_shader,
+            "MandelShaderUniforms",
+            None
+        )?;
+
+
+        // Bring together the target, uniforms, and shader into the MainState
+        Ok(Self {
+            canvas_render_target,
+            uniforms_for_shader,
+            shader,
+        })
+    }
+
+    // TODO command depends on this. change so this depends on command
+    // by doing += argument
+    fn incriment_max_iter(&mut self) {
+        self.uniforms_for_shader.max_iter += ITER_STEP;
+    }
+
+    // TODO command depends on this. change so this depends on command
+    // by doing += argument
+    fn decriment_max_iter(&mut self) {
+        let it = self.uniforms_for_shader.max_iter;
+        let it = std::cmp::max(2, it - ITER_STEP);
+        self.uniforms_for_shader.max_iter = it;
+    }
+}
+
+impl ggez::event::EventHandler for MainState {
+    fn update(&mut self, ctx: &mut Context) -> GameResult {
+
+        // time since last frame to provide to the shader
+        let shader_time = ggez::timer::time_since_start(ctx);
+        let shader_time = ggez::timer::duration_to_f64(shader_time) * SPEED_SCALE;
+        self.uniforms_for_shader.time = shader_time as f32;
+
+        Ok(())
+    }
+
+    fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) {
+
+        // We want everything to scale according to a screen-pixel. With a new
+        // window size, the shader needs new information on pixel resolution
+        let os_scale = graphics::os_hidpi_factor(ctx);
+        self.uniforms_for_shader.resolution = [(width*os_scale), (height*os_scale)];
+    }
+
+    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+        graphics::clear(ctx, [0.1, 0.1, 0.3, 1.0].into());
+
+        // Consider the graphics::Canvas object a software-abstraction of the
+        // computer screen, and graphics::present as its unveiling. Here, we
+        // have the gpu paint to a clean canvas without interuption, then unveil it.
+        {
+            let _lock = graphics::use_shader(ctx, &self.shader);
+            self.shader.send(ctx, self.uniforms_for_shader)?;
+            graphics::draw(ctx, &self.canvas_render_target, DrawParam::default())?;
+            graphics::present(ctx)?;
+        }
+        Ok(())
+    }
+
+    fn mouse_motion_event(
+        &mut self,
+        ctx: &mut Context,
+        x: f32,
+        y: f32,
+        _dx: f32,
+        _dy: f32
+    ) {
+
+        // As with `resize_event()` needing to adjust to match Canvas pixels,
+        // we need to do the same with mouse position.
+        let scale = graphics::os_hidpi_factor(ctx);
+
+        let y = graphics::size(ctx).1 as f32  - y;
+        self.uniforms_for_shader.position[0] = x * scale;
+        self.uniforms_for_shader.position[1] = y * scale;
+    }
+
+    fn key_down_event(
+        &mut self,
+        ctx: &mut Context,
+        keycode: KeyCode,
+        _keymod: KeyMods,
+        _repeat: bool,
+    ) {
+
+        // TODO move this into a function call
+        match Direction::from_keycode(keycode) {
+            Some(Direction::Up)    => self.uniforms_for_shader.center[1] += self.uniforms_for_shader.dimension[1] * 0.2,
+            Some(Direction::Down)  => self.uniforms_for_shader.center[1] -= self.uniforms_for_shader.dimension[1] * 0.2,
+            Some(Direction::Left)  => self.uniforms_for_shader.center[0] -= self.uniforms_for_shader.dimension[0] * 0.2,
+            Some(Direction::Right) => self.uniforms_for_shader.center[0] += self.uniforms_for_shader.dimension[0] * 0.2,
+            None => {},
+        }
+
+
+        // TODO add comments to template high-level representation of planned commands
+        match keycode {
+            KeyCode::E => {
+                self.uniforms_for_shader.dimension[0] *= 0.9;
+                self.uniforms_for_shader.dimension[1] *= 0.9;
+            }
+            KeyCode::W => self.incriment_max_iter(),
+            KeyCode::S => self.decriment_max_iter(),
+            KeyCode::D => {
+                self.uniforms_for_shader.dimension[0] *= 1.1;
+                self.uniforms_for_shader.dimension[1] *= 1.1;
+            },
+            KeyCode::Q => {
+                println!("MainState\n=========\n {:#?}", &self);
+                ggez::quit(ctx);
+            },
+            KeyCode::Tab => {
+                match self.uniforms_for_shader.is_mandel {
+                    0 => self.uniforms_for_shader.is_mandel = 1,
+                    _ => self.uniforms_for_shader.is_mandel = 0,
+                }
+            },
+            _ => {}
+        }
+    }
+}
+
+fn main() -> GameResult {
+    let resource_dir = path::PathBuf::from("./resources");
+
+    let cb = ggez::ContextBuilder::new("shader-driven julia/mandelbrot", "BenPH").add_resource_path(resource_dir).with_conf_file(true);
+    let (ctx, event_loop) = &mut cb.build()?;
+    ctx.conf.window_mode = ggez::conf::WindowMode::resizable(ctx.conf.window_mode, true);
+
+    let mut ms = MainState::new(ctx)?;
+
+    ggez::event::run(ctx, event_loop, &mut ms)
+}

--- a/examples/shader_brot/main.rs
+++ b/examples/shader_brot/main.rs
@@ -199,6 +199,11 @@ impl ggez::event::EventHandler for MainState {
 }
 
 fn main() -> GameResult {
+    println!("Arrow keys to move around");
+    println!("TAB to switch between mandelbrot and julia set");
+    println!("E/D to zoom in/out");
+    println!("W/S to increase/decrease detail (changes performance)");
+
     let resource_dir = path::PathBuf::from("./resources");
 
     let cb = ggez::ContextBuilder::new("shader-driven julia/mandelbrot", "BenPH").add_resource_path(resource_dir).with_conf_file(true);

--- a/resources/fractal.glslf
+++ b/resources/fractal.glslf
@@ -1,0 +1,135 @@
+#version 420 core
+
+#define ESCAPE_BOUNDARY 18
+#define FREQUENCY 0.1
+
+in vec4 gl_FragCoord;
+out vec4 Target0;
+
+
+dvec2 viewport_coord_to_complex(dvec2 coord); // moves and scales gl_FragCoord to desired complex number
+
+// For this iterative escape-fractal, we need to select start value, and iterative modifier
+dvec2 get_c();
+dvec2 get_z();
+
+vec3 hsv2rgb( vec3 c);
+
+layout (std140) uniform MandelShaderUniforms {
+  uniform vec2 u_Center;     // where on the complex plain the user wants the screen-center
+  uniform vec2 u_Dimension;  // the width and height user wants the view onto the complex plane
+  uniform vec2 u_Resolution; // user interogates the pixel coverage of the view, and provides it here
+
+  uniform vec2 u_MousePos;    // Used for julia set, assumes gl_FragCoord format
+  uniform float u_Time;       // Time since start of program in seconds
+  uniform int u_MaxIteration; // User defined limit of iteration count
+  uniform int u_IsMandel;     // (A bit hacky, TODO) select between MandelBrot and Julia
+};
+
+
+
+void main() {
+
+  // load up our iteration values
+  dvec2 z = get_z();
+  dvec2 c = get_c();
+
+
+  int step_count;
+  dvec2 tmp;
+  for (step_count = 0; step_count < u_MaxIteration; step_count++) {
+
+    // Vast majority of performance gets absorbed here
+
+    // TODO micro-optimise
+    // `z = z * z + c`, with z and c being complex numbers
+
+    tmp.x = z.x*z.x - z.y*z.y;
+    tmp.y = 2.0 * z.x*z.y;
+    z.x = tmp.x;
+    z.y = tmp.y;
+    z.x += c.x;
+    z.y += c.y;
+
+    if((z.x*z.x + z.y*z.y) > ESCAPE_BOUNDARY) {
+      break;
+    }
+  }
+
+
+  if (step_count == u_MaxIteration) {
+    Target0 =  vec4(1.0, 1.0, 1.0, 1.0);
+  } else {
+    float dist = float(length(z));
+
+    float two = float(2.0);
+    dist  = log(log(dist)) / log(two);
+
+    float val = float(step_count) - dist;
+    float hue = val/10.0 - u_Time * FREQUENCY;
+
+    Target0 =  vec4(hsv2rgb(vec3((hue), 1.0, 1.0 )), 1.0);
+  }
+}
+// enhance...
+dvec2 vec2_to_dvec2(vec2 floatvec2) {
+  return dvec2(floatvec2);
+}
+
+// center yourself, THEN grow your mind, then you will be moved on the plane of imagination
+dvec2 viewport_coord_to_complex(dvec2 coord) {
+
+  // set the origin to the center of the screen
+  dvec2 result =  dvec2(coord) - u_Resolution/2.0;
+
+
+  // Scale down to a 1.0 by 1.0 view of the complex plane
+  result /= u_Resolution;
+
+  // match the real and im dimensions to user-input
+  result *= u_Dimension;
+
+  // shift the center reference to where the user asked it to be
+  result += u_Center;
+  return result;
+}
+
+
+// TODO set it up so that responsibility between mandel and julia decoupled
+//      at the moment seperate areoas are tightly coupled
+dvec2 get_c() {
+  dvec2 result;
+
+  // for mandel, the iter-step is where that pixel sits in the complex plane
+  // but for julia, it's based on mouse position
+  if(u_IsMandel != 0) {
+    result = viewport_coord_to_complex(gl_FragCoord.xy);
+  } else {
+    result = viewport_coord_to_complex(u_MousePos);
+  }
+
+  return result;
+}
+
+// TODO see get_c()
+dvec2 get_z() {
+  dvec2 result;
+
+  // for mandel, iterate starting from 0, for julia, the start relates to location in
+  // the complex plane
+  if(u_IsMandel != 0) {
+    result = dvec2(0.0, 0.0);
+  } else {
+    result = viewport_coord_to_complex(gl_FragCoord.xy);
+  }
+
+  return result;
+}
+
+
+// hue, saturation, value to reg, green, blue
+vec3 hsv2rgb(vec3 c) {
+  vec4 K =  vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+  vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www );
+  return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use std::path;
 
 use gfx;
-use image;
+use ::image;
 
 use crate::context::{Context, DebugId};
 use crate::error::GameError;


### PR DESCRIPTION
Minor edit to graphics/image.rs to make the compiler happy about imorts. I'm not
so sure on how to make it work without that change :(

If you would prefer this to go into the projects repo, that's cool, but if we can add/make changes to justify putting it into the examples, I'm more than happy for that.