### PR TITLE
Added EventHandler support for anyhow errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ multithread-image-decoding = ["image/hdr", "image/jpeg_rayon"]
 c_dependencies = ["bzip2", "mp3"]
 
 [dependencies]
+anyhow = "1.0.28"
 bitflags = "1"
 zip = { version = "0.5", default-features = false }
 directories = "2"

--- a/README.md
+++ b/README.md
@@ -101,14 +101,15 @@ to common problems.
 ### Basic Project Template
 
 ```rust,no_run
-use ggez::{graphics, Context, ContextBuilder, GameResult};
+use anyhow;
+use ggez::{graphics, Context, ContextBuilder};
 use ggez::event::{self, EventHandler};
 
 fn main() {
     // Make a Context.
     let (mut ctx, mut event_loop) = ContextBuilder::new("my_game", "Cool Game Author")
-		.build()
-		.expect("aieee, could not create ggez context!");
+        .build()
+        .expect("aieee, could not create ggez context!");
 
     // Create an instance of your event handler.
     // Usually, you should provide it with the Context object to
@@ -136,15 +137,15 @@ impl MyGame {
 }
 
 impl EventHandler for MyGame {
-    fn update(&mut self, _ctx: &mut Context) -> GameResult<()> {
+    fn update(&mut self, _ctx: &mut Context) -> anyhow::Result<()> {
         // Update code here...
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
+    fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
         graphics::clear(ctx, graphics::WHITE);
         // Draw code here...
-        graphics::present(ctx)
+        Ok(graphics::present(ctx)?)
     }
 }
 ```

--- a/docs/guides/GenerativeArt.md
+++ b/docs/guides/GenerativeArt.md
@@ -14,16 +14,17 @@ Modify `Cargo.toml` to include `ggez` in the dependencies.
 Just like in `Hello ggez!`, we're going to use a loop and a struct.
 Let's start with this code in `src/main.rs`:
 ```rust,no_run
+use anyhow;
 use ggez::*;
 
 struct State {
 }
 
 impl ggez::event::EventHandler for State {
-  fn update(&mut self, _ctx: &mut Context) -> GameResult {
+  fn update(&mut self, _ctx: &mut Context) -> anyhow::Result<()> {
       Ok(())
   }
-  fn draw(&mut self, ctx: &mut Context) -> GameResult {
+  fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
       graphics::present(ctx)?;
       Ok(())
   }
@@ -71,7 +72,7 @@ Geometry, it's all coming back now.
 
 Here is the code for a [circle](https://docs.rs/ggez/0.4.0/ggez/graphics/struct.Mesh.html#method.new_circle):
 ```rust,skt-draw,no_run
-fn draw(&mut self, ctx: &mut Context) -> GameResult {
+fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
     let circle = graphics::Mesh::new_circle(
         ctx,
         graphics::DrawMode::fill(),
@@ -108,7 +109,7 @@ And that's how a circle is drawn!
 
 Let's try it out with some quick code:
 ```rust,skt-draw,no_run
-fn draw(&mut self, ctx: &mut Context) -> GameResult {
+fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
     let circle = graphics::Mesh::new_circle(
         ctx,
         graphics::DrawMode::fill(),
@@ -152,7 +153,7 @@ And that's how a rectangle is drawn!
 
 Let's try it out with some quick code:
 ```rust,skt-draw,no_run
-fn draw(&mut self, ctx: &mut Context) -> GameResult {
+fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
     let rect = graphics::Mesh::new_rectangle(
         ctx,
         graphics::DrawMode::fill(),
@@ -227,7 +228,7 @@ We're using `Vec.push` to add 2 new values to our `Vec`.
 But we still don't see anything...
 You need to modify `draw` to illustrate your new `State`.
 ```rust,skt-draw,no_run
-fn draw(&mut self, ctx: &mut Context) -> GameResult {
+fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
     for shape in &self.shapes {
         // Make the shape...
         let mesh = match shape {

--- a/docs/guides/GenerativeArt.md.skt.md
+++ b/docs/guides/GenerativeArt.md.skt.md
@@ -4,6 +4,7 @@
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 
+use anyhow;
 use ggez::*;
 use ggez::graphics::*;
 use rand::*;
@@ -25,14 +26,14 @@ impl State {{
 }}
 
 impl event::EventHandler for State {{
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {{
+    fn update(&mut self, _ctx: &mut Context) -> anyhow::Result<()> {{
         Ok(())
     }}
 
     {}
 }}
 
-pub fn main() -> GameResult {{
+pub fn main() -> anyhow::Result<()> {{
     Ok(())
 }}
 ```
@@ -43,6 +44,7 @@ pub fn main() -> GameResult {{
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 
+use anyhow;
 use ggez::*;
 use ggez::graphics::*;
 use rand::*;
@@ -108,6 +110,7 @@ use ggez::graphics::*;
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 
+use anyhow;
 use ggez::*;
 use ggez::graphics::*;
 use ggez::event::*;
@@ -122,11 +125,11 @@ struct State {{
 }}
 
 impl event::EventHandler for State {{
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {{
+    fn update(&mut self, _ctx: &mut Context) -> anyhow::Result<()> {{
         Ok(())
     }}
 
-    fn draw(&mut self, _ctx: &mut Context) -> GameResult {{
+    fn draw(&mut self, _ctx: &mut Context) -> anyhow::Result<()> {{
         Ok(())
     }}
 }}

--- a/docs/guides/HelloGgez.md
+++ b/docs/guides/HelloGgez.md
@@ -84,10 +84,10 @@ Let's add `EventHandler` to our `src/main.rs` file:
 struct State {}
 
 impl ggez::event::EventHandler for State {
-  fn update(&mut self, ctx: &mut Context) -> GameResult<()> {
+  fn update(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
       Ok(())
   }
-  fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
+  fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
       Ok(())
   }
 }
@@ -129,7 +129,7 @@ warning: unused variable: `state`
 warning: unused variable: `ctx`
  --> src\main.rs:9:24
   |
-9 |   fn update(&mut self, ctx: &mut Context) -> GameResult<()> {
+9 |   fn update(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
   |                        ^^^
   |
   = note: to avoid this warning, consider using `_ctx` instead
@@ -137,7 +137,7 @@ warning: unused variable: `ctx`
 warning: unused variable: `ctx`
   --> src\main.rs:13:22
    |
-13 |   fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
+13 |   fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
    |                      ^^^
    |
    = note: to avoid this warning, consider using `_ctx` instead
@@ -184,7 +184,7 @@ You should get 2 warnings:
 warning: unused variable: `ctx`
  --> src\main.rs:9:24
   |
-9 |   fn update(&mut self, ctx: &mut Context) -> GameResult<()> {
+9 |   fn update(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
   |                        ^^^
   |
   = note: #[warn(unused_variables)] on by default
@@ -193,7 +193,7 @@ warning: unused variable: `ctx`
 warning: unused variable: `ctx`
   --> src\main.rs:13:22
    |
-13 |   fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
+13 |   fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
    |                      ^^^
    |
    = note: to avoid this warning, consider using `_ctx` instead
@@ -228,7 +228,7 @@ let state = &mut State { dt: std::time::Duration::new(0, 0) };
 So now that we have state to update, let's update it in our `update` callback!
 We'll use [`timer::delta`](https://docs.rs/ggez/0.4.0/ggez/timer/fn.delta.html) to get the delta time.
 ```rust,skt-update,no_run
-fn update(&mut self, ctx: &mut Context) -> GameResult {
+fn update(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
     self.dt = timer::delta(ctx);
     Ok(())
 }
@@ -236,7 +236,7 @@ fn update(&mut self, ctx: &mut Context) -> GameResult {
 
 To see the changes in `State`, you need to modify the `draw` callback.
 ```rust,skt-draw,no_run
-fn draw(&mut self, ctx: &mut Context) -> GameResult {
+fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
     println!("Hello ggez! dt = {}ns", self.dt.subsec_nanos());
     Ok(())
 }

--- a/docs/guides/HelloGgez.md.skt.md
+++ b/docs/guides/HelloGgez.md.skt.md
@@ -4,6 +4,7 @@
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 
+use anyhow;
 use ggez::*;
 use ggez::graphics::*;
 use ggez::event::*;
@@ -14,14 +15,14 @@ struct State {{
 }}
 
 impl EventHandler for State {{
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {{
+    fn update(&mut self, _ctx: &mut Context) -> anyhow::Result<()> {{
         Ok(())
     }}
 
     {}
 }}
 
-pub fn main() -> GameResult {{
+pub fn main() -> anyhow::Result<()> {{
     Ok(())
 }}
 ```
@@ -32,6 +33,7 @@ pub fn main() -> GameResult {{
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 
+use anyhow;
 use ggez::*;
 use ggez::graphics::*;
 
@@ -42,14 +44,14 @@ struct State {{
 }}
 
 impl event::EventHandler for State {{
-    fn draw(&mut self, _ctx: &mut Context) -> GameResult {{
+    fn draw(&mut self, _ctx: &mut Context) -> anyhow::Result<()> {{
         Ok(())
     }}
 
     {}
 }}
 
-pub fn main() -> GameResult {{
+pub fn main() -> anyhow::Result<()> {{
     Ok(())
 }}
 ```
@@ -60,6 +62,8 @@ pub fn main() -> GameResult {{
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 
+
+use anyhow;
 use ggez::*;
 use ggez::graphics::*;
 use ggez::event::*;
@@ -71,16 +75,16 @@ struct State {{
 }}
 
 impl EventHandler for State {{
-    fn update(&mut self, _c: &mut Context) -> GameResult {{
+    fn update(&mut self, _c: &mut Context) -> anyhow::Result<()> {{
         Ok(())
     }}
 
-    fn draw(&mut self, _c: &mut Context) -> GameResult {{
+    fn draw(&mut self, _c: &mut Context) -> anyhow::Result<()> {{
         Ok(())
     }}
 }}
 
-pub fn main() -> GameResult {{
+pub fn main() -> anyhow::Result<()> {{
     let (ref mut ctx, ref mut event_loop) = ContextBuilder::new("foo", "bar")
         .build()
         .unwrap();
@@ -97,6 +101,7 @@ pub fn main() -> GameResult {{
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 
+use anyhow;
 use ggez::*;
 use ggez::graphics::*;
 
@@ -113,6 +118,7 @@ fn main() {{
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 
+use anyhow;
 use ggez::*;
 use ggez::graphics::*;
 

--- a/examples/01_super_simple.rs
+++ b/examples/01_super_simple.rs
@@ -1,5 +1,6 @@
 //! The simplest possible example that does something.
 
+use anyhow::Result;
 use ggez;
 use ggez::event;
 use ggez::graphics;
@@ -18,12 +19,12 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, _ctx: &mut Context) -> Result<()> {
         self.pos_x = self.pos_x % 800.0 + 1.0;
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
         let circle = graphics::Mesh::new_circle(
@@ -41,7 +42,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let cb = ggez::ContextBuilder::new("super_simple", "ggez");
     let (ctx, event_loop) = &mut cb.build()?;
     let state = &mut MainState::new()?;

--- a/examples/02_hello_world.rs
+++ b/examples/02_hello_world.rs
@@ -3,6 +3,7 @@
 use cgmath;
 use ggez;
 
+use anyhow::Result;
 use ggez::event;
 use ggez::graphics;
 use ggez::{Context, GameResult};
@@ -33,11 +34,11 @@ impl MainState {
 // The `EventHandler` trait also contains callbacks for event handling
 // that you can override if you wish, but the defaults are fine.
 impl event::EventHandler for MainState {
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, _ctx: &mut Context) -> Result<()> {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
         // Drawables are drawn from their top-left corner.
@@ -63,7 +64,7 @@ impl event::EventHandler for MainState {
 // * Second, create a `ggez::game::Game` object which will
 // do the work of creating our MainState and running our game.
 // * Then, just call `game.run()` which runs the `Game` mainloop.
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     // We add the CARGO_MANIFEST_DIR/resources to the resource paths
     // so that ggez will look in our cargo project directory for files.
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {

--- a/examples/03_drawing.rs
+++ b/examples/03_drawing.rs
@@ -2,6 +2,7 @@
 
 use cgmath;
 
+use anyhow::Result;
 use ggez;
 use ggez::event;
 use ggez::graphics;
@@ -104,7 +105,7 @@ fn build_textured_triangle(ctx: &mut Context) -> GameResult<graphics::Mesh> {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         const DESIRED_FPS: u32 = 60;
 
         while timer::check_update_time(ctx, DESIRED_FPS) {
@@ -113,7 +114,7 @@ impl event::EventHandler for MainState {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
         // Draw an image.
@@ -170,7 +171,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");

--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -17,6 +17,9 @@
 use ggez;
 use rand;
 
+// Get anyhow
+use anyhow::Result;
+
 // Next we need to actually `use` the pieces of ggez that we are going
 // to need frequently.
 use ggez::event::{KeyCode, KeyMods};
@@ -215,7 +218,7 @@ impl Food {
     /// Note: this method of drawing does not scale. If you need to render
     /// a large number of shapes, use a SpriteBatch. This approach is fine for
     /// this example since there are a fairly limited number of calls.
-    fn draw(&self, ctx: &mut Context) -> GameResult<()> {
+    fn draw(&self, ctx: &mut Context) -> GameResult {
         // First we set the color to draw with, in this case all food will be
         // colored blue.
         let color = [0.0, 0.0, 1.0, 1.0].into();
@@ -274,7 +277,7 @@ impl Snake {
             last_update_dir: Direction::Right,
             body: body,
             ate: None,
-            next_dir: None
+            next_dir: None,
         }
     }
 
@@ -347,7 +350,7 @@ impl Snake {
     /// Again, note that this approach to drawing is fine for the limited scope of this
     /// example, but larger scale games will likely need a more optimized render path
     /// using SpriteBatch or something similar that batches draw calls.
-    fn draw(&self, ctx: &mut Context) -> GameResult<()> {
+    fn draw(&self, ctx: &mut Context) -> GameResult {
         // We first iterate through the body segments and draw them.
         for seg in self.body.iter() {
             // Again we set the color (in this case an orangey color)
@@ -411,7 +414,7 @@ impl GameState {
 impl event::EventHandler for GameState {
     /// Update will happen on every frame before it is drawn. This is where we update
     /// our game state to react to whatever is happening in the game world.
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, _ctx: &mut Context) -> Result<()> {
         // First we check to see if enough time has elapsed since our last update based on
         // the update rate we defined at the top.
         if Instant::now() - self.last_update >= Duration::from_millis(MILLIS_PER_UPDATE) {
@@ -445,7 +448,7 @@ impl event::EventHandler for GameState {
     }
 
     /// draw is where we should actually render the game's current state.
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         // First we clear the screen to a nice (well, maybe pretty glaring ;)) green
         graphics::clear(ctx, [0.0, 1.0, 0.0, 1.0].into());
         // Then we tell the snake and the food to draw themselves
@@ -485,7 +488,7 @@ impl event::EventHandler for GameState {
     }
 }
 
-fn main() -> GameResult {
+fn main() -> Result<()> {
     // Here we use a ContextBuilder to setup metadata about our game. First the title and author
     let (ctx, events_loop) = &mut ggez::ContextBuilder::new("snake", "Gray Olson")
         // Next we set up the window. This title will be displayed in the title bar of the window.

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -2,6 +2,7 @@
 //! The idea is that this game is simple but still
 //! non-trivial enough to be interesting.
 
+use anyhow::Result;
 use ggez;
 use ggez::audio;
 use ggez::audio::SoundSource;
@@ -424,7 +425,7 @@ fn draw_actor(
 /// handling input events.
 /// **********************************************************************
 impl EventHandler for MainState {
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         const DESIRED_FPS: u32 = 60;
 
         while timer::check_update_time(ctx, DESIRED_FPS) {
@@ -481,7 +482,7 @@ impl EventHandler for MainState {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         // Our drawing is quite simple.
         // Just clear the screen...
         graphics::clear(ctx, graphics::BLACK);
@@ -580,7 +581,7 @@ impl EventHandler for MainState {
 /// `ggez::event::run()` with our `EventHandler` type.
 /// **********************************************************************
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     // We add the CARGO_MANIFEST_DIR/resources to the resource paths
     // so that ggez will look in our cargo project directory for files.
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -4,6 +4,8 @@
 use std::env;
 use std::path;
 
+use anyhow::Result;
+
 use nalgebra as na;
 use rand::rngs::ThreadRng;
 use rand::{self, Rng};
@@ -77,7 +79,7 @@ impl GameState {
 }
 
 impl event::EventHandler for GameState {
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, _ctx: &mut Context) -> Result<()> {
         if self.click_timer > 0 {
             self.click_timer -= 1;
         }
@@ -110,7 +112,7 @@ impl event::EventHandler for GameState {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, Color::from((0.392, 0.584, 0.929)));
 
         if self.batched_drawing {
@@ -167,7 +169,7 @@ impl event::EventHandler for GameState {
     }
 }
 
-fn main() -> GameResult {
+fn main() -> Result<()> {
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");

--- a/examples/canvas_subframe.rs
+++ b/examples/canvas_subframe.rs
@@ -6,6 +6,7 @@ extern crate cgmath;
 extern crate ggez;
 extern crate rand;
 
+use anyhow::Result;
 use ggez::event;
 use ggez::graphics;
 use ggez::timer;
@@ -89,7 +90,7 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         if timer::ticks(ctx) % 100 == 0 {
             println!("Delta frame time: {:?} ", timer::delta(ctx));
             println!("Average FPS: {}", timer::fps(ctx));
@@ -109,7 +110,7 @@ impl event::EventHandler for MainState {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
         self.draw_spritebatch(ctx)?;
         let dims = self.canvas.image().dimensions();
@@ -127,7 +128,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     if cfg!(debug_assertions) && env::var("yes_i_really_want_debug_mode").is_err() {
         eprintln!(
             "Note: Release mode will improve performance greatly.\n    \

--- a/examples/colorspace.rs
+++ b/examples/colorspace.rs
@@ -66,6 +66,7 @@
 //! into sRGB for you to match everything else.  The purpose of this
 //! example is to show that this actually *works* correctly!
 
+use anyhow::Result;
 use ggez;
 use ggez::event;
 use ggez::graphics::{self, DrawParam};
@@ -110,11 +111,11 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, _ctx: &mut Context) -> Result<()> {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, AQUA);
 
         // Draw a white square so we can see things
@@ -144,7 +145,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     use std::env;
     use std::path;
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -10,13 +10,15 @@ extern crate gfx_device_gl;
 extern crate ggez;
 extern crate nalgebra;
 
+use anyhow::Result;
+
 use gfx::texture;
 use gfx::traits::FactoryExt;
 use gfx::Factory;
 
 use ggez::event;
 use ggez::graphics;
-use ggez::{Context, GameResult};
+use ggez::Context;
 use nalgebra as na;
 use std::env;
 use std::f32;
@@ -205,12 +207,12 @@ void main() {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, _ctx: &mut Context) -> Result<()> {
         self.rotation += 0.01;
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         // Do gfx-rs drawing
         {
             let (_factory, device, encoder, _depthview, _colorview) = graphics::gfx_objects(ctx);
@@ -262,7 +264,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -11,12 +11,13 @@
 use cgmath;
 use ggez;
 
+use anyhow::Result;
 use ggez::event;
 use ggez::event::winit_event::{Event, KeyboardInput, WindowEvent};
 use ggez::graphics::{self, DrawMode};
 use ggez::GameResult;
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let cb = ggez::ContextBuilder::new("eventloop", "ggez");
     let (ctx, events_loop) = &mut cb.build()?;
 

--- a/examples/files.rs
+++ b/examples/files.rs
@@ -6,13 +6,14 @@
 
 use ggez;
 
+use anyhow::Result;
 use ggez::{conf, filesystem, ContextBuilder, GameResult};
 use std::env;
 use std::io::{Read, Write};
 use std::path;
 use std::str;
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let mut cb = ContextBuilder::new("ggez_files_example", "ggez");
 
     // We add the CARGO_MANIFEST_DIR/resources to the filesystems paths so

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -7,6 +7,7 @@ use ggez;
 use nalgebra;
 use structopt;
 
+use anyhow::Result;
 use ggez::conf;
 use ggez::event::{self, KeyCode, KeyMods};
 use ggez::graphics::{self, DrawMode};
@@ -50,7 +51,7 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         const DESIRED_FPS: u32 = 60;
         while timer::check_update_time(ctx, DESIRED_FPS) {
             self.angle += 0.01;
@@ -68,7 +69,7 @@ impl event::EventHandler for MainState {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, graphics::BLACK);
         let rotation = timer::ticks(ctx) % 1000;
         let circle = graphics::Mesh::new_circle(
@@ -202,7 +203,7 @@ struct Opt {
     es: bool,
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let opt = Opt::from_args();
 
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -4,6 +4,7 @@
 use ggez;
 use nalgebra;
 
+use anyhow::Result;
 use ggez::event;
 use ggez::graphics::{self, Color};
 use ggez::{Context, GameResult};
@@ -37,11 +38,11 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, _ctx: &mut Context) -> Result<()> {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         let dest_point = na::Point2::new(10.0, 10.0);
 
         if self.draw_with_canvas {
@@ -105,7 +106,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -2,6 +2,7 @@ use cgmath;
 use ggez;
 use rand;
 
+use anyhow::Result;
 use ggez::audio;
 use ggez::audio::SoundSource;
 use ggez::event;
@@ -73,7 +74,7 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         const DESIRED_FPS: u32 = 60;
         while timer::check_update_time(ctx, DESIRED_FPS) {
             self.a += self.direction;
@@ -87,7 +88,7 @@ impl event::EventHandler for MainState {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         let c = self.a as u8;
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
@@ -118,7 +119,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -2,10 +2,11 @@
 
 use ggez;
 
+use anyhow::Result;
 use ggez::event::{self, Axis, Button, GamepadId, KeyCode, KeyMods, MouseButton};
 use ggez::graphics::{self, DrawMode};
 use ggez::input;
-use ggez::{Context, GameResult};
+use ggez::Context;
 
 struct MainState {
     pos_x: f32,
@@ -24,7 +25,7 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         if input::keyboard::is_key_pressed(ctx, KeyCode::A) {
             println!("The A key is pressed");
             if input::keyboard::is_mod_active(ctx, input::keyboard::KeyMods::SHIFT) {
@@ -38,7 +39,7 @@ impl event::EventHandler for MainState {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
         let rectangle = graphics::Mesh::new_rectangle(
             ctx,
@@ -126,7 +127,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let cb = ggez::ContextBuilder::new("input_test", "ggez");
     let (ctx, event_loop) = &mut cb.build()?;
 

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -12,6 +12,7 @@ extern crate ggez;
 #[macro_use]
 extern crate log;
 
+use anyhow::Result;
 use ggez::conf::{WindowMode, WindowSetup};
 use ggez::event::{EventHandler, KeyCode, KeyMods};
 use ggez::filesystem::{self, File};
@@ -81,7 +82,7 @@ impl App {
 /// Where the app meets the `ggez`.
 impl EventHandler for App {
     /// This is where the logic should happen.
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         const DESIRED_FPS: u32 = 60;
         // This tries to throttle updates to desired value.
         while timer::check_update_time(ctx, DESIRED_FPS) {
@@ -92,7 +93,7 @@ impl EventHandler for App {
     }
 
     /// Draws the screen. We don't really have anything to draw.
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
         graphics::present(ctx)?;
         timer::yield_now();
@@ -127,7 +128,7 @@ impl EventHandler for App {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     // This creates a channel that can be used to asynchronously pass things between parts of the
     // app. There's some overhead, so using it somewhere that doesn't need async (read: threads)
     // is suboptimal. But, `fern`'s arbitrary logging requires a channel.

--- a/examples/render_to_image.rs
+++ b/examples/render_to_image.rs
@@ -3,6 +3,7 @@
 use cgmath;
 use ggez;
 
+use anyhow::Result;
 use ggez::event;
 use ggez::graphics::{self, Color, DrawParam};
 use ggez::{Context, GameResult};
@@ -25,11 +26,11 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, _ctx: &mut Context) -> Result<()> {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         // first lets render to our canvas
         graphics::set_canvas(ctx, Some(&self.canvas));
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
@@ -74,7 +75,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let cb = ggez::ContextBuilder::new("render_to_image", "ggez");
     let (ctx, event_loop) = &mut cb.build()?;
     let state = &mut MainState::new(ctx)?;

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -4,6 +4,7 @@ use cgmath;
 use gfx::{self, *};
 use ggez;
 
+use anyhow::Result;
 use ggez::event;
 use ggez::graphics::{self, DrawMode};
 use ggez::timer;
@@ -39,12 +40,12 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         self.dim.rate = 0.5 + (((timer::ticks(ctx) as f32) / 100.0).cos() / 2.0);
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
         let circle = graphics::Mesh::new_circle(
@@ -86,7 +87,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -5,6 +5,7 @@ use cgmath;
 use gfx::{self, *};
 use ggez;
 
+use anyhow::Result;
 use cgmath::{Point2, Vector2};
 use ggez::conf;
 use ggez::event;
@@ -322,7 +323,7 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         if timer::ticks(ctx) % 100 == 0 {
             println!("Average FPS: {}", timer::fps(ctx));
         }
@@ -333,7 +334,7 @@ impl event::EventHandler for MainState {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         let origin = DrawParam::new()
             .dest(Point2::new(0.0, 0.0))
             .scale(Vector2::new(0.5, 0.5));
@@ -407,7 +408,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -1,5 +1,6 @@
 use ggez;
 
+use anyhow::Result;
 use ggez::audio;
 use ggez::audio::SoundSource;
 use ggez::event;
@@ -68,11 +69,11 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, _ctx: &mut Context) -> Result<()> {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
         graphics::queue_text(
@@ -112,7 +113,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");

--- a/examples/spritebatch.rs
+++ b/examples/spritebatch.rs
@@ -4,6 +4,7 @@
 
 use ggez;
 
+use anyhow::Result;
 use ggez::event;
 use ggez::graphics;
 use ggez::nalgebra::{Point2, Vector2};
@@ -26,7 +27,7 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         if timer::ticks(ctx) % 100 == 0 {
             println!("Delta frame time: {:?} ", timer::delta(ctx));
             println!("Average FPS: {}", timer::fps(ctx));
@@ -34,7 +35,7 @@ impl event::EventHandler for MainState {
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, graphics::BLACK);
 
         let time = (timer::duration_to_f64(timer::time_since_start(ctx)) * 1000.0) as u32;
@@ -82,7 +83,7 @@ impl event::EventHandler for MainState {
 // Creating a context depends on loading a config file.
 // Loading a config file depends on having FS (or we can just fake our way around it
 // by creating an FS and then throwing it away; the costs are not huge.)
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     if cfg!(debug_assertions) && env::var("yes_i_really_want_debug_mode").is_err() {
         eprintln!(
             "Note: Release mode will improve performance greatly.\n    \

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -4,6 +4,7 @@ use cgmath;
 use ggez;
 use rand;
 
+use anyhow::Result;
 use cgmath::Point2;
 use ggez::conf::{WindowMode, WindowSetup};
 use ggez::event;
@@ -118,13 +119,13 @@ impl App {
 }
 
 impl event::EventHandler for App {
-    fn update(&mut self, ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> Result<()> {
         const DESIRED_FPS: u32 = 60;
         while timer::check_update_time(ctx, DESIRED_FPS) {}
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
         // `Text` can be used in "immediate mode", but it's slightly less efficient
@@ -204,7 +205,7 @@ impl event::EventHandler for App {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     if cfg!(debug_assertions) && env::var("yes_i_really_want_debug_mode").is_err() {
         eprintln!(
             "Note: Release mode will improve performance greatly.\n    \

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -2,6 +2,7 @@
 use ggez;
 use nalgebra;
 
+use anyhow::Result;
 use ggez::event::{self, KeyCode, KeyMods};
 use ggez::graphics::{self, DrawMode};
 use ggez::{Context, GameResult};
@@ -80,12 +81,12 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, _ctx: &mut Context) -> Result<()> {
         self.pos_x = self.pos_x % 800.0 + 1.0;
         Ok(())
     }
 
-    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+    fn draw(&mut self, ctx: &mut Context) -> Result<()> {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
         let origin: na::Point2<f32> = na::Point2::origin();
@@ -122,7 +123,7 @@ impl event::EventHandler for MainState {
     }
 }
 
-pub fn main() -> GameResult {
+pub fn main() -> Result<()> {
     let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
         let mut path = path::PathBuf::from(manifest_dir);
         path.push("resources");

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ use gfx;
 use glutin;
 use winit;
 
+use anyhow;
 use gilrs;
 use image;
 use lyon;

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,6 @@ use gfx;
 use glutin;
 use winit;
 
-use anyhow;
 use gilrs;
 use image;
 use lyon;

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,6 +10,7 @@
 //! source code for this module, or the [`eventloop`
 //! example](https://github.com/ggez/ggez/blob/master/examples/eventloop.rs).
 
+use anyhow;
 use gilrs;
 use winit::{self, dpi};
 
@@ -40,7 +41,6 @@ use self::winit_event::*;
 pub use winit::EventsLoop;
 
 use crate::context::Context;
-use crate::error::GameResult;
 
 /// A trait defining event callbacks.  This is your primary interface with
 /// `ggez`'s event loop.  Implement this trait for a type and
@@ -55,14 +55,14 @@ use crate::error::GameResult;
 pub trait EventHandler {
     /// Called upon each logic update to the game.
     /// This should be where the game's logic takes place.
-    fn update(&mut self, _ctx: &mut Context) -> GameResult;
+    fn update(&mut self, _ctx: &mut Context) -> anyhow::Result<()>;
 
     /// Called to do the drawing of your game.
     /// You probably want to start this with
     /// [`graphics::clear()`](../graphics/fn.clear.html) and end it
     /// with [`graphics::present()`](../graphics/fn.present.html) and
     /// maybe [`timer::yield_now()`](../timer/fn.yield_now.html).
-    fn draw(&mut self, _ctx: &mut Context) -> GameResult;
+    fn draw(&mut self, _ctx: &mut Context) -> anyhow::Result<()>;
 
     /// A mouse button was pressed
     fn mouse_button_down_event(
@@ -160,7 +160,7 @@ pub fn quit(ctx: &mut Context) {
 ///
 /// It does not try to do any type of framerate limiting.  See the
 /// documentation for the [`timer`](../timer/index.html) module for more info.
-pub fn run<S>(ctx: &mut Context, events_loop: &mut EventsLoop, state: &mut S) -> GameResult
+pub fn run<S>(ctx: &mut Context, events_loop: &mut EventsLoop, state: &mut S) -> anyhow::Result<()>
 where
     S: EventHandler,
 {

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -3,6 +3,7 @@
 //! Example:
 //!
 //! ```rust, compile
+//! use anyhow;
 //! use ggez::event::{self, EventHandler, KeyCode, KeyMods};
 //! use ggez::{graphics, nalgebra as na, timer};
 //! use ggez::input::keyboard;
@@ -13,7 +14,7 @@
 //! }
 //!
 //! impl EventHandler for MainState {
-//!     fn update(&mut self, ctx: &mut Context) -> GameResult {
+//!     fn update(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
 //!         // Increase or decrease `position_x` by 0.5, or by 5.0 if Shift is held.
 //!         if keyboard::is_key_pressed(ctx, KeyCode::Right) {
 //!             if keyboard::is_mod_active(ctx, KeyMods::SHIFT) {
@@ -29,7 +30,7 @@
 //!         Ok(())
 //!     }
 //!
-//!     fn draw(&mut self, ctx: &mut Context) -> GameResult {
+//!     fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
 //!         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 //!         // Create a circle at `position_x` and draw
 //!         let circle = graphics::Mesh::new_circle(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! ## Basic Project Template
 //!
 //! ```rust,no_run
+//! use anyhow;
 //! use ggez::{Context, ContextBuilder, GameResult};
 //! use ggez::event::{self, EventHandler};
 //! use ggez::graphics;
@@ -63,17 +64,17 @@
 //! }
 //!
 //! impl EventHandler for MyGame {
-//!     fn update(&mut self, _ctx: &mut Context) -> GameResult<()> {
+//!     fn update(&mut self, _ctx: &mut Context) -> anyhow::Result<()> {
 //!         // Update code here...
 //! #       Ok(())
 //!     }
 //!
-//!     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
+//!     fn draw(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
 //!         graphics::clear(ctx, graphics::WHITE);
 //!
 //!         // Draw code here...
 //!
-//!         graphics::present(ctx)
+//!         Ok(graphics::present(ctx)?)
 //!     }
 //! }
 //!

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -220,17 +220,18 @@ pub fn time_since_start(ctx: &Context) -> time::Duration {
 /// in your `update()` callback:
 ///
 /// ```rust
+/// # use anyhow;
 /// # use ggez::*;
 /// # fn update_game_physics() -> GameResult { Ok(()) }
 /// # struct State;
 /// # impl ggez::event::EventHandler for State {
-/// fn update(&mut self, ctx: &mut Context) -> GameResult {
+/// fn update(&mut self, ctx: &mut Context) -> anyhow::Result<()> {
 ///     while(timer::check_update_time(ctx, 60)) {
 ///         update_game_physics()?;
 ///     }
 ///     Ok(())
 /// }
-/// # fn draw(&mut self, _ctx: &mut Context) -> GameResult { Ok(()) }
+/// # fn draw(&mut self, _ctx: &mut Context) -> anyhow::Result<()> { Ok(()) }
 /// # }
 /// ```
 pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {


### PR DESCRIPTION
One of the issues with ggez as it stands right now is you can only return ggez errors through the result in the `EventHandler`'s `update()` and `draw()`. This makes it so that any error handling code that you'd want to cause an error all the way through to main will have to either panic, or get somehow converted into a `GameResult` object, which will likely loose any context on the original error.

My proposed solution on this is to use the anyhow crate. This allows you to return any error that implements `std::error::Error`. It essentially acts like a `Box<dyn std::error::Error>`, with a couple of caveats and added features (like guaranteed backtraces and the ability to add context to an error). While this is generally not suited for libraries since it can be overly broad and partially boxes any user of the library to use `anyhow` for error handling, I believe this is appropriate here since there's not many other ways of allowing users to return any error result they want through the event handler.

That all being said, if there's any suggestions for what a better way of doing error handling here is (even if that suggestion is leaving it as is), I'm all ears.