### PR TITLE
Resize gl context on resize

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -168,6 +168,7 @@ where
                         // to handle resizes in their own event loop now.
                         let actual_size =
                             logical_size.to_physical(ctx.gfx_context.hidpi_factor as f64);
+                        ctx.gfx_context.window.resize(actual_size);
                         // let actual_size = logical_size;
                         state.resize_event(
                             ctx,


### PR DESCRIPTION
Wayland needs the gl context to be resized for it to be displayed properly