### PR TITLE
Removing NumSamples::Zero

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -165,7 +165,7 @@ pub struct WindowSetup {
     #[default(String::from("An easy, good game"))]
     pub title: String,
     /// Number of samples to use for multisample anti-aliasing.
-    #[default(NumSamples::Zero)]
+    #[default(NumSamples::One)]
     pub samples: NumSamples,
     /// Whether or not to enable vsync.
     #[default = true]
@@ -292,8 +292,6 @@ impl Backend {
 /// The possible number of samples for multisample anti-aliasing.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum NumSamples {
-    /// Multisampling disabled.
-    Zero = 0,
     /// One sample
     One = 1,
     /// Two samples
@@ -311,7 +309,6 @@ impl NumSamples {
     /// Returns `None` if `i` is invalid.
     pub fn from_u32(i: u32) -> Option<NumSamples> {
         match i {
-            0 => Some(NumSamples::Zero),
             1 => Some(NumSamples::One),
             2 => Some(NumSamples::Two),
             4 => Some(NumSamples::Four),

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -104,7 +104,12 @@ impl GraphicsContextGeneric<GlBackendSpec> {
                 backend.version_tuple(),
             ))
             .with_gl_profile(glutin::GlProfile::Core)
-            .with_multisampling(window_setup.samples as u16)
+            .with_multisampling(match window_setup.samples as u16 {
+                // Fix for https://github.com/ggez/ggez/issues/552
+                // 1 isn't multisampling but glutin wants a 0 to disable it
+                1 => 0,
+                n => n,
+            })
             // 24 color bits, 8 alpha bits
             .with_pixel_format(24, 8)
             .with_vsync(window_setup.vsync);


### PR DESCRIPTION
I think that the fix for #552 is invalid. I haven't been able to gather much information about multisampling but looking at the comments from graphics/canvas.rs:108 and graphics/mod.rs:498, It seems that 1 sample is the true no-sampling mode. The Zero variant causes unnecessary confusion and incoherent errors. As this would unfix #552, I included a possible alternative fix where sample count of 1 gets passed as 0 to glutin. 
I Haven't tested it as I am not that familiar with how the output should look.

Closes #720 as it will no longer be possible to use Zero