### PR TITLE
Remove redundant cargo argument

### DIFF
--- a/docs/guides/HelloGgez.md
+++ b/docs/guides/HelloGgez.md
@@ -21,7 +21,7 @@ You did know this was a Rust library right? 😉
 Open up your terminal and make sure it is in the location where you want to create your new project folder.
 
 ```bash
-cargo new --bin hello_ggez
+cargo new hello_ggez
 cd hello_ggez
 ```
 


### PR DESCRIPTION
`--bin` is the default for cargo since a while