### PR TITLE
Update `Basic Project Template` for 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,20 +116,17 @@ use ggez::event::{self, EventHandler};
 
 fn main() {
     // Make a Context.
-    let (mut ctx, mut event_loop) = ContextBuilder::new("my_game", "Cool Game Author")
+    let (mut ctx, event_loop) = ContextBuilder::new("my_game", "Cool Game Author")
         .build()
         .expect("aieee, could not create ggez context!");
 
     // Create an instance of your event handler.
     // Usually, you should provide it with the Context object to
     // use when setting your game up.
-    let mut my_game = MyGame::new(&mut ctx);
+    let my_game = MyGame::new(&mut ctx);
 
     // Run!
-    match event::run(&mut ctx, &mut event_loop, &mut my_game) {
-        Ok(_) => println!("Exited cleanly."),
-        Err(e) => println!("Error occured: {}", e)
-    }
+    event::run(ctx, event_loop, my_game);
 }
 
 struct MyGame {


### PR DESCRIPTION
`event::run` now returns a `Never` type and doesn't get any references
therefore the old template doesn't compile.