### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/01_super_simple.rs
+++ b/examples/01_super_simple.rs
@@ -10,6 +10,7 @@ struct MainState {
 }
 
 impl MainState {
+    #[allow(clippy::unnecessary_wraps)] // More complex application load fonts/graphics that can fail
     fn new() -> GameResult<MainState> {
         let s = MainState { pos_x: 0.0 };
         Ok(s)

--- a/examples/02_hello_world.rs
+++ b/examples/02_hello_world.rs
@@ -1,8 +1,5 @@
 //! Basic hello world example.
 
-use ggez;
-use glam; // Requires feature "mint"
-
 use ggez::event;
 use ggez::graphics;
 use ggez::{Context, GameResult};

--- a/examples/03_drawing.rs
+++ b/examples/03_drawing.rs
@@ -2,7 +2,6 @@
 
 use glam::*;
 
-use ggez;
 use ggez::event;
 use ggez::graphics::{self, Color, DrawMode, DrawParam};
 use ggez::timer;
@@ -181,7 +180,7 @@ pub fn main() -> GameResult {
 
     let (mut ctx, events_loop) = cb.build()?;
 
-    println!("{}", graphics::renderer_info(&mut ctx)?);
+    println!("{}", graphics::renderer_info(&ctx)?);
     let state = MainState::new(&mut ctx).unwrap();
     event::run(ctx, events_loop, state)
 }

--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -13,10 +13,8 @@
 //! Original repo: https://github.com/termhn/ggez_snake
 
 // First we'll import the crates we need for our game;
-// in this case that is just `ggez` and `oorandom` (and `getrandom`
+// in this case that is just `oorandom` (and `getrandom`
 // to seed the RNG.)
-use getrandom;
-use ggez;
 use oorandom::Rand32;
 
 // Next we need to actually `use` the pieces of ggez that we are going
@@ -79,7 +77,7 @@ where
 {
     fn modulo(&self, n: T) -> T {
         // Because of our trait bounds, we can now apply these operators.
-        (self.clone() % n.clone() + n.clone()) % n.clone()
+        (self.clone() % n.clone() + n.clone()) % n
     }
 }
 
@@ -269,7 +267,7 @@ impl Snake {
             head: Segment::new(pos),
             dir: Direction::Right,
             last_update_dir: Direction::Right,
-            body: body,
+            body,
             ate: None,
             next_dir: None,
         }
@@ -279,11 +277,7 @@ impl Snake {
     /// the snake eats a given piece of Food based
     /// on its current position
     fn eats(&self, food: &Food) -> bool {
-        if self.head.pos == food.pos {
-            true
-        } else {
-            false
-        }
+        self.head.pos == food.pos
     }
 
     /// A helper function that determines whether
@@ -331,7 +325,7 @@ impl Snake {
         // which gives the illusion that the snake is moving. In reality, all the segments stay
         // stationary, we just add a segment to the front and remove one from the back. If we eat
         // a piece of food, then we leave the last segment so that we extend our body by one.
-        if let None = self.ate {
+        if self.ate.is_none() {
             self.body.pop_back();
         }
         // And set our last_update_dir to the direction we just moved.
@@ -419,7 +413,7 @@ impl event::EventHandler for GameState {
         // First we check to see if enough time has elapsed since our last update based
         // on the update rate we defined at the top.
         // if not, we do nothing and return early.
-        if !(Instant::now() - self.last_update >= Duration::from_millis(MILLIS_PER_UPDATE)) {
+        if Instant::now() - self.last_update < Duration::from_millis(MILLIS_PER_UPDATE) {
             return Ok(());
         }
         // Then we check to see if the game is over. If not, we'll update. If so, we'll just do nothing.

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -2,8 +2,6 @@
 //! The idea is that this game is simple but still
 //! non-trivial enough to be interesting.
 
-use getrandom;
-use ggez;
 use ggez::audio;
 use ggez::audio::SoundSource;
 use ggez::conf;

--- a/examples/canvas_subframe.rs
+++ b/examples/canvas_subframe.rs
@@ -2,9 +2,6 @@
 //!
 //! You really want to run this one in release mode.
 
-use ggez;
-use glam;
-
 use ggez::event;
 use ggez::graphics::{self, Color};
 use ggez::timer;
@@ -97,14 +94,14 @@ impl event::EventHandler for MainState {
         // Bounce the rect if necessary
         let (w, h) = graphics::size(ctx);
         if self.draw_pt.x + (w as f32 / 2.0) > (w as f32) || self.draw_pt.x < 0.0 {
-            self.draw_vec.x = self.draw_vec.x * -1.0;
+            self.draw_vec.x *= -1.0
         }
         if self.draw_pt.y + (h as f32 / 2.0) > (h as f32 / 2.0)
             || self.draw_pt.y < -(h as f32 / 2.0)
         {
-            self.draw_vec.y = self.draw_vec.y * -1.0;
+            self.draw_vec.y *= -1.0
         }
-        self.draw_pt = self.draw_pt + self.draw_vec;
+        self.draw_pt += self.draw_vec;
         Ok(())
     }
 

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -4,10 +4,11 @@
 //! the underlying `gfx-rs` data types, so you can bypass ggez's
 //! drawing code entirely and write your own.
 
+// Required for gfx_defines! https://github.com/rust-lang/rust-clippy/issues/5210
+#![allow(clippy::single_component_path_imports)]
 use gfx;
+
 use gfx::*;
-use gfx_device_gl;
-use ggez;
 
 use gfx::texture;
 use gfx::traits::FactoryExt;

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -8,9 +8,6 @@
 //!
 //! It is functionally identical to the `super_simple.rs` example apart from that.
 
-use ggez;
-use glam;
-
 use ggez::event;
 use ggez::event::winit_event::{Event, KeyboardInput, WindowEvent};
 use ggez::graphics::{self, Color, DrawMode};
@@ -43,11 +40,8 @@ pub fn main() -> GameResult {
                                 ..
                             },
                         ..
-                    } => match keycode {
-                        event::KeyCode::Escape => {
-                            *control_flow = winit::event_loop::ControlFlow::Exit
-                        }
-                        _ => (),
+                    } => if let event::KeyCode::Escape = keycode {
+                        *control_flow = winit::event_loop::ControlFlow::Exit
                     },
                     // `CloseRequested` and `KeyboardInput` events won't appear here.
                     x => println!("Other window event fired: {:?}", x),

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -40,9 +40,11 @@ pub fn main() -> GameResult {
                                 ..
                             },
                         ..
-                    } => if let event::KeyCode::Escape = keycode {
-                        *control_flow = winit::event_loop::ControlFlow::Exit
-                    },
+                    } => {
+                        if let event::KeyCode::Escape = keycode {
+                            *control_flow = winit::event_loop::ControlFlow::Exit
+                        }
+                    }
                     // `CloseRequested` and `KeyboardInput` events won't appear here.
                     x => println!("Other window event fired: {:?}", x),
                 },

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -3,8 +3,6 @@
 //!
 //! Prints instructions to the console.
 
-use ggez;
-
 use ggez::conf;
 use ggez::event::{self, KeyCode, KeyMods};
 use ggez::graphics::{self, Color, DrawMode};
@@ -12,7 +10,6 @@ use ggez::timer;
 use ggez::{Context, GameResult};
 
 use argh::FromArgs;
-use glam;
 
 use std::env;
 use std::path;

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -1,8 +1,6 @@
 //! Basic hello world example, drawing
 //! to a canvas.
 
-use ggez;
-
 use ggez::event;
 use ggez::graphics::{self, Color};
 use ggez::{Context, GameResult};

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -1,7 +1,3 @@
-use ggez;
-use glam;
-use oorandom;
-
 use ggez::audio;
 use ggez::audio::SoundSource;
 use ggez::event;
@@ -50,11 +46,11 @@ impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         filesystem::print_all(ctx);
 
-        let image = graphics::Image::new(ctx, "/dragon1.png").unwrap();
+        let image = graphics::Image::new(ctx, "/dragon1.png")?;
 
-        let font = graphics::Font::new(ctx, "/LiberationMono-Regular.ttf").unwrap();
+        let font = graphics::Font::new(ctx, "/LiberationMono-Regular.ttf")?;
         let text = graphics::Text::new(("Hello world!", font, 48.0));
-        let mut sound = audio::Source::new(ctx, "/sound.ogg").unwrap();
+        let mut sound = audio::Source::new(ctx, "/sound.ogg")?;
 
         let pixel_sized_text = graphics::Text::new(("This text is 32 pixels high", font, 32.0));
 

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -67,6 +67,7 @@ struct App {
 
 impl App {
     /// Creates an instance, takes ownership of passed FileLogger.
+    #[allow(clippy::unnecessary_wraps)] // More complex application load fonts/graphics that can fail
     fn new(_ctx: &mut Context, logger: FileLogger) -> GameResult<App> {
         Ok(App {
             file_logger: logger,

--- a/examples/meshbatch.rs
+++ b/examples/meshbatch.rs
@@ -72,7 +72,6 @@ impl event::EventHandler for MainState {
 
         // Update first 50 instances in the mesh batch
         let delta_time = (timer::duration_to_f64(timer::delta(ctx)) * 1000.0) as f32;
-
         let instances = self.mesh_batch.get_instance_params_mut();
         for i in 0..50 {
             if let graphics::Transform::Values {

--- a/examples/meshbatch.rs
+++ b/examples/meshbatch.rs
@@ -1,7 +1,5 @@
 //! An example of how to use a `MeshBatch`.
 
-use ggez;
-
 use ggez::event;
 use ggez::graphics::{self, Color};
 use ggez::timer;
@@ -65,6 +63,7 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
+    #![allow(clippy::needless_range_loop)]
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         if timer::ticks(ctx) % 100 == 0 {
             println!("Delta frame time: {:?} ", timer::delta(ctx));
@@ -73,6 +72,7 @@ impl event::EventHandler for MainState {
 
         // Update first 50 instances in the mesh batch
         let delta_time = (timer::duration_to_f64(timer::delta(ctx)) * 1000.0) as f32;
+
         let instances = self.mesh_batch.get_instance_params_mut();
         for i in 0..50 {
             if let graphics::Transform::Values {

--- a/examples/render_to_image.rs
+++ b/examples/render_to_image.rs
@@ -1,8 +1,5 @@
 //! An example of how to draw to `Image`'s using the `Canvas` type.
 
-use ggez;
-use glam;
-
 use ggez::event;
 use ggez::graphics::{self, Color, DrawParam};
 use ggez::{Context, GameResult};

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -1,8 +1,6 @@
 //! A very simple shader example.
 
 use gfx::{self, *};
-use ggez;
-use glam;
 
 use ggez::event;
 use ggez::graphics::{self, Color, DrawMode};

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -2,9 +2,6 @@
 //! and canvas's to do 2D GPU shadows.
 
 use gfx::{self, *};
-use ggez;
-use glam;
-
 use ggez::conf;
 use ggez::event;
 use ggez::graphics::{self, BlendMode, Canvas, Color, DrawParam, Drawable, Shader};

--- a/examples/spritebatch.rs
+++ b/examples/spritebatch.rs
@@ -16,7 +16,7 @@ struct MainState {
 
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let image = graphics::Image::new(ctx, "/tile.png").unwrap();
+        let image = graphics::Image::new(ctx, "/tile.png")?;
         let batch = graphics::spritebatch::SpriteBatch::new(image);
         let s = MainState { spritebatch: batch };
         Ok(s)

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,9 +1,5 @@
 //! This example demonstrates how to use `Text` to draw TrueType font texts efficiently.
 
-use ggez;
-use glam;
-use oorandom;
-
 use ggez::conf::{WindowMode, WindowSetup};
 use ggez::event;
 use ggez::graphics::{self, Align, Color, DrawParam, Font, PxScale, Text, TextFragment};
@@ -43,6 +39,7 @@ impl App {
 
         // This is what actually happens in `Text::new()`: the `&str` gets
         // automatically converted into a `TextFragment`.
+        #[allow(clippy::needless_update)] // Showing Default::default()
         let mut text = Text::new(TextFragment {
             // `TextFragment` stores a string, and optional parameters which will override those
             // of `Text` itself. This allows inlining differently formatted lines, words,
@@ -90,7 +87,7 @@ impl App {
         // Color is specified when drawing (or queueing), via `DrawParam`.
         // Side note: TrueType fonts aren't very consistent between themselves in terms
         // of apparent scale - this font with default scale will appear too small.
-        text.set_font(fancy_font.clone(), PxScale::from(16.0))
+        text.set_font(fancy_font, PxScale::from(16.0))
             .set_bounds(Vec2::new(300.0, f32::INFINITY), Align::Center);
         texts.insert("1_demo_text_4", text);
 
@@ -134,7 +131,7 @@ impl event::EventHandler for App {
         graphics::draw(ctx, &fps_display, (Vec2::new(200.0, 0.0), Color::WHITE))?;
 
         let mut height = 0.0;
-        for (_key, text) in &self.texts {
+        for text in self.texts.values() {
             // Calling `.queue()` for all bits of text that can share a `DrawParam`,
             // followed with `::draw_queued()` with said params, is the intended way.
             graphics::queue_text(ctx, text, Vec2::new(20.0, 20.0 + height), None);

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -1,6 +1,4 @@
 //! Demonstrates various projection and matrix fiddling/testing.
-use ggez;
-
 use ggez::event::{self, KeyCode, KeyMods};
 use ggez::graphics::{self, Color, DrawMode};
 use ggez::{Context, GameResult};
@@ -111,13 +109,9 @@ impl event::EventHandler for MainState {
         _keymod: KeyMods,
         _repeat: bool,
     ) {
-        match keycode {
-            event::KeyCode::Space => {
-                self.screen_bounds_idx = (self.screen_bounds_idx + 1) % self.screen_bounds.len();
-                graphics::set_screen_coordinates(ctx, self.screen_bounds[self.screen_bounds_idx])
-                    .unwrap();
-            }
-            _ => (),
+        if let event::KeyCode::Space = keycode {
+            self.screen_bounds_idx = (self.screen_bounds_idx + 1) % self.screen_bounds.len();
+            graphics::set_screen_coordinates(ctx, self.screen_bounds[self.screen_bounds_idx]).unwrap();
         }
     }
 }

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -111,7 +111,8 @@ impl event::EventHandler for MainState {
     ) {
         if let event::KeyCode::Space = keycode {
             self.screen_bounds_idx = (self.screen_bounds_idx + 1) % self.screen_bounds.len();
-            graphics::set_screen_coordinates(ctx, self.screen_bounds[self.screen_bounds_idx]).unwrap();
+            graphics::set_screen_coordinates(ctx, self.screen_bounds[self.screen_bounds_idx])
+                .unwrap();
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -257,10 +257,8 @@ where
                 _x => {
                     // trace!("ignoring window event {:?}", x);
                 }
-            },
-            Event::DeviceEvent { event, .. } => match event {
-                _ => (),
-            },
+            }
+            Event::DeviceEvent{..} => (),
             Event::Resumed => (),
             Event::Suspended => (),
             Event::NewEvents(_) => (),

--- a/src/event.rs
+++ b/src/event.rs
@@ -257,8 +257,8 @@ where
                 _x => {
                     // trace!("ignoring window event {:?}", x);
                 }
-            }
-            Event::DeviceEvent{..} => (),
+            },
+            Event::DeviceEvent { .. } => (),
             Event::Resumed => (),
             Event::Suspended => (),
             Event::NewEvents(_) => (),

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -44,6 +44,7 @@ where
     S: BackendSpec,
 {
     /// Create a new `Canvas` with the given size and number of samples.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         ctx: &mut Context,
         width: u16,

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -810,6 +810,7 @@ pub fn clear_font_cache(ctx: &mut Context) {
 /// Returns all the relevant objects at once;
 /// getting them one by one is awkward 'cause it tends to create double-borrows
 /// on the Context object.
+#[allow(clippy::type_complexity)]
 pub fn gfx_objects(
     context: &mut Context,
 ) -> (
@@ -908,7 +909,7 @@ mod tests {
                 h: 1.0,
             };
             let param = DrawParam::new().scale([0.5, 0.5]);
-            let real = transform_rect(r, param.into());
+            let real = transform_rect(r, param);
             let expected = Rect {
                 x: -0.5,
                 y: -0.5,
@@ -925,7 +926,7 @@ mod tests {
                 h: 1.0,
             };
             let param = DrawParam::new().offset([0.5, 0.5]);
-            let real = transform_rect(r, param.into());
+            let real = transform_rect(r, param);
             let expected = Rect {
                 x: -1.5,
                 y: -1.5,
@@ -942,7 +943,7 @@ mod tests {
                 h: 1.0,
             };
             let param = DrawParam::new().rotation(PI * 0.5);
-            let real = transform_rect(r, param.into());
+            let real = transform_rect(r, param);
             let expected = Rect {
                 x: -1.0,
                 y: 1.0,
@@ -962,7 +963,7 @@ mod tests {
                 .scale([0.5, 0.5])
                 .offset([0.0, 1.0])
                 .rotation(PI * 0.5);
-            let real = transform_rect(r, param.into());
+            let real = transform_rect(r, param);
             let expected = Rect {
                 x: 0.5,
                 y: -0.5,

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -190,6 +190,7 @@ pub type Shader<C> = ShaderGeneric<graphics::GlBackendSpec, C>;
 
 type ShaderHandlePtr<Spec> = Box<dyn ShaderHandle<Spec>>;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn create_shader<C, S, Spec>(
     vertex_source: &[u8],
     pixel_source: &[u8],
@@ -276,6 +277,7 @@ where
     /// used, you must include that blend mode as part of the
     /// `blend_modes` parameter at creation. If `None` is given, only the
     /// default [`Alpha`](enum.BlendMode.html#variant.Alpha) blend mode is used.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<P: AsRef<Path>, S: Into<String>>(
         ctx: &mut Context,
         vertex_path: P,

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -545,7 +545,7 @@ mod tests {
         let b2: u32 = black.to_rgba_u32();
         assert_eq!(b2, 0x0000_00FFu32);
         assert_eq!(black, Color::from_rgb_u32(0x00_0000u32));
-        assert_eq!(black, Color::from_rgba_u32(0x00_0000FFu32));
+        assert_eq!(black, Color::from_rgba_u32(0x0000_00FF_u32));
 
         let puce1 = Color::from_rgb_u32(0xCC_8899u32);
         let puce2 = Color::from_rgba_u32(0xCC88_99FFu32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,7 @@
 #![deny(unsafe_code)]
 #![warn(bare_trait_objects)]
 #![warn(missing_copy_implementations)]
+#![allow(clippy::float_cmp)]
 
 #[macro_use]
 extern crate bitflags;

--- a/src/tests/graphics.rs
+++ b/src/tests/graphics.rs
@@ -16,7 +16,7 @@ fn image_encode() {
 
 fn get_rgba_sample(rgba_buf: &[u8], width: usize, sample_pos: Vec2) -> (u8, u8, u8, u8) {
     (
-        rgba_buf[(width * sample_pos.y as usize + sample_pos.x as usize) * 4 + 0],
+        rgba_buf[(width * sample_pos.y as usize + sample_pos.x as usize) * 4],
         rgba_buf[(width * sample_pos.y as usize + sample_pos.x as usize) * 4 + 1],
         rgba_buf[(width * sample_pos.y as usize + sample_pos.x as usize) * 4 + 2],
         rgba_buf[(width * sample_pos.y as usize + sample_pos.x as usize) * 4 + 3],
@@ -134,11 +134,11 @@ fn sanity_check_window_sizes() {
     // Make sure that window sizes are what we ask for, and not what hidpi gives us.
     let w = c.conf.window_mode.width;
     let h = c.conf.window_mode.height;
-    let size = graphics::drawable_size(&mut c);
+    let size = graphics::drawable_size(&c);
     assert_eq!(w, size.0);
     assert_eq!(h, size.1);
 
-    let outer_size = graphics::size(&mut c);
+    let outer_size = graphics::size(&c);
     assert!(size.0 <= outer_size.0);
     assert!(size.1 <= outer_size.1);
 
@@ -153,7 +153,7 @@ fn sanity_check_window_sizes() {
     // Sometimes you need one, sometimes you need both...
     e.run(move |event, _, control_flow| {
         if let winit::event::Event::RedrawEventsCleared = event {
-            let size = graphics::drawable_size(&mut c);
+            let size = graphics::drawable_size(&c);
             assert_eq!(w, size.0);
             assert_eq!(h, size.1);
 

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -771,6 +771,7 @@ impl VFS for ZipFS {
 
     /// Zip files don't have real directories, so we (incorrectly) hack it by
     /// just looking for a path prefix for now.
+    #[allow(clippy::needless_collect)] // Collect is solving lifetime of path
     fn read_dir(&self, path: &Path) -> GameResult<Box<dyn Iterator<Item = GameResult<PathBuf>>>> {
         let path = convenient_path_to_str(path)?;
         let itr = self


### PR DESCRIPTION
While taking a look at ggez, I noticed the latest build failed, and it seemed to be mechanical clippy fixes.

I took a few minutes to fix things. Here's what i did::

- Resolved trivial fixes/refactors as tooling suggested, and added clippy allow for others
- Flowing point comparisons touched _many_ tests so silenced with #![allow(clippy::float_cmp)]

Reading the contrib guidelines, it sounds like master is a release branch, so I was uncertain if this should have been done against devel instead? 

Thought if it is a release branch, then maybe it shouldn't have clippy failures? 

Feel free to take what you'd like, or close if this is not helpful.