### PR TITLE
Reset screen coordinates as default

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -145,7 +145,9 @@ pub trait EventHandler {
 
     /// Called when the user resizes the window, or when it is resized
     /// via [`graphics::set_mode()`](../graphics/fn.set_mode.html).
-    fn resize_event(&mut self, _ctx: &mut Context, _width: f32, _height: f32) {}
+    fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) {
+        graphics::set_screen_coordinates(ctx, Rect::new(0.0, 0.0, width, height));
+    }
 }
 
 /// Terminates the [`ggez::event::run()`](fn.run.html) loop by setting


### PR DESCRIPTION
I'm not sure in what situation you want screen coordinates to reference
a previous screen-size, but I think it shouldn't be default behaviour.
What do you think?