### PR TITLE
Nit: missed final step in comment calculation

### DIFF
--- a/src/graphics/drawparam.rs
+++ b/src/graphics/drawparam.rs
@@ -118,6 +118,7 @@ impl DrawParam {
         //  let axis_angle = Vec3::z() * self.rotation;
         //  let rotation = Matrix4::new_rotation(axis_angle);
         //  let scale = Matrix4::new_nonuniform_scaling(&Vec3::new(self.scale.x, self.scale.y, 1.0));
+        //  translate * offset * rotation * scale * offset_inverse
         let cosr = self.rotation.cos();
         let sinr = self.rotation.sin();
         let m00 = cosr * self.scale.x;


### PR DESCRIPTION
The original to_na_matrix code was left as an explanatory comment, but the return value calculation was omitted - https://github.com/ggez/ggez/pull/716/files. A nitpick but it felt incomplete.