### PR TITLE
fixed drawing transformation matrix

### DIFF
--- a/examples/spritebatch.rs
+++ b/examples/spritebatch.rs
@@ -67,7 +67,7 @@ impl event::EventHandler for MainState {
                 ((time % cycle) as f32 / cycle as f32 * 6.28).sin().abs() * 2.0 + 1.0,
             ))
             .rotation((time % cycle) as f32 / cycle as f32 * 6.28)
-            .offset(Vec2::new(750.0, 750.0));
+            .offset(Vec2::new(0.4, 0.4)); // CAUTION: using an offset here is currently very slow
         graphics::draw(ctx, &self.spritebatch, param)?;
         self.spritebatch.clear();
 

--- a/src/graphics/drawparam.rs
+++ b/src/graphics/drawparam.rs
@@ -57,24 +57,25 @@ impl Transform {
                 offset,
             } => {
                 // Calculate a matrix equivalent to doing this:
-                //  type Vec3 = na::Vector3<f32>;
-                //  let translate = Matrix4::new_translation(&Vec3::new(self.dest.x, self.dest.y, 0.0));
-                //  let offset = Matrix4::new_translation(&Vec3::new(self.offset.x, self.offset.y, 0.0));
-                //  let offset_inverse =
-                //      Matrix4::new_translation(&Vec3::new(-self.offset.x, -self.offset.y, 0.0));
-                //  let axis_angle = Vec3::z() * self.rotation;
-                //  let rotation = Matrix4::new_rotation(axis_angle);
-                //  let scale = Matrix4::new_nonuniform_scaling(&Vec3::new(self.scale.x, self.scale.y, 1.0));
-                //  translate * offset * rotation * scale * offset_inverse
+                // type Vec3 = na::Vector3<f32>;
+                // let o = offset;
+                // let translate = na::Matrix4::new_translation(&Vec3::new(dest.x, dest.y, 0.0));
+                // let offset = na::Matrix4::new_translation(&Vec3::new(offset.x, offset.y, 0.0));
+                // let offset_inverse =
+                //     na::Matrix4::new_translation(&Vec3::new(-o.x, -o.y, 0.0));
+                // let axis_angle = Vec3::z() * *rotation;
+                // let rotation = na::Matrix4::new_rotation(axis_angle);
+                // let scale = na::Matrix4::new_nonuniform_scaling(&Vec3::new(scale.x, scale.y, 1.0));
+                // translate * rotation * scale * offset_inverse
                 //
-                //  Doing the bits manually is faster though, or at least was last I checked.
+                // Doing the bits manually is faster though, or at least was last I checked.
                 let (sinr, cosr) = rotation.sin_cos();
                 let m00 = cosr * scale.x;
                 let m01 = -sinr * scale.y;
                 let m10 = sinr * scale.x;
                 let m11 = cosr * scale.y;
-                let m03 = offset.x * (1.0 - m00) - offset.y * m01 + dest.x;
-                let m13 = offset.y * (1.0 - m11) - offset.x * m10 + dest.y;
+                let m03 = offset.x * (-m00) - offset.y * m01 + dest.x;
+                let m13 = offset.y * (-m11) - offset.x * m10 + dest.y;
                 // Welp, this transpose fixes some bug that makes nothing draw,
                 // that was introduced in commit 2c6b3cc03f34fb240f4246f5a68c75bd85b60eae.
                 // The best part is, I don't know if this code is wrong, or whether there's

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -869,8 +869,7 @@ pub fn transform_rect(rect: Rect, param: DrawParam) -> Rect {
                 y: rect.y - offset.y * rect.h,
             };
             // apply the scale
-            let real_scale = (param.src.w * scale.x,
-                              param.src.h * scale.y);
+            let real_scale = (param.src.w * scale.x, param.src.h * scale.y);
             r.w = real_scale.0 * rect.w;
             r.h = real_scale.1 * rect.h;
             r.x *= real_scale.0;

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -861,19 +861,26 @@ pub fn transform_rect(rect: Rect, param: DrawParam) -> Rect {
             dest,
             rotation,
         } => {
-            let w = param.src.w * scale.x * rect.w;
-            let h = param.src.h * scale.y * rect.h;
-            let offset_x = w * offset.x;
-            let offset_y = h * offset.y;
-            let dest_x = dest.x - offset_x;
-            let dest_y = dest.y - offset_y;
+            // first apply the offset
             let mut r = Rect {
-                w,
-                h,
-                x: dest_x + rect.x * scale.x,
-                y: dest_y + rect.y * scale.y,
+                w: rect.w,
+                h: rect.h,
+                x: rect.x - offset.x * rect.w,
+                y: rect.y - offset.y * rect.h,
             };
+            // apply the scale
+            let real_scale = (param.src.w * scale.x,
+                              param.src.h * scale.y);
+            r.w = real_scale.0 * rect.w;
+            r.h = real_scale.1 * rect.h;
+            r.x *= real_scale.0;
+            r.y *= real_scale.1;
+            // apply the rotation
             r.rotate(rotation);
+            // apply the destination translation
+            r.x += dest.x;
+            r.y += dest.y;
+
             r
         }
         Transform::Matrix(_m) => todo!("Fix me"),
@@ -968,6 +975,70 @@ mod tests {
                 y: -0.5,
                 w: 0.5,
                 h: 1.0,
+            };
+            assert_relative_eq!(real, expected);
+        }
+        {
+            let r = Rect {
+                x: -1.0,
+                y: -1.0,
+                w: 2.0,
+                h: 1.0,
+            };
+            let param = DrawParam::new()
+                .scale([0.5, 0.5])
+                .offset([0.0, 1.0])
+                .rotation(PI * 0.5)
+                .dest([1.0, 0.0]);
+            let real = transform_rect(r, param.into());
+            let expected = Rect {
+                x: 1.5,
+                y: -0.5,
+                w: 0.5,
+                h: 1.0,
+            };
+            assert_relative_eq!(real, expected);
+        }
+        {
+            let r = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 1.0,
+            };
+            let param = DrawParam::new()
+                .offset([0.5, 0.5])
+                .rotation(PI * 1.5)
+                .dest([1.0, 0.5]);
+            let real = transform_rect(r, param.into());
+            let expected = Rect {
+                x: 0.5,
+                y: 0.0,
+                w: 1.0,
+                h: 1.0,
+            };
+            assert_relative_eq!(real, expected);
+        }
+        {
+            let r = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 1.0,
+            };
+            let param = DrawParam::new()
+                .offset([0.5, 0.5])
+                .rotation(PI * 0.25)
+                .scale([2.0, 1.0])
+                .dest([1.0, 2.0]);
+            let real = transform_rect(r, param.into());
+            let sqrt = (2f32).sqrt() / 2.;
+            let unit = sqrt + sqrt / 2.;
+            let expected = Rect {
+                x: -unit + 1.,
+                y: -unit + 2.,
+                w: 2. * unit,
+                h: 2. * unit,
             };
             assert_relative_eq!(real, expected);
         }

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -157,6 +157,20 @@ impl SpriteBatch {
 
 impl graphics::Drawable for SpriteBatch {
     fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult {
+        // scale the offset according to the dimensions of the spritebatch
+        // but only if there is an offset (it's too expensive to calculate the dimensions to always to this)
+        let mut new_param = param;
+        if let Transform::Values { offset, .. } = param.trans {
+            if offset != [0.0, 0.0].into() {
+                if let Some(dim) = self.dimensions(ctx) {
+                    let new_offset = mint::Vector2 {
+                        x: offset.x * dim.w + dim.x,
+                        y: offset.y * dim.h + dim.y,
+                    };
+                    new_param = param.offset(new_offset);
+                }
+            }
+        }
         // Awkwardly we must update values on all sprites and such.
         // Also awkwardly we have this chain of colors with differing priorities.
         self.flush(ctx, &self.image)?;
@@ -174,7 +188,7 @@ impl graphics::Drawable for SpriteBatch {
         slice.instances = Some((self.sprites.len() as u32, 0));
         // It's a little silly converting this mint matrix back to a glam
         // one but it's simpler than the alternative.
-        let m = Matrix4::from(param.trans.to_bare_matrix());
+        let m = Matrix4::from(new_param.trans.to_bare_matrix());
         gfx.set_global_mvp(m)?;
         let previous_mode: Option<BlendMode> = if let Some(mode) = self.blend_mode {
             let current_mode = gfx.blend_mode();


### PR DESCRIPTION
This pull request fixes how the transformation matrix is calculated, making offset work as intended.
For more details and examples of the problematic behavior see #879.