### PR TITLE
Invalidated text cached_metrics when returning a mutable slice of tex…

### DIFF
--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -203,6 +203,7 @@ impl Text {
 
     /// Returns a mutable slice with all fragments.
     pub fn fragments_mut(&mut self) -> &mut [TextFragment] {
+        self.invalidate_cached_metrics();
         &mut self.fragments
     }
 


### PR DESCRIPTION
…t fragments.