### PR TITLE
Add ContextBuilder::add_zipfile_bytes() to load zip files from memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
    disabling it will build ggez without unnecessary C dependencies
    (currently `bzip2` and `minimp3`). [#549](https://github.com/ggez/ggez/issues/549)
  * Added (basic) spatial sound support.
+ * Added loading of resource zip files from in-memory bytes
 
 ## Changed
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -303,6 +303,22 @@ impl Filesystem {
         self.vfs.push_back(Box::new(physfs));
     }
 
+    /// Adds any object that implements Read + Seek as a zip file.
+    ///
+    /// Note: This is not intended for system files for the same reasons as
+    /// for `.mount()`. Rather, it can be used to read zip files from sources
+    /// such as `std::io::Cursor::new(includes_bytes!(...))` in order to embed
+    /// resources into the game's executable.
+    pub(crate) fn add_zip_file<R: io::Read + io::Seek + 'static>(
+        &mut self,
+        reader: R,
+    ) -> GameResult<()> {
+        let zipfs = vfs::ZipFS::from_read(reader)?;
+        trace!("Adding zip file from reader");
+        self.vfs.push_back(Box::new(zipfs));
+        Ok(())
+    }
+
     /// Looks for a file named `/conf.toml` in any resource directory and
     /// loads it if it finds it.
     /// If it can't read it for some reason, returns an error.


### PR DESCRIPTION
This gives the ability to embed resources into the executable using
include_bytes!(), or loading zip files from arbitrary places.

See issue #469.