### PR TITLE
02_hello_world.rs

### DIFF
--- a/examples/02_hello_world.rs
+++ b/examples/02_hello_world.rs
@@ -9,6 +9,7 @@ use ggez::{Context, GameResult};
 use std::env;
 use std::path;
 
+
 // First we make a structure to contain the game's state
 struct MainState {
     frames: usize,
@@ -42,7 +43,10 @@ impl event::EventHandler for MainState {
 
         // Drawables are drawn from their top-left corner.
         let offset = self.frames as f32 / 10.0;
-        let dest_point = cgmath::Point2::new(offset, offset);
+        let dest_point = mint::Point2 {
+            x: (offset),
+            y: (offset),
+        };
         graphics::draw(ctx, &self.text, (dest_point,))?;
         graphics::present(ctx)?;
 


### PR DESCRIPTION
Changed to avoid compilation error because of missing trait:

```console
graphics::draw(ctx, &self.text, (dest_point,))?;
    |         ^^^^^^^^^^^^^^ the trait `std::convert::From<cgmath::point::Point2<f32>>` is not implemented for `mint::vector::Point2<f32>`
```

The help suggested the below action so I choose a compatible (?) type.

```console
T: Into<DrawParam>,
    |        --------------- required by this bound in `ggez::graphics::draw`
    |
    = help: the following implementations were found:
              <mint::vector::Point2<T> as std::convert::From<[T; 2]>>
              <mint::vector::Point2<T> as std::convert::From<mint::vector::Vector2<T>>>
    = note: required because of the requirements on the impl of `std::convert::Into<mint::vector::Point2<f32>>` for `cgmath::point::Point2<f32>`
    = note: required because of the requirements on the impl of `std::convert::From<(cgmath::point::Point2<f32>,)>` for `ggez::graphics::drawparam::DrawParam`
    = note: required because of the requirements on the impl of `std::convert::Into<ggez::graphics::drawparam::DrawParam>` for `(cgmath::point::Point2<f32>,)`
```
