### PR TITLE
Add `filter` and `set_filter` to `Canvas`

### DIFF
--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -107,6 +107,16 @@ impl Canvas {
         &self.image
     }
 
+    /// Get the filter mode for the image.
+    pub fn filter(&self) -> FilterMode {
+        self.image.filter()
+    }
+
+    /// Set the filter mode for the canvas.
+    pub fn set_filter(&mut self, mode: FilterMode) {
+        self.image.set_filter(mode)
+    }
+
     /// Destroys the `Canvas` and returns the `Image` it contains.
     pub fn into_inner(self) -> Image {
         // TODO: This texture is created with different settings


### PR DESCRIPTION
I want to do some pixelart graphics, so my idea was to render to a fixed size canvas, and then upscale it with nearest pixel filter. Seemed like a pretty trivial and innocent change. Tests are failing on master, but this change somehow also makes different tests fail on my machine and I haven't dug out why yet.