### PR TITLE
System deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 cache: cargo
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then cargo test headless; cargo test --doc; cargo test --test skeptic; fi
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then cargo test --test skeptic; cargo test headless; cargo test --doc; fi
 #  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cargo test --verbose headless --no-default-features; fi
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ For details, see [docs/BuildingForEveryPlatform.md](docs/BuildingForEveryPlatfor
 
 Check out the [projects list!](docs/Projects.md)
 
+## System dependencies
+
+On Ubuntu, you can install the dependencies with:
+```bash
+sudo apt-get install libudev-dev
+sudo apt-get install libasound2-dev
+```
+If you're on some other Linux platform, find the corresponding packages.
+
 ## Usage
 
 ggez requires rustc >= 1.36 and is distributed on

--- a/docs/Projects.md
+++ b/docs/Projects.md
@@ -6,7 +6,7 @@ submit a PR, please!
 ## Games!
 
  * <https://github.com/ozkriff/zemeroth>
- * Le Train Dispatcher: <https://athorus.itch.io/ltd>
+ * <https://athorus.itch.io/ltd>: Le Train Dispatcher allows you to route trains in a fully simulated rail network. Particular care has been taken on the realistic management of light signals (block systems, switches protection), train physics and curve tracing.
  * <https://github.com/Piripant/sudoku>
 
 # 0.4.x
@@ -42,7 +42,7 @@ submit a PR, please!
 ## Games
 
  * <https://github.com/obsoke/rustris>
- * <https://rap2hpoutre.github.io/llamassacre-website/> 
+ * <https://rap2hpoutre.github.io/llamassacre-website/>
 
 ## Examples/tutorial code
 


### PR DESCRIPTION
# Overview
When trying to use `ggez` in a project, the install failed due to missing system dependencies:
* `libudev-dev` (for `Ubuntu`; different for other distros).
* `libasound2-dev` (for `Ubuntu`; different for other distros).
So I've added a section, `System dependencies`, to the README.

# Information
* OS: `Ubuntu 19.10`.
* Cargo version: `cargo 1.40.0 (bc8e4c8be 2019-11-22)`.
* GGEZ version: `0.5.1`.

# `cargo`'s output.
## Before installing `libudev-dev`.
```
   Compiling libc v0.2.66
   Compiling cfg-if v0.1.10
   Compiling autocfg v1.0.0
   Compiling serde v1.0.104
   Compiling cc v1.0.50
   Compiling autocfg v0.1.7
   Compiling semver-parser v0.7.0
   Compiling proc-macro2 v0.4.30
   Compiling unicode-xid v0.1.0
   Compiling xml-rs v0.8.0
   Compiling bitflags v1.2.1
   Compiling log v0.4.8
   Compiling byteorder v1.3.2
   Compiling pkg-config v0.3.17
   Compiling khronos_api v3.1.0
   Compiling scopeguard v1.0.0
   Compiling syn v0.15.44
   Compiling maybe-uninit v2.0.0
   Compiling rand_core v0.4.2
   Compiling void v1.0.2
   Compiling linked-hash-map v0.5.2
   Compiling arrayvec v0.5.1
   Compiling proc-macro2 v1.0.8
   Compiling nix v0.14.1
   Compiling same-file v1.0.6
   Compiling unicode-xid v0.2.0
   Compiling getrandom v0.1.14
   Compiling syn v1.0.14
   Compiling ryu v1.0.2
   Compiling arrayvec v0.4.12
   Compiling version_check v0.1.5
   Compiling ppv-lite86 v0.2.6
   Compiling rustc-demangle v0.1.16
   Compiling nodrop v0.1.14
   Compiling downcast-rs v1.1.1
   Compiling xdg v2.2.0
   Compiling itoa v0.4.4
   Compiling crc32fast v1.2.0
   Compiling pulldown-cmark v0.2.0
   Compiling libm v0.1.4
   Compiling typenum v1.11.2
   Compiling nix v0.15.0
   Compiling remove_dir_all v0.5.2
   Compiling num-derive v0.2.5
   Compiling adler32 v1.0.4
   Compiling percent-encoding v2.1.0
   Compiling xi-unicode v0.2.0
   Compiling glob v0.2.11
   Compiling bytecount v0.4.0
   Compiling rawpointer v0.2.1
   Compiling lzw v0.10.0
   Compiling mint v0.5.4
   Compiling uuid v0.8.1
   Compiling color_quant v1.0.1
   Compiling vec_map v0.8.1
   Compiling claxon v0.4.2
   Compiling hound v3.4.0
   Compiling podio v0.1.6
   Compiling fnv v1.0.6
   Compiling num-traits v0.2.11
   Compiling num-integer v0.1.42
   Compiling num-complex v0.2.4
   Compiling num-rational v0.2.3
   Compiling num-iter v0.1.40
   Compiling crossbeam-utils v0.7.0
   Compiling crossbeam-epoch v0.8.0
   Compiling rand_chacha v0.1.1
   Compiling rand_pcg v0.1.2
   Compiling rand v0.6.5
   Compiling libloading v0.5.2
   Compiling backtrace-sys v0.1.32
   Compiling minimp3-sys v0.3.1
   Compiling bzip2-sys v0.1.7
   Compiling x11-dl v2.18.4
   Compiling libudev-sys v0.1.4
   Compiling alsa-sys v0.1.2
   Compiling lock_api v0.3.3
   Compiling rand_core v0.3.1
   Compiling rand_jitter v0.1.4
   Compiling walkdir v2.3.1
   Compiling error-chain v0.12.1
   Compiling c2-chacha v0.2.3
   Compiling inflate v0.4.5
   Compiling matrixmultiply v0.2.3
   Compiling gif v0.10.3
error: failed to run custom build command for `libudev-sys v0.1.4`

Caused by:
  process didn't exit successfully: `/home/kove/Documents/gol/target/debug/build/libudev-sys-a2baf8f556bbfbfe/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "`\"pkg-config\" \"--libs\" \"--cflags\" \"libudev\"` did not exit successfully: exit code: 1\n--- stderr\nPackage libudev was not found in the pkg-config search path.\nPerhaps you should add the directory containing `libudev.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'libudev\' found\n"', src/libcore/result.rs:1165:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
```
So I did some research and ran:
```
sudo apt-get install libudev-dev
```
I then ran the build again.
## Before installing `libasound2-dev`.
```
   Compiling libudev-sys v0.1.4
   Compiling alsa-sys v0.1.2
error: failed to run custom build command for `alsa-sys v0.1.2`

Caused by:
  process didn't exit successfully: `/home/kove/Documents/gol/target/debug/build/alsa-sys-ccc713fee0bc9388/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "`\"pkg-config\" \"--libs\" \"--cflags\" \"alsa\"` did not exit successfully: exit code: 1\n--- stderr\nPackage alsa was not found in the pkg-config search path.\nPerhaps you should add the directory containing `alsa.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'alsa\' found\n"', src/libcore/result.rs:1165:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
```
So I did some research and ran:
```
sudo apt-get install libasound2-dev
```
**And now it installs just fine!**