### PR TITLE
Reduce crate size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.33.0
+  - 1.36.0
 os:
   - linux
   - osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Unreleased
+
+## Added
+
+## Changed
+
+ * Minimum rustc version is now 1.36
+
+## Deprecated
+
+## Removed
+
+## Fixed
+
+## Broken
+
 # 0.5.1
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "MIT"
 readme = "README.md"
 categories = ["game-engines"]
 build = "build.rs"
+exclude = ["resources", "!DejaVuSerif.ttf"]
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ gfx_device_gl = "0.16"
 glyph_brush = "0.5"
 gfx_window_glutin = "0.30"
 glutin = "0.20"
-winit = { version = "0.19" }
+winit = { version = "0.19.3" }
 image = {version = "0.22", default-features = false, features = ["gif_codec", "jpeg", "ico", "png_codec", "pnm",
 "tga", "tiff", "webp", "bmp", "dxt", ] }
 rodio = { version = "0.9", default-features = false, features = ["flac", "vorbis", "wav"] }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the `Context` and an instance of your `EventHandler` to run your game's
 main loop.
 
 See the [API docs](https://docs.rs/ggez/) for full documentation, or the [examples](/examples) directory for a number of commented examples of varying complexity.  Most examples show off
-a single feature of ggez, while `astroblasto` and `snake` are a small but complete games.
+a single feature of ggez, while `astroblasto` and `snake` are small but complete games.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Check out the [projects list!](docs/Projects.md)
 
 ## Usage
 
-ggez requires rustc >= 1.33 and is distributed on
+ggez requires rustc >= 1.36 and is distributed on
 crates.io.  To include it in your project, just add the dependency
 line to your `Cargo.toml` file:
 

--- a/README.md
+++ b/README.md
@@ -130,21 +130,21 @@ impl MyGame {
     pub fn new(_ctx: &mut Context) -> MyGame {
         // Load/create resources such as images here.
         MyGame {
-		    // ...
-		}
+            // ...
+        }
     }
 }
 
 impl EventHandler for MyGame {
     fn update(&mut self, _ctx: &mut Context) -> GameResult<()> {
         // Update code here...
-		Ok(())
+        Ok(())
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
-		graphics::clear(ctx, graphics::WHITE);
+        graphics::clear(ctx, graphics::WHITE);
         // Draw code here...
-		graphics::present(ctx)
+        graphics::present(ctx)
     }
 }
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
         - TARGET: x86_64-pc-windows-msvc
           CHANNEL: nightly
         - TARGET: x86_64-pc-windows-msvc
-          CHANNEL: 1.33.0
+          CHANNEL: 1.36.0
 
 install:
     - curl -sSf -o rustup-init.exe https://win.rustup.rs

--- a/docs/Projects.md
+++ b/docs/Projects.md
@@ -14,6 +14,7 @@ submit a PR, please!
  * <https://github.com/vinceniko/tetrust>
  * <https://github.com/icefoxen/ld42/>
  * <https://github.com/conwayste/conwayste/>
+ * <https://github.com/avandolder/tetrominoes-rust>
 
 # Examples/tutorial code
 

--- a/docs/Projects.md
+++ b/docs/Projects.md
@@ -1,14 +1,19 @@
 This is a place for people to pimp their stuff that is built with ggez.  If you want your project listed here, add it and
 submit a PR, please!
 
+# 0.5.x
+
+## Games!
+
+ * <https://github.com/ozkriff/zemeroth>
+
 # 0.4.x
 
-# Games!
+## Games!
 
  * <https://github.com/MushuYoWushu/mehens_portable_casino>
  * <https://github.com/maccam912/thewizzerofoz>
  * <https://github.com/Piripant/skii>
- * <https://github.com/ozkriff/zemeroth>
  * <https://github.com/Swampsoft/solitaire>
  * <https://github.com/obsoke/rustris>
  * <https://github.com/vinceniko/tetrust>
@@ -16,18 +21,18 @@ submit a PR, please!
  * <https://github.com/conwayste/conwayste/>
  * <https://github.com/avandolder/tetrominoes-rust>
 
-# Examples/tutorial code
+## Examples/tutorial code
 
  * <https://github.com/ggez/game-template> -- a general-purpose getting-started template integrating warmy, specs, and some other useful tools.
  * <https://github.com/termhn/ggez_snake>
  * <https://github.com/rafaeldelboni/ggez-specs-hello-world> -- A simple hello world project using ggez and specs.
  * <https://github.com/rafaeldelboni/ggez-specs-rhusics-hello-world> -- A hello world project using ggez, specs and rhusics for physics.
 
-# Tools/add-ons
+## Tools/add-ons
 
  * <https://github.com/ggez/ggez-goodies> (incomplete, but maybe useful to someone)
 
-# Written things
+## Written things
 
 
 # 0.3.x

--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -378,7 +378,7 @@ impl Snake {
 struct GameState {
     /// First we need a Snake
     snake: Snake,
-    /// A piee of food
+    /// A piece of food
     food: Food,
     /// Whether the game is over or not
     gameover: bool,


### PR DESCRIPTION
Hi, I saw issue #704 and thought I'd create a PR for it.

I excluded almost all of the `resources` folder from the `[package]` in `Cargo.toml` to reduce the crate size.
I left *'DejaVuSerif.ttf'* alone as removing it broke the `cargo package` build:
https://github.com/ggez/ggez/blob/e3cc91902e8dd993597e27cb81adde16301fcbe9/src/graphics/text.rs#L420-L425


This change reduces the size of **'ggez-0.5.1.crate'** from **946KB** to **380KB**.