### PR TITLE
Add premultiplied alpha blend mode

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -190,6 +190,7 @@ impl GraphicsContextGeneric<GlBackendSpec> {
             BlendMode::Replace,
             BlendMode::Lighten,
             BlendMode::Darken,
+            BlendMode::Premultiplied,
         ];
         let multisample_samples = window_setup.samples as u8;
         let (vs_text, fs_text) = backend.shaders();

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -67,6 +67,8 @@ pub enum BlendMode {
     Lighten,
     /// When combining two fragments, choose the darker value
     Darken,
+    /// When using premultiplied alpha, use this.
+    Premultiplied,
 }
 
 impl From<BlendMode> for Blend {
@@ -113,6 +115,18 @@ impl From<BlendMode> for Blend {
                     destination: Factor::OneMinus(BlendValue::SourceAlpha),
                 },
             },
+            BlendMode::Premultiplied => Blend {
+                color: BlendChannel {
+                    equation: Equation::Add,
+                    source: Factor::One,
+                    destination: Factor::One,
+                },
+                alpha: BlendChannel {
+                    equation: Equation::Min,
+                    source: Factor::OneMinus(BlendValue::SourceAlpha),
+                    destination: Factor::OneMinus(BlendValue::SourceAlpha),
+                },
+            }
         }
     }
 }

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -126,7 +126,7 @@ impl From<BlendMode> for Blend {
                     source: Factor::OneMinus(BlendValue::SourceAlpha),
                     destination: Factor::OneMinus(BlendValue::SourceAlpha),
                 },
-            }
+            },
         }
     }
 }

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -122,8 +122,8 @@ impl From<BlendMode> for Blend {
                     destination: Factor::OneMinus(BlendValue::SourceAlpha),
                 },
                 alpha: BlendChannel {
-                    equation: Equation::Sub,
-                    source: Factor::One,
+                    equation: Equation::Add,
+                    source: Factor::OneMinus(BlendValue::DestinationAlpha),
                     destination: Factor::One,
                 },
             },

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -123,7 +123,7 @@ impl From<BlendMode> for Blend {
                 },
                 alpha: BlendChannel {
                     equation: Equation::Add,
-                    source: Factor::OneMinus(BlendValue::DestinationAlpha),
+                    source: Factor::OneMinus(BlendValue::DestAlpha),
                     destination: Factor::One,
                 },
             },

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -122,7 +122,7 @@ impl From<BlendMode> for Blend {
                     destination: Factor::One,
                 },
                 alpha: BlendChannel {
-                    equation: Equation::Min,
+                    equation: Equation::Add,
                     source: Factor::OneMinus(BlendValue::SourceAlpha),
                     destination: Factor::OneMinus(BlendValue::SourceAlpha),
                 },

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -117,9 +117,9 @@ impl From<BlendMode> for Blend {
             },
             BlendMode::Premultiplied => Blend {
                 color: BlendChannel {
-                    equation: Equation::Sub,
+                    equation: Equation::Add,
                     source: Factor::One,
-                    destination: Factor::ZeroPlus(BlendValue::SourceAlpha),
+                    destination: Factor::OneMinus(BlendValue::SourceAlpha),
                 },
                 alpha: BlendChannel {
                     equation: Equation::Sub,

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -117,14 +117,14 @@ impl From<BlendMode> for Blend {
             },
             BlendMode::Premultiplied => Blend {
                 color: BlendChannel {
-                    equation: Equation::Add,
+                    equation: Equation::Sub,
                     source: Factor::One,
-                    destination: Factor::One,
+                    destination: Factor::ZeroPlus(BlendValue::SourceAlpha),
                 },
                 alpha: BlendChannel {
-                    equation: Equation::Add,
-                    source: Factor::OneMinus(BlendValue::SourceAlpha),
-                    destination: Factor::OneMinus(BlendValue::SourceAlpha),
+                    equation: Equation::Sub,
+                    source: Factor::One,
+                    destination: Factor::One,
                 },
             },
         }


### PR DESCRIPTION
Note: I haven't been able to get any blend mode to work, so I'm very unsure if this does what I intend it to do. Regardless, setting the blend mode on either the `Image` or `Mesh`, in any combination, doesn't display any result at all.

This attempts to add the blend mode required to fix #902 

EDIT: Findings - setting the game mode globally via `ggez::graphics::set_blend_mode()` seems to work, so it's only the local  overrides that are broken. I guess that should go into a separate PR?

Anyway, now I have a way to test this, so it's time to play with values!

EDIT: Trying all combinations feels like shooting in the dark, I don't really understand what I'm doing, so any pointers would be helpul :(