### PR TITLE
docs: update `BLACK` and `WHITE` usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ impl EventHandler for MyGame {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
-        graphics::clear(ctx, graphics::WHITE);
+        graphics::clear(ctx, graphics::Color::WHITE);
         // Draw code here...
         graphics::present(ctx)
     }

--- a/docs/guides/GenerativeArt.md
+++ b/docs/guides/GenerativeArt.md
@@ -76,7 +76,7 @@ graphics::Mesh::new_circle(
     mint::Point2{x: 200.0, y: 300.0},
     100.0,
     0.1,
-    graphics::WHITE,
+    graphics::Color::WHITE,
 )?;
 ```
 
@@ -103,14 +103,14 @@ And that's how a circle is drawn!
 Let's try it out with some quick code:
 ```rust,skt-draw,no_run
 fn draw(&mut self, ctx: &mut Context) -> GameResult {
-    graphics::clear(ctx, graphics::BLACK);
+    graphics::clear(ctx, graphics::Color::BLACK);
     let circle = graphics::Mesh::new_circle(
         ctx,
         graphics::DrawMode::fill(),
         mint::Point2{x: 200.0, y: 300.0},
         100.0,
         0.1,
-        graphics::WHITE,
+        graphics::Color::WHITE,
     )?;
     graphics::draw(ctx, &circle, graphics::DrawParam::default())?;
     graphics::present(ctx)?;
@@ -130,7 +130,7 @@ graphics::Mesh::new_rectangle(
     ctx,
     graphics::DrawMode::fill(),
     graphics::Rect::new(500.0, 250.0, 200.0, 100.0),
-    graphics::WHITE,
+    graphics::Color::WHITE,
 )?;
 ```
 
@@ -148,12 +148,12 @@ And that's how a rectangle is drawn!
 Let's try it out with some quick code:
 ```rust,skt-draw,no_run
 fn draw(&mut self, ctx: &mut Context) -> GameResult {
-    graphics::clear(ctx, graphics::BLACK);
+    graphics::clear(ctx, graphics::Color::BLACK);
     let rect = graphics::Mesh::new_rectangle(
         ctx,
         graphics::DrawMode::fill(),
         graphics::Rect::new(500.0, 250.0, 200.0, 100.0),
-        graphics::WHITE,
+        graphics::Color::WHITE,
     )?;
     graphics::draw(ctx, &rect, graphics::DrawParam::default())?;
     graphics::present(ctx)?;
@@ -224,15 +224,15 @@ But we still don't see anything...
 You need to modify `draw` to illustrate your new `State`.
 ```rust,skt-draw,no_run
 fn draw(&mut self, ctx: &mut Context) -> GameResult {
-    graphics::clear(ctx, graphics::BLACK);
+    graphics::clear(ctx, graphics::Color::BLACK);
     for shape in &self.shapes {
         // Make the shape...
         let mesh = match shape {
             &Shape::Rectangle(rect) => {
-                Mesh::new_rectangle(ctx, graphics::DrawMode::fill(), rect, graphics::WHITE)?
+                Mesh::new_rectangle(ctx, graphics::DrawMode::fill(), rect, graphics::Color::WHITE)?
             }
             &Shape::Circle(origin, radius) => {
-                Mesh::new_circle(ctx, graphics::DrawMode::fill(), origin, radius, 0.1, graphics::WHITE)?
+                Mesh::new_circle(ctx, graphics::DrawMode::fill(), origin, radius, 0.1, graphics::Color::WHITE)?
             }
         };
 

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -50,18 +50,18 @@ pub use self::t::{FillOptions, FillRule, LineCap, LineJoin, StrokeOptions};
 ///                 na::Point2::new(0.0, 0.0),
 ///             ],
 ///             1.0,
-///             graphics::WHITE,
+///             graphics::Color::WHITE,
 ///         )?
 ///         // Add vertices for an exclamation mark!
-///         .ellipse(DrawMode::fill(), na::Point2::new(0.0, 25.0), 2.0, 15.0, 2.0, graphics::WHITE,)
-///         .circle(DrawMode::fill(), na::Point2::new(0.0, 45.0), 2.0, 2.0, graphics::WHITE,)
+///         .ellipse(DrawMode::fill(), na::Point2::new(0.0, 25.0), 2.0, 15.0, 2.0, graphics::Color::WHITE,)
+///         .circle(DrawMode::fill(), na::Point2::new(0.0, 45.0), 2.0, 2.0, graphics::Color::WHITE,)
 ///         // Finalize then unwrap. Unwrapping via `?` operator either yields the final `Mesh`,
 ///         // or propagates the error (note return type).
 ///         .build(ctx)?;
 ///     // Draw 3 meshes in a line, 1st and 3rd tilted by 1 radian.
-///     graphics::draw(ctx, &mesh, (na::Point2::new(50.0, 50.0), -1.0, graphics::WHITE))?;
-///     graphics::draw(ctx, &mesh, (na::Point2::new(150.0, 50.0), 0.0, graphics::WHITE))?;
-///     graphics::draw(ctx, &mesh, (na::Point2::new(250.0, 50.0), 1.0, graphics::WHITE))?;
+///     graphics::draw(ctx, &mesh, (na::Point2::new(50.0, 50.0), -1.0, graphics::Color::WHITE))?;
+///     graphics::draw(ctx, &mesh, (na::Point2::new(150.0, 50.0), 0.0, graphics::Color::WHITE))?;
+///     graphics::draw(ctx, &mesh, (na::Point2::new(250.0, 50.0), 1.0, graphics::Color::WHITE))?;
 ///     Ok(())
 /// }
 /// ```

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -38,7 +38,7 @@
 //!             na::Point2::new(self.position_x, 380.0),
 //!             100.0,
 //!             2.0,
-//!             graphics::WHITE,
+//!             graphics::Color::WHITE,
 //!         )?;
 //!         graphics::draw(ctx, &circle, graphics::DrawParam::default())?;
 //!         graphics::present(ctx)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@
 //!     }
 //!
 //!     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
-//!         graphics::clear(ctx, graphics::WHITE);
+//!         graphics::clear(ctx, graphics::Color::WHITE);
 //!         // Draw code here...
 //!         graphics::present(ctx)
 //!     }


### PR DESCRIPTION
After those constants were moved from `graphics` to `graphics::Color`,
some documentation items became out of date.
