### PR TITLE
Use ggez::nalgebra instead of nalgebra in examples. Fix #802.

### DIFF
--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -10,7 +10,7 @@ use ggez::event::{self, EventHandler, KeyCode, KeyMods};
 use ggez::graphics;
 use ggez::timer;
 use ggez::{Context, ContextBuilder, GameResult};
-use nalgebra as na;
+use ggez::nalgebra as na;
 use rand;
 
 use std::env;

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -4,7 +4,7 @@
 use std::env;
 use std::path;
 
-use nalgebra as na;
+use ggez::nalgebra as na;
 use rand::rngs::ThreadRng;
 use rand::{self, Rng};
 

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -17,7 +17,7 @@ use gfx::Factory;
 use ggez::event;
 use ggez::graphics;
 use ggez::{Context, GameResult};
-use nalgebra as na;
+use ggez::nalgebra as na;
 use std::env;
 use std::f32;
 use std::path;

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -17,7 +17,7 @@ use structopt::StructOpt;
 use std::env;
 use std::path;
 
-use nalgebra as na;
+use ggez::nalgebra as na;
 type Point2 = na::Point2<f32>;
 
 struct WindowSettings {

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -7,7 +7,7 @@ use nalgebra;
 use ggez::event;
 use ggez::graphics::{self, Color};
 use ggez::{Context, GameResult};
-use nalgebra as na;
+use ggez::nalgebra as na;
 use std::env;
 use std::path;
 

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -5,7 +5,7 @@ use nalgebra;
 use ggez::event::{self, KeyCode, KeyMods};
 use ggez::graphics::{self, DrawMode};
 use ggez::{Context, GameResult};
-use nalgebra as na;
+use ggez::nalgebra as na;
 use std::env;
 use std::path;
 


### PR DESCRIPTION
With this, you can turn an example into a crate just by adding `ggez` and `rand` as dependencies.
Otherwise you need to add the same version of `nalgebra` as used by your version of `ggez`.
Proposed by @Kinrany