### PR TITLE
forced the window dimensions to be physical not logical

### DIFF
--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -55,10 +55,6 @@ impl event::EventHandler for MainState {
         Ok(())
     }
 
-    fn resize_event(&mut self, _ctx: &mut Context, width: f32, height: f32)  {
-        println!("width: {}, height: {}", width, height);
-    }
-
     fn mouse_button_down_event(&mut self, _ctx: &mut Context, button: MouseButton, x: f32, y: f32) {
         self.mouse_down = true;
         println!("Mouse button pressed: {:?}, x: {}, y: {}", button, x, y);

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -65,10 +65,15 @@ impl event::EventHandler for MainState {
         println!("Mouse button released: {:?}, x: {}, y: {}", button, x, y);
     }
 
-    fn mouse_motion_event(&mut self, _ctx: &mut Context, x: f32, y: f32, xrel: f32, yrel: f32) {
+    fn mouse_motion_event(&mut self, ctx: &mut Context, x: f32, y: f32, xrel: f32, yrel: f32) {
         if self.mouse_down {
-            self.pos_x = x;
-            self.pos_y = y;
+            // Mouse coordinates are PHYSICAL coordinates, but here we want logical coordinates
+            // so we need to divide through the scale factor.
+            // In more advanced/realistic scenarios you may need to calculate the logical coordinates
+            // using ggez::graphics::screen_coordinates.
+            let scale_f = graphics::window(ctx).scale_factor() as f32;
+            self.pos_x = x / scale_f;
+            self.pos_y = y / scale_f;
         }
         println!(
             "Mouse motion, x: {}, y: {}, relative x: {}, relative y: {}",

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -55,6 +55,10 @@ impl event::EventHandler for MainState {
         Ok(())
     }
 
+    fn resize_event(&mut self, _ctx: &mut Context, width: f32, height: f32)  {
+        println!("width: {}, height: {}", width, height);
+    }
+
     fn mouse_button_down_event(&mut self, _ctx: &mut Context, button: MouseButton, x: f32, y: f32) {
         self.mouse_down = true;
         println!("Mouse button pressed: {:?}, x: {}, y: {}", button, x, y);
@@ -65,15 +69,23 @@ impl event::EventHandler for MainState {
         println!("Mouse button released: {:?}, x: {}, y: {}", button, x, y);
     }
 
-    fn mouse_motion_event(&mut self, ctx: &mut Context, x: f32, y: f32, xrel: f32, yrel: f32) {
+    fn mouse_motion_event(&mut self, _ctx: &mut Context, x: f32, y: f32, xrel: f32, yrel: f32) {
         if self.mouse_down {
-            // Mouse coordinates are PHYSICAL coordinates, but here we want logical coordinates
-            // so we need to divide through the scale factor.
-            // In more advanced/realistic scenarios you may need to calculate the logical coordinates
-            // using ggez::graphics::screen_coordinates.
-            let scale_f = graphics::window(ctx).scale_factor() as f32;
-            self.pos_x = x / scale_f;
-            self.pos_y = y / scale_f;
+            // Mouse coordinates are PHYSICAL coordinates, but here we want logical coordinates.
+
+            // If you simply use the initial coordinate system, then physical and logical
+            // coordinates are identical.
+            self.pos_x = x;
+            self.pos_y = y;
+
+            // If you change your screen coordinate system you need to calculate the
+            // logical coordinates like this:
+            /*
+            let screen_rect = graphics::screen_coordinates(ctx);
+            let size = graphics::window(ctx).inner_size();
+            logical_x = (x / (size.width  as f32)) * screen_rect.w + screen_rect.x;
+            logical_y = (y / (size.height as f32)) * screen_rect.h + screen_rect.y;
+            */
         }
         println!(
             "Mouse motion, x: {}, y: {}, relative x: {}, relative y: {}",
@@ -132,7 +144,11 @@ impl event::EventHandler for MainState {
 
 pub fn main() -> GameResult {
     let cb = ggez::ContextBuilder::new("input_test", "ggez");
-    let (ctx, event_loop) = cb.build()?;
+    let (mut ctx, event_loop) = cb.build()?;
+
+    // remove the comment to see how physical mouse coordinates can differ
+    // from logical game coordinates when the screen coordinate system changes
+    // graphics::set_screen_coordinates(&mut ctx, Rect::new(20., 50., 2000., 1000.));
 
     let state = MainState::new();
     event::run(ctx, event_loop, state)

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -144,7 +144,7 @@ impl event::EventHandler for MainState {
 
 pub fn main() -> GameResult {
     let cb = ggez::ContextBuilder::new("input_test", "ggez");
-    let (mut ctx, event_loop) = cb.build()?;
+    let (ctx, event_loop) = cb.build()?;
 
     // remove the comment to see how physical mouse coordinates can differ
     // from logical game coordinates when the screen coordinate system changes

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -400,7 +400,7 @@ impl event::EventHandler for MainState {
     }
 
     fn mouse_motion_event(&mut self, ctx: &mut Context, x: f32, y: f32, _xrel: f32, _yrel: f32) {
-        let (w, h) = graphics::size(ctx);
+        let (w, h) = graphics::drawable_size(ctx);
         let (x, y) = (x / w as f32, 1.0 - y / h as f32);
         self.torch.pos = [x, y];
     }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -23,6 +23,8 @@ pub enum FullscreenType {
     Windowed,
     /// True fullscreen, which used to be preferred 'cause it can have
     /// small performance benefits over windowed fullscreen.
+    ///
+    /// Also it allows us to set different resolutions.
     True,
     /// Windowed fullscreen, generally preferred over real fullscreen
     /// these days 'cause it plays nicer with multiple monitors.
@@ -90,7 +92,7 @@ pub struct WindowMode {
 }
 
 impl WindowMode {
-    /// Set default window size.
+    /// Set default window size, or screen resolution in true fullscreen mode.
     pub fn dimensions(mut self, width: f32, height: f32) -> Self {
         self.width = width;
         self.height = height;

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -435,14 +435,6 @@ impl Conf {
     }
 }
 
-/// Returns an iterator providing all resolutions supported on the current monitor.
-pub fn supported_resolutions(ctx: &crate::Context) -> impl Iterator<Item=winit::dpi::PhysicalSize<u32>> {
-    let gfx = &ctx.gfx_context;
-    let window = gfx.window.window();
-    let monitor = window.current_monitor().unwrap();
-    monitor.video_modes().map(|v_mode| v_mode.size())
-}
-
 #[cfg(test)]
 mod tests {
     use crate::conf;

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -54,10 +54,10 @@ pub enum FullscreenType {
 /// ```
 #[derive(Debug, Copy, Clone, SmartDefault, Serialize, Deserialize, PartialEq)]
 pub struct WindowMode {
-    /// Window width
+    /// Logical window width
     #[default = 800.0]
     pub width: f32,
-    /// Window height
+    /// Logical window height
     #[default = 600.0]
     pub height: f32,
     /// Whether or not to maximize the window
@@ -91,6 +91,8 @@ pub struct WindowMode {
 
 impl WindowMode {
     /// Set default window size, or screen resolution in true fullscreen mode.
+    /// Note that the physical window dimensions also depend on the
+    /// [`scale_factor`](https://docs.rs/winit/0.24.0/winit/window/struct.Window.html#method.scale_factor) of the window.
     pub fn dimensions(mut self, width: f32, height: f32) -> Self {
         self.width = width;
         self.height = height;

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -54,10 +54,10 @@ pub enum FullscreenType {
 /// ```
 #[derive(Debug, Copy, Clone, SmartDefault, Serialize, Deserialize, PartialEq)]
 pub struct WindowMode {
-    /// Logical window width
+    /// Window width
     #[default = 800.0]
     pub width: f32,
-    /// Logical window height
+    /// Window height
     #[default = 600.0]
     pub height: f32,
     /// Whether or not to maximize the window
@@ -90,9 +90,7 @@ pub struct WindowMode {
 }
 
 impl WindowMode {
-    /// Set default window size, or screen resolution in true fullscreen mode.
-    /// Note that the physical window dimensions also depend on the
-    /// [`scale_factor`](https://docs.rs/winit/0.24.0/winit/window/struct.Window.html#method.scale_factor) of the window.
+    /// Set default window size.
     pub fn dimensions(mut self, width: f32, height: f32) -> Self {
         self.width = width;
         self.height = height;

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -435,6 +435,14 @@ impl Conf {
     }
 }
 
+/// Returns an iterator providing all resolutions supported on the current monitor.
+pub fn supported_resolutions(ctx: &crate::Context) -> impl Iterator<Item=winit::dpi::PhysicalSize<u32>> {
+    let gfx = &ctx.gfx_context;
+    let window = gfx.window.window();
+    let monitor = window.current_monitor().unwrap();
+    monitor.video_modes().map(|v_mode| v_mode.size())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::conf;

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -513,13 +513,17 @@ where
                     for v_mode in v_modes {
                         let size = v_mode.size();
                         if (size.width, size.height) == (mode.width as u32, mode.height as u32) {
-                            window.set_fullscreen(Some(winit::window::Fullscreen::Exclusive(v_mode)));
+                            window
+                                .set_fullscreen(Some(winit::window::Fullscreen::Exclusive(v_mode)));
                             match_found = true;
                             break;
                         }
                     }
                     if !match_found {
-                        return Err(GameError::WindowError(format!("resolution {}x{} is not supported by this monitor", mode.width, mode.height)));
+                        return Err(GameError::WindowError(format!(
+                            "resolution {}x{} is not supported by this monitor",
+                            mode.width, mode.height
+                        )));
                     }
                 }
             }

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -307,9 +307,8 @@ impl GraphicsContextGeneric<GlBackendSpec> {
         gfx.set_window_mode(window_mode);
 
         // Calculate and apply the actual initial projection matrix
-        let phys_size = gfx.window.window().inner_size();
-        let w = phys_size.width as f32;
-        let h = phys_size.height as f32;
+        let w = window_mode.width;
+        let h = window_mode.height;
         let rect = Rect {
             x: 0.0,
             y: 0.0,

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -476,15 +476,11 @@ where
 
         window.set_maximized(mode.maximized);
 
-        // we need the scale_factor to counter hidpi-measures, so that our window
-        // is ACTUALLY as big as we asked for
-        let scale_factor = window.scale_factor();
-
         // TODO LATER: find out if single-dimension constraints are possible?
         let min_dimensions = if mode.min_width > 0.0 && mode.min_height > 0.0 {
-            Some(dpi::LogicalSize {
-                width: f64::from(mode.min_width) / scale_factor,
-                height: f64::from(mode.min_height) / scale_factor,
+            Some(dpi::PhysicalSize {
+                width: f64::from(mode.min_width),
+                height: f64::from(mode.min_height),
             })
         } else {
             None
@@ -492,9 +488,9 @@ where
         window.set_min_inner_size(min_dimensions);
 
         let max_dimensions = if mode.max_width > 0.0 && mode.max_height > 0.0 {
-            Some(dpi::LogicalSize {
-                width: f64::from(mode.max_width) / scale_factor,
-                height: f64::from(mode.max_height) / scale_factor,
+            Some(dpi::PhysicalSize {
+                width: f64::from(mode.max_width),
+                height: f64::from(mode.max_height),
             })
         } else {
             None
@@ -505,9 +501,9 @@ where
             FullscreenType::Windowed => {
                 window.set_fullscreen(None);
                 window.set_decorations(!mode.borderless);
-                window.set_inner_size(dpi::LogicalSize {
-                    width: f64::from(mode.width) / scale_factor,
-                    height: f64::from(mode.height) / scale_factor,
+                window.set_inner_size(dpi::PhysicalSize {
+                    width: f64::from(mode.width),
+                    height: f64::from(mode.height),
                 });
                 window.set_resizable(mode.resizable);
             }

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -306,8 +306,9 @@ impl GraphicsContextGeneric<GlBackendSpec> {
         gfx.set_window_mode(window_mode);
 
         // Calculate and apply the actual initial projection matrix
-        let w = window_mode.width;
-        let h = window_mode.height;
+        let phys_size = gfx.window.window().inner_size();
+        let w = phys_size.width as f32;
+        let h = phys_size.height as f32;
         let rect = Rect {
             x: 0.0,
             y: 0.0,

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -109,14 +109,12 @@ impl GraphicsContextGeneric<GlBackendSpec> {
             .with_pixel_format(24, 8)
             .with_vsync(window_setup.vsync);
 
-        let window_size = dpi::LogicalSize::<f64>::from((window_mode.width, window_mode.height));
+        let window_size = dpi::PhysicalSize::<f64>::from((window_mode.width, window_mode.height));
         let mut window_builder = winit::window::WindowBuilder::new()
             .with_title(window_setup.title.clone())
             .with_inner_size(window_size)
             .with_resizable(window_mode.resizable)
-            .with_visible(window_mode.visible)
-            .with_inner_size(window_size)
-            .with_resizable(window_mode.resizable);
+            .with_visible(window_mode.visible);
 
         // We need to disable drag-and-drop on windows for multithreaded stuff like cpal to work.
         // See winit bug here: https://github.com/rust-windowing/winit/pull/1524
@@ -303,7 +301,6 @@ impl GraphicsContextGeneric<GlBackendSpec> {
             glyph_cache,
             glyph_state,
         };
-        // this also resizes the window, so that it's ACTUALLY (physically) as big as WindowMode states
         gfx.set_window_mode(window_mode);
 
         // Calculate and apply the actual initial projection matrix

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -755,6 +755,16 @@ pub fn window(context: &Context) -> &glutin::window::Window {
     gfx.window.window()
 }
 
+/// Returns an iterator providing all resolutions supported by the current monitor.
+pub fn supported_resolutions(
+    ctx: &crate::Context,
+) -> impl Iterator<Item = winit::dpi::PhysicalSize<u32>> {
+    let gfx = &ctx.gfx_context;
+    let window = gfx.window.window();
+    let monitor = window.current_monitor().unwrap();
+    monitor.video_modes().map(|v_mode| v_mode.size())
+}
+
 /// Returns the size of the window in pixels as (width, height),
 /// including borders, titlebar, etc.
 /// Returns zeros if the window doesn't exist.

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -757,8 +757,8 @@ pub fn window(context: &Context) -> &glutin::window::Window {
 pub fn size(context: &Context) -> (f32, f32) {
     let gfx = &context.gfx_context;
     let window = gfx.window.window();
-    let logical_size = window.outer_size().to_logical(window.scale_factor());
-    (logical_size.width, logical_size.height)
+    let physical_size = window.outer_size();
+    (physical_size.width as f32, physical_size.height as f32)
 }
 
 /// Returns the size of the window's underlying drawable in pixels as (width, height).
@@ -766,8 +766,8 @@ pub fn size(context: &Context) -> (f32, f32) {
 pub fn drawable_size(context: &Context) -> (f32, f32) {
     let gfx = &context.gfx_context;
     let window = gfx.window.window();
-    let logical_size = window.inner_size().to_logical(window.scale_factor());
-    (logical_size.width, logical_size.height)
+    let physical_size = window.inner_size();
+    (physical_size.width as f32, physical_size.height as f32)
 }
 
 /// Return raw window context

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -701,6 +701,9 @@ pub fn set_fullscreen(context: &mut Context, fullscreen: conf::FullscreenType) -
 }
 
 /// Sets the window size/resolution to the specified width and height.
+///
+/// Note:   These dimensions are only interpreted as resolutions in true fullscreen mode.
+///         If the selected resolution is not supported this function will return an Error.
 pub fn set_drawable_size(context: &mut Context, width: f32, height: f32) -> GameResult {
     let window_mode = context.conf.window_mode.dimensions(width, height);
     set_mode(context, window_mode)

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -681,33 +681,34 @@ pub fn set_blend_mode(ctx: &mut Context, mode: BlendMode) -> GameResult {
 /// [`set_screen_coordinates()`](fn.set_screen_coordinates.html) after
 /// changing the window size to make sure everything is what you want
 /// it to be.
-pub fn set_mode(context: &mut Context, mode: WindowMode) -> GameResult {
+pub fn set_mode(context: &mut Context, mut mode: WindowMode) -> GameResult {
     let gfx = &mut context.gfx_context;
-    gfx.set_window_mode(mode);
+    let result = gfx.set_window_mode(mode);
+    if let Err(GameError::WindowError(_)) = result {
+        // true fullscreen could not be set because the video mode matching the resolution is missing
+        // so keep the old one
+        mode.fullscreen_type = context.conf.window_mode.fullscreen_type;
+    }
     // Save updated mode.
     context.conf.window_mode = mode;
-    Ok(())
+    result
 }
 
 /// Sets the window to fullscreen or back.
 pub fn set_fullscreen(context: &mut Context, fullscreen: conf::FullscreenType) -> GameResult {
-    let mut window_mode = context.conf.window_mode;
-    window_mode.fullscreen_type = fullscreen;
+    let window_mode = context.conf.window_mode.fullscreen_type(fullscreen);
     set_mode(context, window_mode)
 }
 
 /// Sets the window size/resolution to the specified width and height.
 pub fn set_drawable_size(context: &mut Context, width: f32, height: f32) -> GameResult {
-    let mut window_mode = context.conf.window_mode;
-    window_mode.width = width;
-    window_mode.height = height;
+    let window_mode = context.conf.window_mode.dimensions(width, height);
     set_mode(context, window_mode)
 }
 
 /// Sets whether or not the window is resizable.
 pub fn set_resizable(context: &mut Context, resizable: bool) -> GameResult {
-    let mut window_mode = context.conf.window_mode;
-    window_mode.resizable = resizable;
+    let window_mode = context.conf.window_mode.resizable(resizable);
     set_mode(context, window_mode)
 }
 


### PR DESCRIPTION
The initial coordinate system was calculated based on the **logical** window size, while we actually want it to match the **physical** window size, so I changed it.
I also added some explanation to the input example, since users should be aware that they may need to think about such things.

inspired by / solving #883