### PR TITLE
Bump `nalgebra` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ toml = "0.5"
 log = "0.4"
 lyon = "0.13"
 smart-default = "0.5"
-nalgebra = {version = "0.18", features = ["mint"] }
+nalgebra = {version = "0.21", features = ["mint"] }
 # Has to be the same version of mint that nalgebra uses here.
 mint = "0.5"
 gilrs = "0.7"
@@ -68,4 +68,3 @@ skeptic = "0.13"
 
 [build-dependencies]
 skeptic = "0.13"
-


### PR DESCRIPTION
This bumps the `nalgebra` dependency in order to get away from an old version of `rand` that is injected. Currently 3 versions of `rand` are included in the `ggez` dependency graph, with the oldest coming via `skeptic`. Improving that is tracked here: https://github.com/budziq/rust-skeptic/pull/115.

`nalgebra` and `mint` seem to still be compatible, as marked in `Cargo.toml`.

Tests don't seem to pass locally - it freezes for me after a while when trying to open a `ggez` window and load some audio.