### PR TITLE
BlendChannel rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,18 +45,18 @@ old_school_gfx_glutin_ext = "0.26"
 glutin = "0.26"
 winit = "0.24"
 image = {version = "0.23", default-features = false, features = ["gif", "png", "pnm", "tga", "tiff", "webp", "bmp", "dxt", ] }
-rodio = { version = "0.13", default-features = false, features = ["flac", "vorbis", "wav"] }
+rodio = { version = "0.14", default-features = false, features = ["flac", "vorbis", "wav"] }
 serde = "1"
 serde_derive = "1"
 toml = "0.5"
 log = "0.4"
 lyon = "0.17.5"
 smart-default = "0.6"
-glam = { version = "0.12", features = ["mint"]}
+glam = { version = "0.15", features = ["mint"]}
 # Has to be the same version of mint that our math lib uses here.
 mint = "0.5"
 gilrs = "0.8"
-approx = "0.4"
+approx = "0.5"
 bytemuck = "1.5.1"
 
 [dev-dependencies]

--- a/docs/BuildingForEveryPlatform.md
+++ b/docs/BuildingForEveryPlatform.md
@@ -2,11 +2,10 @@
 
 Greetings, one and all.  Today we shall explore how to build and
 deploy a `ggez` game for every possible platform.  For platforms like
-Linux it's pretty darn simple.  For ones like Android it gets
-harder and you have to jump through hoops.  The purpose of this is to
-document the hoops and give you a cookbook on the best jumping methods
-and trajectories.  We will progress generally from the easiest to
-hardest jumps.
+Linux it's pretty darn simple, but sometimes you have to jump through a
+couple hoops.  The purpose of this is to document the hoops and give you
+a cookbook on the best jumping methods and trajectories.  We will
+progress generally from the easiest to hardest jumps.
 
 ## Project setup
 
@@ -80,7 +79,7 @@ Should just build.  We recommend using the MSVC toolchain whenever possible, the
 
 ## Distributing
 
-Just copy-paste the exe and resource files to the destination computer.
+Just copy-paste the exe and resource directory to the destination computer.
 
 # Android
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -38,10 +38,10 @@ files.  Note that paths **must start with leading slash**; relative
 paths are not allowed!  Also note that it expects the `resources/`
 directory to be beside the *executable*, not in the cargo root dir,
 which is annoying because cargo tends to put the executable in
-`target/debug/whatever`.  You can add the cargo root dir to the lookup
-path by pulling it from the environment variable, see the examples for
-how.  Sorry, there's no especially good way of doing it automatically;
-we've tried.
+`target/debug/whatever`.  You can add the cargo root dir to the
+filesystem lookup path by pulling it from the environment variable, see
+the examples for how.  Sorry, there's no especially good way of doing it
+automatically; we've tried.
 
 If that doesn't help, call `Context::print_resource_stats()`.  That
 should print out all the files it can find, and where it is finding
@@ -68,8 +68,9 @@ on the issue tracker.
 Great, how do you troubleshoot it?
 
 On Linux, the program `glxinfo` will give you more info than you ever
-wanted about exactly what your graphics driver supports, and if you
-dig enough through it you can find what version of OpenGL it supports.
+wanted about exactly what features your graphics driver supports, and if
+you dig enough through it you can find what version of OpenGL it has
+available.
 
 To request different graphics settings you can change the appropriate
 entries in the `Conf` object before creating your `Context`.  If you
@@ -94,9 +95,13 @@ In general, ggez is designed to focus on 2D graphics.  We want it to be possible
 
 ## How do I make a GUI?
 
-As of 2017 we know of no good ui options thus far besides "implement
-it yourself" or "write a backend for Conrod or something so it can
-draw using ggez".
+There's no *great* way to do it currently, but as of 2021 there's a few
+GUI libraries that are able to use `ggez` as a drawing backend.
+`raui` seems to offer a `ggez` backend natively, though we have no idea
+how well it works, and `iced` used to have one but it seems to have
+vanished with a code rewrite.  There's several other IMGUI-style
+GUI crates that have pluggable drawing backends, maybe some of them
+can either be drawn with `ggez` or are easy to write new backends for.
 
 Contributions are welcome! ;-)
 
@@ -121,20 +126,34 @@ and scaling your `Image`s with `graphics::DrawParam`.
 
 ## Can I use `specs`, `legion` or another entity-component system?
 
-Sure!  ggez doesn't include such a thing itself, since it's more or less out of scope for this, but it is specifically
-designed to make it easy to Lego together with other tools.  The [game template](https://github.com/ggez/game-template) repo
-demonstrates how to use ggez with `specs` for ECS, `warmy` for resource loading, and other nice crates. This template is available with `legion` in place of `specs` as well [here](https://github.com/Quetzal2/game-template).
+Sure!  ggez doesn't include such a thing itself, since it's more or less
+out of scope for this, but it is specifically designed to make it easy
+to Lego together with other tools.  The [game
+template](https://github.com/ggez/game-template) repo is a little old
+but demonstrates how to use ggez with `specs` for ECS, `warmy` for
+resource loading, and other nice crates. This template is available with
+`legion` in place of `specs` as well
+[here](https://github.com/Quetzal2/game-template).
 
 <a name="library_mint">
 
 ## What is mint and how do I use `Into<mint::Point2<f32>>` and other `Into<mint::T>` types?
 
 </a>
-mint stands for "Math INteroperability Types" which means that it provides types for other math libraries to convert to and from with. What you are supposed to do is to add a math library of your choice to your game such as glam or nalgebra, usually with a "mint" feature.
- For example. You can add <code>glam = { version = "0.15.2", features = ["mint"] }</code> in your Cargo.toml, then when you try to pass something to, say <code>DrawParam::new().dest(my_point)</code>, you will be able to pass a glam type like <code>DrawParam::new().dest(glam::vec2(10.0, 15.0))</code> to set the destination to x=10 and y=15.
-Going the other way around is a bit more verbose, you need to do <code>glam::Vec2::from(my_draw_param.dest)</code>
+mint stands for "Math INteroperability Types" which means that it
+provides types for other math libraries to convert to and from with.
+What you are supposed to do is to add a math library of your choice to
+your game such as glam or nalgebra, usually with a "mint" feature.  For
+example. You can add `glam = { version = "0.15.2", features =
+["mint"] }` in your Cargo.toml, then when you try to pass
+something to, say `DrawParam::new().dest(my_point)`, you will
+be able to pass a glam type like
+`DrawParam::new().dest(glam::vec2(10.0, 15.0))` to set the
+destination to x=10 and y=15.  Going the other way around is a bit more
+verbose, you need to do `glam::Vec2::from(my_draw_param.dest)`
 
-Another example, moving a draw param's destination diagonally by 1 down and 1 right.
+Another example, moving a draw param's destination diagonally by 1 down
+and 1 right.
 
 ```rust
 let dest = glam::Vec2::from(my_draw_param.dest);
@@ -178,14 +197,6 @@ opt-level = 2: 430 fps
 opt-level = 3: 450 fps
 ```
 
-<a name="perf_text">
-
-## Text rendering is still slow!
-
-Rendering text to a bitmap is actually pretty computationally expensive.  If you call `Text::new()` every single frame it's going to take a relatively large amount of time, and larger bitmaps and more text will take longer.
-
-Ideally you'd be able to use a glyph cache to render letters to a texture once, and then just create a mesh that uses the bits of that texture to draw text.  There's a couple partial implementations, such as the [gfx_glyph crate](https://crates.io/crates/gfx_glyph).
-
 <a name="perf_debug">
 
 ## That's lame, can't I just compile my game in debug mode but ggez with optimizations on?
@@ -218,12 +229,12 @@ If your question is not answered there, open an
 
 Apple will be supported when they treat programmers trying to use
 their systems as something other than third-class citizens.  See
-https://drewdevault.com/2017/10/26/Fuck-you-nvidia.html for the
+<https://drewdevault.com/2017/10/26/Fuck-you-nvidia.html> for the
 general message, but replace "NVidia" with "Apple" and make it an
 ongoing problem of continual exploitation that has made Apple the
 richest company in the world off of the work of others.
 
-That said, ggez will probably build and run fine on Mac, and pull
+That said, `ggez` will probably build and run fine on Mac, and pull
 requests for Mac-specific bugs will be accepted as long as they don't
 break anything else.  In the mean time, consider writing your software
 for a company that doesn't treat you like dirt.
@@ -236,28 +247,40 @@ for a company that doesn't treat you like dirt.
 
 ## If I write X, will you include it in ggez?
 
-Maybe, if it's something that fits in with ggez's goals: a simple and flexible 2D game framework with a LÖVE-ish API,
-which provides all the basics you need in one package without dictating too much about the more complicated tools.
+Maybe, if it's something that fits in with ggez's goals: a simple and
+flexible 2D game framework with a LÖVE-ish API, which provides all the
+basics you need in one package without dictating too much about the more
+complicated tools.
 
 Examples of things that would be included:
 
- * Sprite batches -- extension of existing functionality, follows LÖVE's example, large performance win
- * Glyph cache -- replaces existing functionality with a more capable version, large performance win
- * Sound mixer -- Follows LÖVE's example, fundamental functionality that should be provided, not tool-specific
+ * Sprite batches -- extension of existing functionality, follows LÖVE's
+   example, large performance win
+ * Glyph cache -- replaces existing functionality with a more capable
+   version, large performance win
+ * Sound mixer -- Follows LÖVE's example, fundamental functionality that
+   should be provided, not tool-specific
 
 Examples of things that would not be included:
 
- * Map loader for the Tiled map editor -- No reason we should force a user into a particular tool format
- * Sprite animation engine -- Makes assumptions about the sort of game the user will create, easily made its own crate
- * GUI library -- A large and complicated problem, and it doesn't need to be part of ggez to solve the problem
+ * Map loader for the Tiled map editor -- No reason we should force a
+   user into a particular tool format
+ * Sprite animation engine -- Makes assumptions about the sort of game
+   the user will create, easily made its own crate
+ * GUI library -- A large and complicated problem, and it doesn't need
+   to be part of ggez to solve the problem
 
-Part of the goal of this sort of setup is to make it easy for people to write more sophisticated tools atop ggez!  By all
-means, write your Tiled map drawer or your aseprite sprite loader!  Submit a PR to add it to the `docs/Projects.md` file!
-We'd love to have an ecosystem of awesome tools.
+Part of the goal of this sort of setup is to make it easy for people to
+write more sophisticated tools atop ggez!  By all means, write your
+Tiled map drawer or your aseprite sprite loader!  Submit a PR to add it
+to the `docs/Projects.md` file!  We'd love to have an ecosystem of
+awesome tools.
 
-One favor to ask: If you're making a crate to do `foo`, please don't name it `ggez-foo`.  It makes it harder to search for
-ggez on crates.io and get things that are officially supported by the maintainers, such as `ggez-goodies`.  For an
-example, search for `gfx` on `crates.io` and see how messy the results are.
+One favor to ask: If you're making a crate to do `foo`, please don't
+name it `ggez-foo`.  It makes it harder to search for ggez on crates.io
+and get things that are officially supported by the maintainers, such as
+`ggez-goodies`.  For an example, search for `gfx` on `crates.io` and see
+how messy the results are.
 
 For a fuller discussion of this, see [issue #373](https://github.com/ggez/ggez/issues/373).
 

--- a/docs/guides/GenerativeArt.md
+++ b/docs/guides/GenerativeArt.md
@@ -3,7 +3,7 @@
 This is a guide to create a program that randomly generates shapes to display.
 
 At the end of this guide you will:
-*  Have used the [`graphics`](https://docs.rs/ggez/0.5.1/ggez/graphics/) module of `ggez` to draw shapes
+*  Have used the [`graphics`](https://docs.rs/ggez/0.6.0/ggez/graphics/) module of `ggez` to draw shapes
 
 ## Project Setup
 
@@ -13,19 +13,20 @@ Modify `Cargo.toml` to include `ggez` in the dependencies.
 
 Just like in `Hello ggez!`, we're going to use a loop and a struct.
 Let's start with this code in `src/main.rs`:
+
 ```rust,no_run
 use ggez::*;
 
 struct State {}
 
 impl ggez::event::EventHandler for State {
-  fn update(&mut self, _ctx: &mut Context) -> GameResult {
-      Ok(())
-  }
-  fn draw(&mut self, ctx: &mut Context) -> GameResult {
-      graphics::present(ctx)?;
-      Ok(())
-  }
+    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+        Ok(())
+    }
+    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+        graphics::present(ctx)?;
+        Ok(())
+    }
 }
 
 fn main() {
@@ -42,33 +43,33 @@ Test to make sure everything is correct by running `cargo run`.
 
 If there are no errors and you see a window you are good.
 
-## [ggez::graphics](https://docs.rs/ggez/0.5.1/ggez/graphics/)
+## [ggez::graphics](https://docs.rs/ggez/0.6.0/ggez/graphics/)
 
-Glancing over the docs for [`ggez::graphics`](https://docs.rs/ggez/0.5.1/ggez/graphics/) you can see there is a lot of functionality there.
-The basic shapes can be found in [`graphics::Mesh`](https://docs.rs/ggez/0.5.1/ggez/graphics/struct.Mesh.html#methods)
+Glancing over the docs for [`ggez::graphics`](https://docs.rs/ggez/0.6.0/ggez/graphics/) you can see there is a lot of functionality there.
+The basic shapes can be found in [`graphics::Mesh`](https://docs.rs/ggez/0.6.0/ggez/graphics/struct.Mesh.html#methods)
 
 So which shapes are in `Mesh`?
 
-* [line](https://docs.rs/ggez/0.5.1/ggez/graphics/struct.Mesh.html#method.new_line)
-* [circle](https://docs.rs/ggez/0.5.1/ggez/graphics/struct.Mesh.html#method.new_circle)
-* [ellipse](https://docs.rs/ggez/0.5.1/ggez/graphics/struct.Mesh.html#method.new_ellipse)
-* [polygon](https://docs.rs/ggez/0.5.1/ggez/graphics/struct.Mesh.html#method.new_polygon)
-* [rectangle](https://docs.rs/ggez/0.5.1/ggez/graphics/struct.Mesh.html#method.new_rectangle)
+* [line](https://docs.rs/ggez/0.6.0/ggez/graphics/struct.Mesh.html#method.new_line)
+* [circle](https://docs.rs/ggez/0.6.0/ggez/graphics/struct.Mesh.html#method.new_circle)
+* [ellipse](https://docs.rs/ggez/0.6.0/ggez/graphics/struct.Mesh.html#method.new_ellipse)
+* [polygon](https://docs.rs/ggez/0.6.0/ggez/graphics/struct.Mesh.html#method.new_polygon)
+* [rectangle](https://docs.rs/ggez/0.6.0/ggez/graphics/struct.Mesh.html#method.new_rectangle)
 
 We are just going to touch on 2 shapes in this guide: the circle and the rectangle.
 
 Additionally there are 2 other methods we will look at.
 These 2 are used to show and erase the screen:
 
-* [clear](https://docs.rs/ggez/0.5.1/ggez/graphics/fn.clear.html)
-* [present](https://docs.rs/ggez/0.5.1/ggez/graphics/fn.present.html)
+* [clear](https://docs.rs/ggez/0.6.0/ggez/graphics/fn.clear.html)
+* [present](https://docs.rs/ggez/0.6.0/ggez/graphics/fn.present.html)
 
 ### ⚫ The Circle
 
 Circles are represented by 2 pieces of information: origin, and radius.
 Geometry, it's all coming back now.
 
-Here is the code for a [circle](https://docs.rs/ggez/0.5.1/ggez/graphics/struct.Mesh.html#method.new_circle):
+Here is the code for a [circle](https://docs.rs/ggez/0.6.0/ggez/graphics/struct.Mesh.html#method.new_circle):
 ```rust,skt-expression,no_run
 graphics::Mesh::new_circle(
     ctx,
@@ -86,7 +87,7 @@ Why did I just write like a million?!
 Well, `ctx` is needed to tell `ggez` where you are drawing to.
 `ctx` is what is passed into `update` and `draw` already.
 
-[`graphics::DrawMode::fill()`](https://docs.rs/ggez/0.5.1/ggez/graphics/enum.DrawMode.html) is choosing between outlining the circle or filling it in.
+[`graphics::DrawMode::fill()`](https://docs.rs/ggez/0.6.0/ggez/graphics/enum.DrawMode.html) is choosing between outlining the circle or filling it in.
 
 Point, now here is one we expected.
 This is the origin of the circle.
@@ -124,7 +125,7 @@ If you see a circle on the screen when you run `cargo run` you're good!
 
 Rectangles are represented by 3 pieces of information: origin, width, and height.
 
-Here is the code for a [rectangle](https://docs.rs/ggez/0.5.1/ggez/graphics/struct.Mesh.html#method.new_rectangle):
+Here is the code for a [rectangle](https://docs.rs/ggez/0.6.0/ggez/graphics/struct.Mesh.html#method.new_rectangle):
 ```rust,skt-expression,no_run
 graphics::Mesh::new_rectangle(
     ctx,
@@ -137,8 +138,8 @@ graphics::Mesh::new_rectangle(
 It might seem weird that there are less parameters for more required information than a circle,
 but this is correct.
 
-[`Rect`](https://docs.rs/ggez/0.5.1/ggez/graphics/struct.Rect.html) is a convenient type that represents a... rectangle!
-[`graphics::Rect::new(500.0, 250.0, 200.0, 100.0)`](https://docs.rs/ggez/0.5.1/ggez/graphics/struct.Rect.html) positions the rectangle's top-left corner at `x: 500, y: 250` and
+[`Rect`](https://docs.rs/ggez/0.6.0/ggez/graphics/struct.Rect.html) is a convenient type that represents a... rectangle!
+[`graphics::Rect::new(500.0, 250.0, 200.0, 100.0)`](https://docs.rs/ggez/0.6.0/ggez/graphics/struct.Rect.html) positions the rectangle's top-left corner at `x: 500, y: 250` and
 specifies `width: 200, height: 100`.
 
 And that's how a rectangle is drawn!
@@ -229,10 +230,10 @@ fn draw(&mut self, ctx: &mut Context) -> GameResult {
         // Make the shape...
         let mesh = match shape {
             &Shape::Rectangle(rect) => {
-                Mesh::new_rectangle(ctx, graphics::DrawMode::fill(), rect, graphics::Color::WHITE)?
+                graphics::Mesh::new_rectangle(ctx, graphics::DrawMode::fill(), rect, graphics::Color::WHITE)?
             }
             &Shape::Circle(origin, radius) => {
-                Mesh::new_circle(ctx, graphics::DrawMode::fill(), origin, radius, 0.1, graphics::Color::WHITE)?
+                graphics::Mesh::new_circle(ctx, graphics::DrawMode::fill(), origin, radius, 0.1, graphics::Color::WHITE)?
             }
         };
 
@@ -254,32 +255,33 @@ Random numbers can be generated using the [rand crate](https://docs.rs/rand/0.8.
 We don't want 2 shapes fixed in location.
 We want 2 shapes randomly generated!
 
-Include `rand` in your `Cargo.toml`:
+Include your favorite RNG in your `Cargo.toml`:
 ```toml
 [dependencies]
 ggez = "0.6.0"
-rand = "0.8.3"
+oorandom = "11"
 ```
 
-At the top of `main.rs` `use` `rand`:
+At the top of `main.rs` add a `use` statement for the RNG:
 ```rust,skt-definition,no_run
-use rand::{thread_rng, Rng};
+use oorandom::Rand32;
 ```
 
 Change how the 2 shapes are created to include randomness:
 ```rust,skt-expression,no_run
+    let mut rng = Rand32::new(4); // Random number chosen by fair die roll
 shapes.push(Shape::Rectangle(ggez::graphics::Rect::new(
-    thread_rng().gen_range(0.0..800.0),
-    thread_rng().gen_range(0.0..600.0),
-    thread_rng().gen_range(0.0..800.0),
-    thread_rng().gen_range(0.0..600.0),
+    rng.rand_float() * 800.0,
+    rng.rand_float() * 600.0,
+    rng.rand_float() * 800.0,
+    rng.rand_float() * 600.0,
 )));
 shapes.push(Shape::Circle(
     mint::Point2{
-        x: thread_rng().gen_range(0.0..800.0),
-        y: thread_rng().gen_range(0.0..600.0),
+        x: rng.rand_float() * 800.0,
+        y: rng.rand_float() * 600.0,
     },
-    thread_rng().gen_range(0.0..300.0),
+    rng.rand_float() * 300.0,
 ));
 ```
 Run `cargo run` a couple times and see how the shapes move around and change shape.
@@ -291,33 +293,34 @@ Modify your `main.rs`:
 ```rust,skt-expression,no_run
 let mut shapes = Vec::new();
 for _ in 0..8 {
-    if thread_rng().gen::<bool>() {
+    if rng.rand_i32() >= 0 {
         shapes.push(Shape::Rectangle(ggez::graphics::Rect::new(
-            thread_rng().gen_range(0.0..800.0),
-            thread_rng().gen_range(0.0..600.0),
-            thread_rng().gen_range(0.0..800.0),
-            thread_rng().gen_range(0.0..600.0),
+            rng.rand_float() * 800.0,
+            rng.rand_float() * 600.0,
+            rng.rand_float() * 800.0,
+            rng.rand_float() * 600.0,
         )));
     } else {
         shapes.push(Shape::Circle(
             mint::Point2{
-                x: thread_rng().gen_range(0.0..800.0),
-                y: thread_rng().gen_range(0.0..600.0),
+                x: rng.rand_float() * 800.0,
+                y: rng.rand_float() * 600.0,
             },
-            thread_rng().gen_range(0.0..300.0),
+            rng.rand_float() * 300.0,
         ));
     }
 }
 ```
 Now we are creating 8 shapes of random type, size, and position.
 
-run `cargo run` a couple more times.
+Run `cargo run` a couple more times.  Add the `getrandom` crate or some
+other source of true randomness to seed the RNG.
 Bask in the expressiveness and technique of your computer.
 Print it out, put it on a canvas, and sell it to your local museum.
 
 ## 💪 Challenges
 
 Optional activities for those that want more:
-* Randomize colors
-* Include more shapes: lines, polygons, ellipse
-* Draw a new shape every 5 seconds instead of upfront
+ * Randomize colors
+ * Include more shapes: lines, polygons, ellipse
+ * Draw a new shape every 5 seconds instead of upfront

--- a/docs/guides/HelloGgez.md
+++ b/docs/guides/HelloGgez.md
@@ -35,7 +35,7 @@ version = "0.1.0"
 authors = ["Awesome Person awesome@person.com"]
 
 [dependencies]
-ggez = "0.6.0"
+ggez = "0.6"
 ```
 
 ### ✔ Check Project Setup
@@ -211,9 +211,11 @@ struct State {
     dt: std::time::Duration,
 }
 ```
+
 `dt` is going to represent the time each frame has taken. It stands for "delta time" and is a useful metric for games to handle variable frame rates.
 
 Now in `main`, you need to update the `State` instantiation to include `dt`:
+
 ```rust,skt-expression,no_run
 let state = State {
     dt: std::time::Duration::new(0, 0),
@@ -222,6 +224,7 @@ let state = State {
 
 So now that we have state to update, let's update it in our `update` callback!
 We'll use [`timer::delta`](https://docs.rs/ggez/0.6.0/ggez/timer/fn.delta.html) to get the delta time.
+
 ```rust,skt-update,no_run
 fn update(&mut self, ctx: &mut Context) -> GameResult {
     self.dt = timer::delta(ctx);

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -87,9 +87,9 @@ const MAX_ROCK_VEL: f32 = 50.0;
 fn create_player() -> Actor {
     Actor {
         tag: ActorType::Player,
-        pos: Point2::zero(),
+        pos: Point2::ZERO,
         facing: 0.,
-        velocity: Vector2::zero(),
+        velocity: Vector2::ZERO,
         ang_vel: 0.,
         bbox_size: PLAYER_BBOX,
         life: PLAYER_LIFE,
@@ -99,9 +99,9 @@ fn create_player() -> Actor {
 fn create_rock() -> Actor {
     Actor {
         tag: ActorType::Rock,
-        pos: Point2::zero(),
+        pos: Point2::ZERO,
         facing: 0.,
-        velocity: Vector2::zero(),
+        velocity: Vector2::ZERO,
         ang_vel: 0.,
         bbox_size: ROCK_BBOX,
         life: ROCK_LIFE,
@@ -111,9 +111,9 @@ fn create_rock() -> Actor {
 fn create_shot() -> Actor {
     Actor {
         tag: ActorType::Shot,
-        pos: Point2::zero(),
+        pos: Point2::ZERO,
         facing: 0.,
-        velocity: Vector2::zero(),
+        velocity: Vector2::ZERO,
         ang_vel: SHOT_ANG_VEL,
         bbox_size: SHOT_BBOX,
         life: SHOT_LIFE,

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -65,7 +65,7 @@ fn default_view() -> Isometry3 {
     Mat4::look_at_rh(
         Point3::new(1.5f32, -5.0, 3.0),
         Point3::new(0f32, 0.0, 0.0),
-        Vector3::unit_z(),
+        Vector3::Z,
     )
 }
 

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -77,7 +77,7 @@ impl event::EventHandler for MainState {
         graphics::queue_text(
             ctx,
             &graphics::Text::new("Press number keys 1-6 to play a sound, or escape to quit."),
-            Vec2::zero(),
+            Vec2::ZERO,
             None,
         );
         graphics::draw_queued_text(

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -85,7 +85,7 @@ impl event::EventHandler for MainState {
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::clear(ctx, [0.1, 0.2, 0.3, 1.0].into());
 
-        let origin = Vec2::zero();
+        let origin = Vec2::ZERO;
         graphics::draw(ctx, &self.gridmesh, (origin, Color::WHITE))?;
 
         let param = graphics::DrawParam::new()

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -47,7 +47,7 @@ where
 /// and pass in a rectangle with position (0, 0) and a size equal to that of the
 /// canvas.
 ///
-/// If you draw onto a canvas using BlendMode::Alpha you need to set its blend mode to 
+/// If you draw onto a canvas using BlendMode::Alpha you need to set its blend mode to
 /// `BlendMode::Premultiplied` before drawing it to a new surface. This is a side effect
 /// of the premultiplication of RGBA values when the canvas was rendered to.
 /// This requirement holds for both drawing
@@ -55,9 +55,9 @@ where
 /// ```
 /// let mut canvas = Canvas::new(width, height, conf::NumSamples::One, get_window_color_format(ctx));
 /// graphics::set_canvas(ctx, Some(&canvas));
-/// 
+///
 /// // Draw to canvas here...
-/// 
+///
 /// graphics::present(ctx);
 /// graphics::set_canvas(ctx, None);
 /// canvas.set_blend_mode(Some(BlendMode::Premultiplied));

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -46,6 +46,22 @@ where
 /// need to call [`graphics::set_screen_coordinates`](fn.set_screen_coordinates.html)
 /// and pass in a rectangle with position (0, 0) and a size equal to that of the
 /// canvas.
+///
+/// If you draw onto a canvas using BlendMode::Alpha you need to set its blend mode to 
+/// `BlendMode::Premultiplied` before drawing it to a new surface. This is a side effect
+/// of the premultiplication of RGBA values when the canvas was rendered to.
+/// This requirement holds for both drawing
+/// the `Canvas` directly or converting it to an `Image` first.
+/// ```
+/// let mut canvas = Canvas::new(width, height, conf::NumSamples::One, get_window_color_format(ctx));
+/// graphics::set_canvas(ctx, Some(&canvas));
+/// 
+/// // Draw to canvas here...
+/// 
+/// graphics::present(ctx);
+/// graphics::set_canvas(ctx, None);
+/// canvas.set_blend_mode(Some(BlendMode::Premultiplied));
+/// ```
 pub type Canvas = CanvasGeneric<GlBackendSpec>;
 
 impl<S> CanvasGeneric<S>

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -252,7 +252,7 @@ fn flip_draw_param_vertical(param: DrawParam) -> DrawParam {
             glam::Mat4::from(mat)
                 * glam::Mat4::from_scale_rotation_translation(
                     glam::vec3(1.0, -1.0, 1.0),
-                    Quat::identity(),
+                    Quat::IDENTITY,
                     glam::vec3(0.0, 1.0, 0.0),
                 ),
         )

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -273,7 +273,7 @@ impl GraphicsContextGeneric<GlBackendSpec> {
         let right = window_mode.width;
         let top = 0.0;
         let bottom = window_mode.height;
-        let initial_projection = Matrix4::identity(); // not the actual initial projection matrix, just placeholder
+        let initial_projection = Matrix4::IDENTITY; // not the actual initial projection matrix, just placeholder
         let globals = Globals {
             mvp_matrix: initial_projection.to_cols_array_2d(),
         };
@@ -323,7 +323,7 @@ impl GraphicsContextGeneric<GlBackendSpec> {
             h,
         };
         gfx.set_projection_rect(rect);
-        gfx.set_global_mvp(Matrix4::identity())?;
+        gfx.set_global_mvp(Matrix4::IDENTITY)?;
         Ok(gfx)
     }
 }

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -996,7 +996,7 @@ impl MeshBatch {
             gfx.data.rect_instance_properties = old_instance_buffer;
 
             // Undo the change we've made to the global MVP
-            gfx.set_global_mvp(Matrix4::identity())?;
+            gfx.set_global_mvp(Matrix4::IDENTITY)?;
         }
 
         Ok(())

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -640,7 +640,7 @@ pub fn set_default_filter(ctx: &mut Context, mode: FilterMode) {
 pub fn set_screen_coordinates(context: &mut Context, rect: Rect) -> GameResult {
     let gfx = &mut context.gfx_context;
     gfx.set_projection_rect(rect);
-    gfx.set_global_mvp(Matrix4::identity())
+    gfx.set_global_mvp(Matrix4::IDENTITY)
     //gfx.update_globals()
 }
 

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -87,7 +87,18 @@ impl From<BlendMode> for Blend {
                     destination: Factor::One,
                 },
             },
-            BlendMode::Alpha => blend::ALPHA,
+            BlendMode::Alpha => Blend {
+                color: BlendChannel {
+                    equation: Equation::Add,
+                    source: Factor::ZeroPlus(BlendValue::SourceAlpha),
+                    destination: Factor::OneMinus(BlendValue::SourceAlpha),
+                },
+                alpha: BlendChannel {
+                    equation: Equation::Add,
+                    source: Factor::OneMinus(BlendValue::DestAlpha),
+                    destination: Factor::One,
+                },
+            },
             BlendMode::Invert => blend::INVERT,
             BlendMode::Multiply => blend::MULTIPLY,
             BlendMode::Replace => blend::REPLACE,

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -207,7 +207,7 @@ impl graphics::Drawable for SpriteBatch {
         if let Some(mode) = previous_mode {
             gfx.set_blend_mode(mode)?;
         }
-        gfx.set_global_mvp(graphics::Matrix4::identity())?;
+        gfx.set_global_mvp(graphics::Matrix4::IDENTITY)?;
         Ok(())
     }
     fn dimensions(&self, _ctx: &mut Context) -> Option<Rect> {

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -240,6 +240,12 @@ impl From<Rect> for [f32; 4] {
 /// For convenience, several colors are provided:
 /// [`WHITE`](`Color::WHITE`)
 /// [`BLACK`](`Color::BLACK`)
+/// [`RED`](`Color::RED`)
+/// [`GREEN`](`Color::GREEN`)
+/// [`BLUE`](`Color::BLUE`)
+/// [`CYAN`](`Color::CYAN`)
+/// [`MAGENTA`](`Color::MAGENTA`)
+/// [`YELLOW`](`Color::YELLOW`)
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Color {
@@ -266,6 +272,54 @@ impl Color {
     pub const BLACK: Color = Color {
         r: 0.0,
         g: 0.0,
+        b: 0.0,
+        a: 1.0,
+    };
+
+    /// Red
+    pub const RED: Color = Color {
+        r: 1.0,
+        g: 0.0,
+        b: 0.0,
+        a: 1.0,
+    };
+
+    /// Green
+    pub const GREEN: Color = Color {
+        r: 0.0,
+        g: 1.0,
+        b: 0.0,
+        a: 1.0,
+    };
+
+    /// Blue
+    pub const BLUE: Color = Color {
+        r: 0.0,
+        g: 0.0,
+        b: 1.0,
+        a: 1.0,
+    };
+
+    /// Cyan
+    pub const CYAN: Color = Color {
+        r: 0.0,
+        g: 1.0,
+        b: 1.0,
+        a: 1.0,
+    };
+
+    /// Magenta
+    pub const MAGENTA: Color = Color {
+        r: 1.0,
+        g: 0.0,
+        b: 1.0,
+        a: 1.0,
+    };
+
+    /// Yellow
+    pub const YELLOW: Color = Color {
+        r: 1.0,
+        g: 1.0,
         b: 0.0,
         a: 1.0,
     };

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -24,8 +24,8 @@ pub struct MouseContext {
 impl MouseContext {
     pub(crate) fn new() -> Self {
         Self {
-            last_position: Point2::zero(),
-            last_delta: Point2::zero(),
+            last_position: Point2::ZERO,
+            last_delta: Point2::ZERO,
             cursor_type: CursorIcon::Default,
             buttons_pressed: HashMap::new(),
             cursor_grabbed: false,


### PR DESCRIPTION
```BlendMode::Premultiplied``` uses a different rule for calculating the alpha channel when drawing. It's (IMO) clearly better, since it does what you'd expect from alpha. Instead of two objects with alpha 0.5 creating a pixel with an alpha of 1 this new rule creates a pixel with an alpha of 0.75 (which is what's to be expected when two objects that are each half transparent are laid ontop of each other).

To make everything consistent again i propose to change ```BlendMode::Alpha``` to also adapt this new rule. It shouldn't change the output _that_ much. At least I've found no example where this change clearly breaks something badly (though I'm sure such an example could be constructed, if one really wanted to do so).
In fact, it should make the output more consistent with what a user should expect, though I do realize that someone porting from 0.5 to 0.6 might notice it and not like it.