### PR TITLE
Link to a ggez+legion template in the FAQ.

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -149,11 +149,11 @@ graphics::set_screen_coordinates(&mut context, Rect::new(0.0, 0.0, 1.0, 1.0)).un
 
 and scaling your `Image`s with `graphics::DrawParam`.
 
-# Can I use `specs` or another entity-component system?
+# Can I use `specs`, `legion` or another entity-component system?
 
 Sure!  ggez doesn't include such a thing itself, since it's more or less out of scope for this, but it is specifically
 designed to make it easy to Lego together with other tools.  The [game template](https://github.com/ggez/game-template) repo
-demonstrates how to use ggez with `specs` for ECS, `warmy` for resource loading, and other nice crates.
+demonstrates how to use ggez with `specs` for ECS, `warmy` for resource loading, and other nice crates. This template is available with `legion` in place of `specs` as well [here](https://github.com/Quetzal2/game-template).
 
 # If I write X, will you include it in ggez?
 


### PR DESCRIPTION
Added a link to a version of the ggez-template using `legion` in place of `specs`.