### PR TITLE
Glyph position

### DIFF
--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -342,8 +342,7 @@ impl Text {
         let glyph_positions: Vec<mint::Point2<f32>> = {
             let varied_section = self.generate_varied_section(Point2::new(0.0, 0.0), None);
             use glyph_brush::GlyphCruncher;
-            gb
-                .glyphs(varied_section)
+            gb.glyphs(varied_section)
                 .map(|glyph| glyph.glyph.position)
                 .map(|pos| mint::Point2 { x: pos.x, y: pos.y })
                 .collect()

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -139,6 +139,7 @@ struct CachedMetrics {
     string: Option<String>,
     width: Option<f32>,
     height: Option<f32>,
+    glyph_positions: Vec<mint::Point2<f32>>,
 }
 
 impl Default for CachedMetrics {
@@ -147,6 +148,7 @@ impl Default for CachedMetrics {
             string: None,
             width: None,
             height: None,
+            glyph_positions: Vec::new(),
         }
     }
 }
@@ -325,6 +327,42 @@ impl Text {
             metrics.string = Some(string_accm.clone());
         }
         string_accm
+    }
+
+    /// Calculates, caches, and returns position of the glyphs
+    fn calculate_glyph_positions(
+        &self,
+        gb: &mut GlyphBrush<DrawParam>,
+    ) -> std::cell::Ref<Vec<mint::Point2<f32>>> {
+        if let Ok(metrics) = self.cached_metrics.try_borrow() {
+            if !metrics.glyph_positions.is_empty() {
+                return std::cell::Ref::map(metrics, |metrics| &metrics.glyph_positions);
+            }
+        }
+        let glyph_positions: Vec<mint::Point2<f32>> = {
+            let varied_section = self.generate_varied_section(Point2::new(0.0, 0.0), None);
+            use glyph_brush::GlyphCruncher;
+            gb
+                .glyphs(varied_section)
+                .map(|glyph| glyph.glyph.position)
+                .map(|pos| mint::Point2 { x: pos.x, y: pos.y })
+                .collect()
+        };
+        if let Ok(mut metrics) = self.cached_metrics.try_borrow_mut() {
+            metrics.glyph_positions = glyph_positions;
+        } else {
+            panic!();
+        }
+        if let Ok(metrics) = self.cached_metrics.try_borrow() {
+            return std::cell::Ref::map(metrics, |metrics| &metrics.glyph_positions);
+        } else {
+            panic!();
+        }
+    }
+
+    /// Returns a Vec containing the coordinates of the formatted and wrapped text.
+    pub fn glyph_positions(&self, context: &Context) -> std::cell::Ref<Vec<mint::Point2<f32>>> {
+        self.calculate_glyph_positions(&mut context.gfx_context.glyph_brush.borrow_mut())
     }
 
     /// Calculates, caches, and returns width and height of formatted and wrapped text.


### PR DESCRIPTION
Closes #849 and closes #738 with something like
```rust
self.glyph_positions(context)
    .iter()
    .for_each(|glyph_position| println!("There's a glyph at {:?}!", glyph_position));
```