### PR TITLE
Allow Custom Gamepads

### DIFF
--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -43,6 +43,13 @@ impl GilrsGamepadContext {
         let gilrs = Gilrs::new()?;
         Ok(GilrsGamepadContext { gilrs })
     }
+
+    /// Returns a `GilrsGamepadContext` with the entered Gilrs
+    pub fn from(custom_gilrs: Gilrs) -> Self {
+        GilrsGamepadContext {
+            gilrs: custom_gilrs,
+        }
+    }
 }
 
 impl GamepadContext for GilrsGamepadContext {

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -43,12 +43,12 @@ impl GilrsGamepadContext {
         let gilrs = Gilrs::new()?;
         Ok(GilrsGamepadContext { gilrs })
     }
+}
 
-    /// Returns a `GilrsGamepadContext` with the entered Gilrs
-    pub fn from(custom_gilrs: Gilrs) -> Self {
-        GilrsGamepadContext {
-            gilrs: custom_gilrs,
-        }
+impl From<Gilrs> for GilrsGamepadContext {
+    /// Converts from a `Gilrs` custom instance to a `GilrsGamepadContext`
+    fn from(gilrs: Gilrs) -> Self {
+        Self { gilrs }
     }
 }
 


### PR DESCRIPTION
With the addition of the `GilrsGamepadContext::from()` method, developers can now create any `Gilrs` type, change it to a `GilrsGamepadContext` type, and then do
```ctx.gamepad_context = Box::new(GilrsGamepadContext::from(gilrs));```
to use their custom `Gilrs` type.

The reason this is important is that it allows developers to use Gilrs methods that aren't currently accessible through ggez, like the `add_mappings()` method (see https://docs.rs/gilrs/0.7.4/gilrs/struct.GilrsBuilder.html#method.add_mappings). That specific example allows for custom gamepad mappings to be added in, which most importantly allows developers to read the contents of a file that has been filled with gilrs mapping strings and use them in their ggez project, which makes for easy gamepad setup even if the gamepad isn't automatically supported (automatically supported controllers: https://github.com/gabomdq/gamecontrollerdb/blob/c5992e0edc141be1fd0764c810792b4ead26e25c/gamecontrollerdb.txt) using a program such as this: https://generalarcade.com/gamepadtool/.