### PR TITLE
Skip winit 0.19.2 due to compile error from parking_lot crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ gfx_device_gl = "0.16"
 glyph_brush = "0.5"
 gfx_window_glutin = "0.30"
 glutin = "0.20"
-winit = { version = "0.19" }
+winit = { version = "0.19.3" }
 image = {version = "0.22", default-features = false, features = ["gif_codec", "jpeg", "ico", "png_codec", "pnm",
 "tga", "tiff", "webp", "bmp", "dxt", ] }
 rodio = { version = "0.9", default-features = false, features = ["flac", "vorbis", "wav"] }


### PR DESCRIPTION
This fixes a compile error I got when attempting to run the hello_canvas example: https://github.com/rust-windowing/winit/issues/1115