### PR TITLE
Replace to_rgba8 with to_rgba

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -343,7 +343,7 @@ pub(crate) fn load_icon(
     let mut reader = filesystem.open(icon_file)?;
     let _ = reader.read_to_end(&mut buf)?;
     let i = imgcrate::load_from_memory(&buf)?;
-    let image_data = i.to_rgba8();
+    let image_data = i.to_rgba();
     Icon::from_rgba(image_data.to_vec(), i.width(), i.height()).map_err(|e| {
         let msg = format!("Could not load icon: {:?}", e);
         GameError::ResourceLoadError(msg)

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -154,7 +154,7 @@ impl Image {
     /// Creates a new `Image` from the given buffer, which should contain an image encoded
     /// in a supported image file format.
     pub fn from_bytes(context: &mut Context, bytes: &[u8]) -> GameResult<Self> {
-        let img = image::load_from_memory(&bytes)?.to_rgba8();
+        let img = image::load_from_memory(&bytes)?.to_rgba();
         let (width, height) = img.dimensions();
         let better_width = u16::try_from(width)
             .map_err(|_| GameError::ResourceLoadError(String::from("Image width > u16::MAX")))?;


### PR DESCRIPTION
In newer versions of `image` (tested with `0.23.11`), `DynamicImage::to_rgba8()` has been removed and replaced with `to_rgba()`. This replaces two calls to it that cause compile errors.