### PR TITLE
Mesh batching and canvas improvements

### DIFF
--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -274,7 +274,7 @@ impl Snake {
             last_update_dir: Direction::Right,
             body: body,
             ate: None,
-            next_dir: None
+            next_dir: None,
         }
     }
 

--- a/examples/meshbatch.rs
+++ b/examples/meshbatch.rs
@@ -1,0 +1,125 @@
+//! An example of how to use a `MeshBatch`.
+
+use ggez;
+
+use ggez::event;
+use ggez::graphics;
+use ggez::nalgebra::Point2;
+use ggez::timer;
+use ggez::{Context, GameResult};
+use rand::seq::SliceRandom;
+use rand::{thread_rng, Rng};
+use std::env;
+use std::f32::consts::PI;
+use std::path;
+
+const TWO_PI: f32 = 2.0 * PI;
+
+struct MainState {
+    mesh_batch: graphics::MeshBatch,
+}
+
+impl MainState {
+    fn new(ctx: &mut Context) -> GameResult<MainState> {
+        let mesh = graphics::MeshBuilder::new()
+            .circle(
+                graphics::DrawMode::stroke(4.0),
+                Point2::new(0.0, 0.0),
+                8.0,
+                1.0,
+                (0, 0, 255).into(),
+            )
+            .line(
+                &[Point2::new(0.0, 0.0), Point2::new(8.0, 0.0)],
+                2.0,
+                (255, 255, 0).into(),
+            )?
+            .build(ctx)?;
+
+        let mut mesh_batch = graphics::MeshBatch::new(mesh)?;
+
+        // Generate enough instances to fill the entire screen
+        let items_x = (graphics::drawable_size(ctx).0 / 16.0) as u32;
+        let items_y = (graphics::drawable_size(ctx).1 / 16.0) as u32;
+        for x in 1..items_x {
+            for y in 1..items_y {
+                let x = x as f32;
+                let y = y as f32;
+
+                let p = graphics::DrawParam::new()
+                    .dest(Point2::new(x * 16.0, y * 16.0))
+                    .rotation(thread_rng().gen_range(0.0, TWO_PI));
+
+                mesh_batch.add(p);
+            }
+        }
+
+        // Randomly shuffle generated instances.
+        // We will update the first 50 of them later.
+        mesh_batch
+            .get_instance_params_mut()
+            .shuffle(&mut thread_rng());
+
+        let s = MainState { mesh_batch };
+        Ok(s)
+    }
+}
+
+impl event::EventHandler for MainState {
+    fn update(&mut self, ctx: &mut Context) -> GameResult {
+        if timer::ticks(ctx) % 100 == 0 {
+            println!("Delta frame time: {:?} ", timer::delta(ctx));
+            println!("Average FPS: {}", timer::fps(ctx));
+        }
+
+        // Update first 50 instances in the mesh batch
+        let delta_time = (timer::duration_to_f64(timer::delta(ctx)) * 1000.0) as f32;
+        let instances = self.mesh_batch.get_instance_params_mut();
+        for i in 0..50 {
+            let rotation = &mut instances[i].rotation;
+            if (i % 2) == 0 {
+                *rotation += 0.001 * TWO_PI * delta_time;
+                if *rotation > TWO_PI {
+                    *rotation -= TWO_PI;
+                }
+            } else {
+                *rotation -= 0.001 * TWO_PI * delta_time;
+                if *rotation < 0.0 {
+                    *rotation += TWO_PI;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+        graphics::clear(ctx, graphics::BLACK);
+
+        // Flush the first 50 instances in the batch to make our changes visible
+        // to the graphics card.
+        self.mesh_batch.flush_range(ctx, graphics::MeshIdx(0), 50)?;
+
+        // Draw the batch
+        self.mesh_batch.draw(ctx, graphics::DrawParam::default())?;
+
+        graphics::present(ctx)?;
+        Ok(())
+    }
+}
+
+pub fn main() -> GameResult {
+    let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
+        let mut path = path::PathBuf::from(manifest_dir);
+        path.push("resources");
+        path
+    } else {
+        path::PathBuf::from("./resources")
+    };
+
+    let cb = ggez::ContextBuilder::new("spritebatch", "ggez").add_resource_path(resource_dir);
+    let (ctx, event_loop) = &mut cb.build()?;
+
+    let state = &mut MainState::new(ctx)?;
+    event::run(ctx, event_loop, state)
+}

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -223,8 +223,9 @@ impl MainState {
             glow: 0.0,
             strength: LIGHT_STRENGTH,
         };
+        let color_format = ggez::graphics::get_window_color_format(ctx);
         let foreground = Canvas::with_window_size(ctx)?;
-        let occlusions = Canvas::new(ctx, LIGHT_RAY_COUNT, 1, conf::NumSamples::One)?;
+        let occlusions = Canvas::new(ctx, LIGHT_RAY_COUNT, 1, conf::NumSamples::One, color_format)?;
         let mut shadows = Canvas::with_window_size(ctx)?;
         // The shadow map will be drawn on top using the multiply blend mode
         shadows.set_blend_mode(Some(BlendMode::Multiply));

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -41,7 +41,7 @@ pub type Canvas = CanvasGeneric<GlBackendSpec>;
 
 impl<S> CanvasGeneric<S>
 where
-    S: BackendSpec
+    S: BackendSpec,
 {
     /// Create a new `Canvas` with the given size and number of samples.
     pub fn new(

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -113,6 +113,16 @@ where
             debug_id,
         })
     }
+
+    /// A helper function to get the raw gfx texture handle
+    pub fn get_raw_texture_handle(&self) -> gfx::handle::RawTexture<B::Resources> {
+        self.texture_handle.clone()
+    }
+
+    /// A helper function to get the raw gfx texture view
+    pub fn get_raw_texture_view(&self) -> gfx::handle::RawShaderResourceView<B::Resources> {
+        self.texture.clone()
+    }
 }
 
 /// In-GPU-memory image data available to be drawn on the screen,

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -598,6 +598,11 @@ pub fn renderer_info(ctx: &Context) -> GameResult<String> {
     ))
 }
 
+/// Returns the screen color format used by the context
+pub fn get_window_color_format(ctx: &Context) -> gfx::format::Format {
+    ctx.gfx_context.color_format()
+}
+
 /// Returns a rectangle defining the coordinate system of the screen.
 /// It will be `Rect { x: left, y: top, w: width, h: height }`
 ///
@@ -1059,5 +1064,4 @@ mod tests {
             assert_relative_eq!(real, expected);
         }
     }
-
 }

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -38,7 +38,7 @@ pub struct SpriteBatch {
 
 /// An index of a particular sprite in a `SpriteBatch`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SpriteIdx(usize);
+pub struct SpriteIdx(pub usize);
 
 impl SpriteBatch {
     /// Creates a new `SpriteBatch`, drawing with the given image.

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -1,7 +1,7 @@
 pub(crate) use nalgebra as na;
+use serde::{Deserialize, Serialize};
 use std::f32;
 use std::u32;
-use serde::{Serialize, Deserialize};
 
 use crate::graphics::{FillOptions, StrokeOptions};
 

--- a/src/tests/text.rs
+++ b/src/tests/text.rs
@@ -41,9 +41,9 @@ fn test_monospace_text_is_actually_monospace() {
     let font = graphics::Font::new(ctx, "/DejaVuSansMono.ttf").unwrap();
 
     let text1 = graphics::Text::new(("Hello 1", font, 24.0));
-    let text2 = graphics::Text::new(("Hello 2", font, 24.0));;
-    let text3 = graphics::Text::new(("Hello 3", font, 24.0));;
-    let text4 = graphics::Text::new(("Hello 4", font, 24.0));;
+    let text2 = graphics::Text::new(("Hello 2", font, 24.0));
+    let text3 = graphics::Text::new(("Hello 3", font, 24.0));
+    let text4 = graphics::Text::new(("Hello 4", font, 24.0));
 
     let width1 = text1.width(ctx);
     let width2 = text3.width(ctx);


### PR DESCRIPTION
Hi,

My application involves some distance field rendering on the GPU, which needs a floating point render target. I've added an extra parameter to Canvas::new() function and a bunch of other really minor things.

The other thing is the "MeshBatch" struct that can be used to render instanced geometry, works similarly to the current "SpriteBatch"-es, but tries to cache instance data and only update it when necessary.

Thanks.