### PR TITLE
Fixed upside-down screenshot & report error for antialiased Screenshot

### DIFF
--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -213,10 +213,18 @@ impl Image {
         let reader = gfx.factory.read_mapping(&dl_buffer)?;
 
         // intermediary buffer to avoid casting.
-        // Apparently this also at one point made the screenshot upside-down,
-        // but no longer?
         let mut data = Vec::with_capacity(self.width as usize * self.height as usize * 4);
-        data.extend(reader.into_iter().flatten());
+        // Assuming OpenGL backend whose typical readback option (glReadPixels) has origin at bottom left.
+        // Image formats on the other hand usually deal with top right.
+        for y in (0..self.height as usize).rev() {
+            data.extend(
+                reader
+                    .iter()
+                    .skip(y * self.width as usize)
+                    .take(self.width as usize)
+                    .flatten(),
+            );
+        }
         Ok(data)
     }
 

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -504,9 +504,6 @@ pub fn present(ctx: &mut Context) -> GameResult<()> {
 /// Take a screenshot by outputting the current render surface
 /// (screen or selected canvas) to an `Image`.
 pub fn screenshot(ctx: &mut Context) -> GameResult<Image> {
-    // TODO LATER: This makes the screenshot upside-down form some reason...
-    // Probably because all our images are upside down, for coordinate reasons!
-    // How can we fix it?
     use gfx::memory::Bind;
     let debug_id = DebugId::get(ctx);
 
@@ -1059,5 +1056,4 @@ mod tests {
             assert_relative_eq!(real, expected);
         }
     }
-
 }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -509,6 +509,11 @@ pub fn screenshot(ctx: &mut Context) -> GameResult<Image> {
 
     let gfx = &mut ctx.gfx_context;
     let (w, h, _depth, aa) = gfx.data.out.get_dimensions();
+    if aa != gfx_core::texture::AaMode::Single {
+        // Details see https://github.com/ggez/ggez/issues/751
+        return Err(GameError::RenderError("Can't take screenshots of anti aliased textures.\n(since neither copying or resolving them is supported right now)".to_string()));
+    }
+
     let surface_format = gfx.color_format();
     let gfx::format::Format(surface_type, channel_type) = surface_format;
 

--- a/src/tests/graphics.rs
+++ b/src/tests/graphics.rs
@@ -30,6 +30,12 @@ fn save_screenshot() {
     .unwrap();
     graphics::draw(c, &tri_mesh, graphics::DrawParam::default()).unwrap();
     graphics::present(c).unwrap();
+
+    // Right now what we're screenshoting is not the front buffer, but the backbuffer.
+    // I.e. since we're double buffering we're always one picture in the past.
+    // Querying the front buffer can be much slower, so probably we should keep it as is.
+    graphics::present(c).unwrap();
+
     let screenshot = graphics::screenshot(c).unwrap();
     screenshot
         .encode(c, graphics::ImageFormat::Png, "/screenshot_test.png")

--- a/src/tests/graphics.rs
+++ b/src/tests/graphics.rs
@@ -23,9 +23,7 @@ fn get_rgba_sample(rgba_buf: &[u8], width: usize, sample_pos: Point2<f32>) -> (u
     )
 }
 
-#[test]
-fn save_screenshot() {
-    let (c, _e) = &mut tests::make_context();
+fn save_screenshot_test(c: &mut Context) {
     graphics::clear(c, Color::new(0.1, 0.2, 0.3, 1.0));
 
     let width = graphics::drawable_size(c).0;
@@ -101,6 +99,21 @@ fn save_screenshot() {
         .encode(c, graphics::ImageFormat::Png, "/screenshot_test.png")
         .unwrap();
 }
+
+#[test]
+fn save_screenshot() {
+    let (c, _e) = &mut tests::make_context();
+    save_screenshot_test(c);
+}
+
+// Not supported, see https://github.com/ggez/ggez/issues/751
+// #[test]
+// fn save_screenshot_with_antialiasing() {
+//     let cb = ContextBuilder::new("ggez_unit_tests", "ggez")
+//         .window_setup(conf::WindowSetup::default().samples(conf::NumSamples::Eight));
+//     let (c, _e) = &mut tests::make_context_from_contextbuilder(cb);
+//     save_screenshot_test(c);
+// }
 
 #[test]
 fn load_images() {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,13 +11,17 @@ mod graphics;
 mod mesh;
 mod text;
 
-/// Make a basic `Context` with sane defaults.
-pub fn make_context() -> (Context, event::EventsLoop) {
-    let mut cb = ContextBuilder::new("ggez_unit_tests", "ggez");
+pub fn make_context_from_contextbuilder(mut cb: ContextBuilder) -> (Context, event::EventsLoop) {
     if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");
         cb = cb.add_resource_path(path);
     }
     cb.build().unwrap()
+}
+
+/// Make a basic `Context` with sane defaults.
+pub fn make_context() -> (Context, event::EventsLoop) {
+    let cb = ContextBuilder::new("ggez_unit_tests", "ggez");
+    make_context_from_contextbuilder(cb)
 }


### PR DESCRIPTION
For discussion on how taking screenshots of antialiased targets doesn't work see https://github.com/ggez/ggez/issues/751

* fixed and enhanced screenshot test
  * left screenshot test with AA and necessary changes in (will remove if that's desired instead, feature won't work for quite some time I'd expect)
* fixed screenshots being upside down inside graphics::Image
* report RenderError when trying to take screenshot of a target with anti aliasing