### PR TITLE
Scale Image correctly when using Transform::Matrix

### DIFF
--- a/src/graphics/drawparam.rs
+++ b/src/graphics/drawparam.rs
@@ -204,6 +204,15 @@ impl DrawParam {
         }
     }
 
+    /// Set the transformation matrix of the drawable.
+    pub fn transform<M>(mut self, transform: M) -> Self
+    where
+        M: Into<mint::ColumnMatrix4<f32>>,
+    {
+        self.trans = Transform::Matrix(transform.into());
+        self
+    }
+
     pub(crate) fn to_instance_properties(&self, srgb: bool) -> InstanceProperties {
         let mat: [[f32; 4]; 4] = *self.trans.to_bare_matrix().as_ref();
         let color: [f32; 4] = if srgb {

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -344,15 +344,20 @@ impl Drawable for Image {
         let src_height = param.src.h;
         // We have to mess with the scale to make everything
         // be its-unit-size-in-pixels.
+        let scale_x = src_width * f32::from(self.width);
+        let scale_y = src_height * f32::from(self.height);
         let new_param = match param.trans {
             Transform::Values { scale, .. } => {
                 let new_scale = mint::Vector2 {
-                    x: scale.x * src_width * f32::from(self.width),
-                    y: scale.y * src_height * f32::from(self.height),
+                    x: scale.x * scale_x,
+                    y: scale.y * scale_y,
                 };
                 param.scale(new_scale)
             }
-            Transform::Matrix(_) => param,
+            Transform::Matrix(m) => {
+                let m_scale = Matrix4::from_scale((scale_x, scale_y, 1.0).into());
+                param.transform(Matrix4::from(m) * m_scale)
+            }
         };
 
         gfx.update_instance_properties(new_param)?;


### PR DESCRIPTION
When currently drawing an `Image` while using `Transform::Matrix` instead of `Transform::Values`, the output is rendered way too small. This PR adds the required scale factor to get the correct image size.

Furthermore, it adds a method `transform` to `DrawParam`.

Fixes #894.