### PR TITLE
Remove unused imports in examples/

### DIFF
--- a/examples/01_super_simple.rs
+++ b/examples/01_super_simple.rs
@@ -1,6 +1,5 @@
 //! The simplest possible example that does something.
 
-use ggez;
 use ggez::event;
 use ggez::graphics;
 use ggez::nalgebra as na;

--- a/examples/02_hello_world.rs
+++ b/examples/02_hello_world.rs
@@ -1,6 +1,5 @@
 //! Basic hello world example.
 
-use cgmath;
 use ggez;
 
 use ggez::event;

--- a/examples/02_hello_world.rs
+++ b/examples/02_hello_world.rs
@@ -1,7 +1,5 @@
 //! Basic hello world example.
 
-use ggez;
-
 use ggez::event;
 use ggez::graphics;
 use ggez::{Context, GameResult};

--- a/examples/03_drawing.rs
+++ b/examples/03_drawing.rs
@@ -1,8 +1,5 @@
 //! A collection of semi-random shape and image drawing examples.
 
-use cgmath;
-
-use ggez;
 use ggez::event;
 use ggez::graphics;
 use ggez::graphics::{Color, DrawMode, DrawParam};

--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -12,12 +12,7 @@
 //! Author: @termhn
 //! Original repo: https://github.com/termhn/ggez_snake
 
-// First we'll import the crates we need for our game;
-// in this case that is just `ggez` and `rand`.
-use ggez;
-use rand;
-
-// Next we need to actually `use` the pieces of ggez that we are going
+// First we need to actually `use` the pieces of ggez that we are going
 // to need frequently.
 use ggez::event::{KeyCode, KeyMods};
 use ggez::{event, graphics, Context, GameResult};

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -2,7 +2,6 @@
 //! The idea is that this game is simple but still
 //! non-trivial enough to be interesting.
 
-use ggez;
 use ggez::audio;
 use ggez::audio::SoundSource;
 use ggez::conf;
@@ -11,7 +10,6 @@ use ggez::graphics;
 use ggez::nalgebra as na;
 use ggez::timer;
 use ggez::{Context, ContextBuilder, GameResult};
-use rand;
 
 use std::env;
 use std::path;

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -6,7 +6,7 @@ use std::path;
 
 use ggez::nalgebra as na;
 use rand::rngs::ThreadRng;
-use rand::{self, Rng};
+use rand::Rng;
 
 use ggez::graphics::{spritebatch::SpriteBatch, Color, Image};
 use ggez::Context;

--- a/examples/canvas_subframe.rs
+++ b/examples/canvas_subframe.rs
@@ -2,10 +2,6 @@
 //!
 //! You really want to run this one in release mode.
 
-extern crate cgmath;
-extern crate ggez;
-extern crate rand;
-
 use ggez::event;
 use ggez::graphics;
 use ggez::timer;

--- a/examples/colorspace.rs
+++ b/examples/colorspace.rs
@@ -66,7 +66,6 @@
 //! into sRGB for you to match everything else.  The purpose of this
 //! example is to show that this actually *works* correctly!
 
-use ggez;
 use ggez::event;
 use ggez::graphics::{self, DrawParam};
 use ggez::nalgebra as na;

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -6,9 +6,6 @@
 
 #[macro_use]
 extern crate gfx;
-extern crate gfx_device_gl;
-extern crate ggez;
-extern crate nalgebra;
 
 use gfx::texture;
 use gfx::traits::FactoryExt;

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -8,9 +8,6 @@
 //!
 //! It is functionally identical to the `super_simple.rs` example apart from that.
 
-use cgmath;
-use ggez;
-
 use ggez::event;
 use ggez::event::winit_event::{Event, KeyboardInput, WindowEvent};
 use ggez::graphics::{self, DrawMode};

--- a/examples/files.rs
+++ b/examples/files.rs
@@ -4,8 +4,6 @@
 //! It doesn't use an event loop, it just runs once and exits,
 //! printing a bunch of stuff to the console.
 
-use ggez;
-
 use ggez::{conf, filesystem, ContextBuilder, GameResult};
 use std::env;
 use std::io::{Read, Write};

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -3,9 +3,6 @@
 //!
 //! Prints instructions to the console.
 
-use ggez;
-use structopt;
-
 use ggez::conf;
 use ggez::event::{self, KeyCode, KeyMods};
 use ggez::graphics::{self, DrawMode};

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -4,7 +4,6 @@
 //! Prints instructions to the console.
 
 use ggez;
-use nalgebra;
 use structopt;
 
 use ggez::conf;

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -2,7 +2,6 @@
 //! to a canvas.
 
 use ggez;
-use nalgebra;
 
 use ggez::event;
 use ggez::graphics::{self, Color};

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -1,8 +1,6 @@
 //! Basic hello world example, drawing
 //! to a canvas.
 
-use ggez;
-
 use ggez::event;
 use ggez::graphics::{self, Color};
 use ggez::nalgebra as na;

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -1,7 +1,3 @@
-use cgmath;
-use ggez;
-use rand;
-
 use ggez::audio;
 use ggez::audio::SoundSource;
 use ggez::event;

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -1,7 +1,5 @@
 //! Example that just prints out all the input events.
 
-use ggez;
-
 use ggez::event::{self, Axis, Button, GamepadId, KeyCode, KeyMods, MouseButton};
 use ggez::graphics::{self, DrawMode};
 use ggez::input;

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -6,11 +6,7 @@
 //! `fern` provides a way to write log output to a `std::sync::mpsc::Sender`, so we can use a
 //! matching `std::sync::mpsc::Receiver` to get formatted log strings for file output.
 
-extern crate chrono;
-extern crate fern;
-extern crate ggez;
-#[macro_use]
-extern crate log;
+use log::*;
 
 use ggez::conf::{WindowMode, WindowSetup};
 use ggez::event::{EventHandler, KeyCode, KeyMods};

--- a/examples/render_to_image.rs
+++ b/examples/render_to_image.rs
@@ -1,8 +1,5 @@
 //! An example of how to draw to `Image`'s using the `Canvas` type.
 
-use cgmath;
-use ggez;
-
 use ggez::event;
 use ggez::graphics::{self, Color, DrawParam};
 use ggez::{Context, GameResult};

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -1,8 +1,6 @@
 //! A very simple shader example.
 
-use cgmath;
-use gfx::{self, *};
-use ggez;
+use gfx::*;
 
 use ggez::event;
 use ggez::graphics::{self, DrawMode};

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -1,10 +1,7 @@
 //! A more sophisticated example of how to use shaders
 //! and canvas's to do 2D GPU shadows.
 
-use cgmath;
-use gfx::{self, *};
-use ggez;
-
+use gfx::*;
 use cgmath::{Point2, Vector2};
 use ggez::conf;
 use ggez::event;

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -1,5 +1,3 @@
-use ggez;
-
 use ggez::audio;
 use ggez::audio::SoundSource;
 use ggez::event;

--- a/examples/spritebatch.rs
+++ b/examples/spritebatch.rs
@@ -2,8 +2,6 @@
 //!
 //! You really want to run this one in release mode.
 
-use ggez;
-
 use ggez::event;
 use ggez::graphics;
 use ggez::nalgebra::{Point2, Vector2};

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,9 +1,5 @@
 //! This example demonstrates how to use `Text` to draw TrueType font texts efficiently.
 
-use cgmath;
-use ggez;
-use rand;
-
 use cgmath::Point2;
 use ggez::conf::{WindowMode, WindowSetup};
 use ggez::event;

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -1,6 +1,5 @@
 //! Demonstrates various projection and matrix fiddling/testing.
 use ggez;
-use nalgebra;
 
 use ggez::event::{self, KeyCode, KeyMods};
 use ggez::graphics::{self, DrawMode};

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -1,6 +1,4 @@
 //! Demonstrates various projection and matrix fiddling/testing.
-use ggez;
-
 use ggez::event::{self, KeyCode, KeyMods};
 use ggez::graphics::{self, DrawMode};
 use ggez::nalgebra as na;


### PR DESCRIPTION
This pull request removes unused imports in `examples/` and removes statements like
```rust
use ggez;
```

As use statement with one path segment do nothing and extern crates is not needed in the latest versions of rust.