### PR TITLE
Inform in Canvas doc about graphics::set_screen_coordinates

### DIFF
--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -39,6 +39,12 @@ where
 /// by using shaders that render to an image.
 /// If you just want to draw multiple things efficiently, look at
 /// [`SpriteBatch`](spritebatch/struct.Spritebatch.html).
+///
+/// Note that if the canvas is not of the same size as the screen, and you want
+/// to render using coordinates relative to the canvas' coordinate system, you
+/// need to call [`graphics::set_screen_coordinates`](fn.set_screen_coordinates.html)
+/// and pass in a rectangle with position (0, 0) and a size equal to that of the
+/// canvas.
 pub type Canvas = CanvasGeneric<GlBackendSpec>;
 
 impl<S> CanvasGeneric<S>

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -99,7 +99,7 @@ pub trait BackendSpec: fmt::Debug {
     /// A helper function to take a RawShaderResourceView and turn it into a typed one based on
     /// the surface type defined in a `BackendSpec`.
     ///
-    /// But right now we only allow surfaces that use [f32;4] colors, so we can freely
+    /// But right now we only allow surfaces that use \[f32;4\] colors, so we can freely
     /// hardcode this in the `ShaderResourceType` type.
     fn raw_to_typed_shader_resource(
         &self,


### PR DESCRIPTION
If you render to a canvas that has a different aspect ratio than
the screen, the results will look skewed.