### PR TITLE
Show a more useful `Debug` string for `filseystem::File`s

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -53,20 +53,10 @@ pub struct Filesystem {
 
 /// Represents a file, either in the filesystem, or in the resources zip file,
 /// or whatever.
+#[derive(Debug)]
 pub enum File {
     /// A wrapper for a VFile trait object.
     VfsFile(Box<dyn vfs::VFile>),
-}
-
-impl fmt::Debug for File {
-    // Make this more useful?
-    // But we can't seem to get a filename out of a file,
-    // soooooo.
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            File::VfsFile(ref _file) => write!(f, "VfsFile"),
-        }
-    }
 }
 
 impl io::Read for File {


### PR DESCRIPTION
Hello! ggez is great!

I ran into a problem trying to figure out where my files where and just having `VfsFile` when printing debug strings wasn't super helpful. After poking around I ended up doing something locally just to get the filename out, but looking at the ggez code it can easily be done here.

At first I changed the impl Debug to
```rust
impl fmt::Debug for File {
    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
        match *self {
            File::VfsFile(ref file) => write!(f, "VfsFile {:?}", file),
        }
    }
}
```

but then I figured the `derive(Debug)` string would end up being similar which it did, this looks something like
```
VfsFile(File { fd: 3, path: \"<INSERT YOU GGEZ PATH HERE>"/ggez/resources/testfile.txt\", read: true, write: false })
```
Which seems a bit more useful. I'd be happy to add a test for this as well, but I could only come up with just comparing the string to see if it starts with `VfsFile(File {` which doesn't seem that satisfactory.

I should note I only tested this on linux, so I guess I should test whether this explodes on other systems or for some other reason that I isn't obvious to me.