### PR TITLE
Bump rustc version to 1.40

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Check out the [projects list!](docs/Projects.md)
 
 ## Usage
 
-ggez requires rustc >= 1.36 and is distributed on
-crates.io.  To include it in your project, just add the dependency
+ggez requires rustc >= 1.37 and is distributed on
+crates.io. To include it in your project, just add the dependency
 line to your `Cargo.toml` file:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Check out the [projects list!](docs/Projects.md)
 
 ## Usage
 
-ggez requires rustc >= 1.38 and is distributed on
+ggez requires rustc >= 1.40 and is distributed on
 crates.io. To include it in your project, just add the dependency
 line to your `Cargo.toml` file:
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Check out the [projects list!](docs/Projects.md)
 
 ## Usage
 
-ggez requires rustc >= 1.37 and is distributed on
+ggez requires rustc >= 1.38 and is distributed on
 crates.io. To include it in your project, just add the dependency
 line to your `Cargo.toml` file:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
         - TARGET: x86_64-pc-windows-msvc
           CHANNEL: nightly
         - TARGET: x86_64-pc-windows-msvc
-          CHANNEL: 1.37.0
+          CHANNEL: 1.38.0
 
 install:
     - curl -sSf -o rustup-init.exe https://win.rustup.rs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
         - TARGET: x86_64-pc-windows-msvc
           CHANNEL: nightly
         - TARGET: x86_64-pc-windows-msvc
-          CHANNEL: 1.38.0
+          CHANNEL: 1.40.0
 
 install:
     - curl -sSf -o rustup-init.exe https://win.rustup.rs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
         - TARGET: x86_64-pc-windows-msvc
           CHANNEL: nightly
         - TARGET: x86_64-pc-windows-msvc
-          CHANNEL: 1.36.0
+          CHANNEL: 1.37.0
 
 install:
     - curl -sSf -o rustup-init.exe https://win.rustup.rs


### PR DESCRIPTION
This pull request bumps the minimum rustc version to 1.40 as `static_assertions` minimum version of rustc is 1.37 and `cast` requires rustc 1.38 and for `#[cfg(doctest)]` requires rustc 1.40. This should also make the `master` tree go green again!