### PR TITLE
Make uv consistent in vertex builder

### DIFF
--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -389,7 +389,7 @@ impl t::VertexConstructor<t::FillVertex, Vertex> for VertexBuilder {
     fn new_vertex(&mut self, vertex: t::FillVertex) -> Vertex {
         Vertex {
             pos: [vertex.position.x, vertex.position.y],
-            uv: [vertex.position.x, vertex.position.y],
+            uv: [0.0, 0.0],
             color: self.color.into(),
         }
     }


### PR DESCRIPTION
Using the position as uv for the FillVertex builder is pretty arbitrary and not consistent with the [StrokeVertex builder](https://github.com/ggez/ggez/blob/master/src/graphics/mesh.rs#L402). 
I'm trying to mix basic shapes and textures shapes in one big mesh (with one image acting as an atlas) and having a consistent uv for basic shapes (not made with MeshBuilder::raw) is important.

EDIT: Actually, I kind of understand why it's the case and I think I'll wait for the new rendering version (ggraphics) before trying anything advanced. 