### PR TITLE
Fix travis ci rustc version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.36.0
+  - 1.40.0
 os:
   - linux
   - osx


### PR DESCRIPTION
Fix travis ci minimum rustc version used in travis ci and will make all of the tests go green!