### PR TITLE
Added colorspace example for Text Drawable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ gfx_device_gl = "0.16"
 glyph_brush = "0.5"
 gfx_window_glutin = "0.30"
 glutin = "0.20"
-winit = { version = "0.19" }
+winit = { version = "0.19.3" }
 image = {version = "0.22", default-features = false, features = ["gif_codec", "jpeg", "ico", "png_codec", "pnm",
 "tga", "tiff", "webp", "bmp", "dxt", ] }
 rodio = { version = "0.9", default-features = false, features = ["flac", "vorbis", "wav"] }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the `Context` and an instance of your `EventHandler` to run your game's
 main loop.
 
 See the [API docs](https://docs.rs/ggez/) for full documentation, or the [examples](/examples) directory for a number of commented examples of varying complexity.  Most examples show off
-a single feature of ggez, while `astroblasto` and `snake` are a small but complete games.
+a single feature of ggez, while `astroblasto` and `snake` are small but complete games.
 
 ## Getting started
 

--- a/docs/Projects.md
+++ b/docs/Projects.md
@@ -14,6 +14,7 @@ submit a PR, please!
  * <https://github.com/vinceniko/tetrust>
  * <https://github.com/icefoxen/ld42/>
  * <https://github.com/conwayste/conwayste/>
+ * <https://github.com/avandolder/tetrominoes-rust>
 
 # Examples/tutorial code
 

--- a/docs/Projects.md
+++ b/docs/Projects.md
@@ -1,14 +1,19 @@
 This is a place for people to pimp their stuff that is built with ggez.  If you want your project listed here, add it and
 submit a PR, please!
 
+# 0.5.x
+
+## Games!
+
+ * <https://github.com/ozkriff/zemeroth>
+
 # 0.4.x
 
-# Games!
+## Games!
 
  * <https://github.com/MushuYoWushu/mehens_portable_casino>
  * <https://github.com/maccam912/thewizzerofoz>
  * <https://github.com/Piripant/skii>
- * <https://github.com/ozkriff/zemeroth>
  * <https://github.com/Swampsoft/solitaire>
  * <https://github.com/obsoke/rustris>
  * <https://github.com/vinceniko/tetrust>
@@ -16,18 +21,18 @@ submit a PR, please!
  * <https://github.com/conwayste/conwayste/>
  * <https://github.com/avandolder/tetrominoes-rust>
 
-# Examples/tutorial code
+## Examples/tutorial code
 
  * <https://github.com/ggez/game-template> -- a general-purpose getting-started template integrating warmy, specs, and some other useful tools.
  * <https://github.com/termhn/ggez_snake>
  * <https://github.com/rafaeldelboni/ggez-specs-hello-world> -- A simple hello world project using ggez and specs.
  * <https://github.com/rafaeldelboni/ggez-specs-rhusics-hello-world> -- A hello world project using ggez, specs and rhusics for physics.
 
-# Tools/add-ons
+## Tools/add-ons
 
  * <https://github.com/ggez/ggez-goodies> (incomplete, but maybe useful to someone)
 
-# Written things
+## Written things
 
 
 # 0.3.x

--- a/examples/colorspace.rs
+++ b/examples/colorspace.rs
@@ -81,6 +81,7 @@ struct MainState {
     demo_mesh: graphics::Mesh,
     square_mesh: graphics::Mesh,
     demo_image: graphics::Image,
+    demo_text: graphics::Text,
 }
 
 impl MainState {
@@ -100,10 +101,18 @@ impl MainState {
             graphics::WHITE,
         )?;
         let demo_image = graphics::Image::solid(ctx, 200, AQUA)?;
+        let demo_text = graphics::Text::new(graphics::TextFragment {
+            text: "-".to_string(),
+            color: Some(AQUA),
+            font: Some(graphics::Font::default()),
+            scale: Some(graphics::Scale::uniform(300.0)),
+        });
+
         let s = MainState {
             demo_mesh,
             square_mesh,
             demo_image,
+            demo_text,
         };
         Ok(s)
     }
@@ -137,6 +146,12 @@ impl event::EventHandler for MainState {
             ctx,
             &self.demo_image,
             DrawParam::default().dest(na::Point2::new(450.0, 200.0)),
+        )?;
+
+        graphics::draw(
+            ctx,
+            &self.demo_text,
+            DrawParam::default().dest(na::Point2::new(150.0, 135.0)),
         )?;
 
         graphics::present(ctx)?;


### PR DESCRIPTION
As per issue #657 I added a Text Drawable to the colorspace example. It is a "-" character to be as visible as I could think to make it right under the circle.

I didn't want to do any of the other examples from the issue to make sure I was doing this how you wanted @icefoxen.

![colorspace example with the Text Drawable under the circle](https://user-images.githubusercontent.com/8014396/67734624-2240f000-f9c7-11e9-874a-5453c6a901a4.png)

I'm not sure why the README or Projects markdown files are included in this pull request. They don't show up in the diff for master branch. Let me know if you want me to pull them into this branch.