### PR TITLE
don't resize windows when ScaleFactorChanged events happen

### DIFF
--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -21,7 +21,7 @@ pub fn main() -> GameResult {
     let mut position: f32 = 1.0;
 
     // Handle events. Refer to `winit` docs for more information.
-    events_loop.run(move |event, _window_target, control_flow| {
+    events_loop.run(move |mut event, _window_target, control_flow| {
         if !ctx.continuing {
             *control_flow = ControlFlow::Exit;
             return;
@@ -33,7 +33,7 @@ pub fn main() -> GameResult {
 
         // This tells `ggez` to update it's internal states, should the event require that.
         // These include cursor position, view updating on resize, etc.
-        event::process_event(ctx, &event);
+        event::process_event(ctx, &mut event);
         match event {
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::CloseRequested => event::quit(ctx),

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -52,6 +52,7 @@ pub enum FullscreenType {
 ///     max_height: 0.0,
 ///     resizable: false,
 ///     visible: true,
+///     resize_on_scale_factor_change: false,
 /// }
 /// # , WindowMode::default());}
 /// ```
@@ -90,6 +91,17 @@ pub struct WindowMode {
     /// Whether this window should displayed (true) or hidden (false)
     #[default = true]
     pub visible: bool,
+    /// Whether this window should change its size in physical pixels
+    /// when its hidpi factor changes, i.e. when [`WindowEvent::ScaleFactorChanged`](https://docs.rs/winit/0.25.0/winit/event/enum.WindowEvent.html#variant.ScaleFactorChanged)
+    /// is fired.
+    ///
+    /// You usually want this to be false, since the window suddenly changing size may break your game.
+    /// Setting this to true may be desirable if you plan for it and want your window to behave like
+    /// windows of other programs when being dragged from one screen to another, for example.
+    ///
+    /// For more context on this take a look at [this conversation](https://github.com/ggez/ggez/pull/949#issuecomment-854731226).
+    #[default = false]
+    pub resize_on_scale_factor_change: bool,
 }
 
 impl WindowMode {
@@ -141,6 +153,12 @@ impl WindowMode {
     /// Set visibility
     pub fn visible(mut self, visible: bool) -> Self {
         self.visible = visible;
+        self
+    }
+
+    /// Set whether to resize when the hidpi factor changes
+    pub fn resize_on_scale_factor_change(mut self, resize_on_scale_factor_change: bool) -> Self {
+        self.resize_on_scale_factor_change = resize_on_scale_factor_change;
         self
     }
 }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -57,10 +57,10 @@ pub enum FullscreenType {
 /// ```
 #[derive(Debug, Copy, Clone, SmartDefault, Serialize, Deserialize, PartialEq)]
 pub struct WindowMode {
-    /// Window width
+    /// Window width in physical pixels
     #[default = 800.0]
     pub width: f32,
-    /// Window height
+    /// Window height in physical pixels
     #[default = 600.0]
     pub height: f32,
     /// Whether or not to maximize the window

--- a/src/event.rs
+++ b/src/event.rs
@@ -354,12 +354,14 @@ pub fn process_event(ctx: &mut Context, event: &mut winit::event::Event<()>) {
                 ctx.keyboard_context.set_key(*keycode, pressed);
             }
             winit_event::WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
-                // actively set the new_inner_size to be the desired size
-                // to stop winit from resizing our window
-                **new_inner_size = winit::dpi::PhysicalSize::<u32>::from([
-                    ctx.conf.window_mode.width,
-                    ctx.conf.window_mode.height,
-                ]);
+                if !ctx.conf.window_mode.resize_on_scale_factor_change {
+                    // actively set the new_inner_size to be the desired size
+                    // to stop winit from resizing our window
+                    **new_inner_size = winit::dpi::PhysicalSize::<u32>::from([
+                        ctx.conf.window_mode.width,
+                        ctx.conf.window_mode.height,
+                    ]);
+                }
             }
             _ => (),
         },

--- a/src/event.rs
+++ b/src/event.rs
@@ -354,9 +354,12 @@ pub fn process_event(ctx: &mut Context, event: &mut winit::event::Event<()>) {
                 ctx.keyboard_context.set_key(*keycode, pressed);
             }
             winit_event::WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
-                // actively set the new_inner_size to be the current inner size
+                // actively set the new_inner_size to be the desired size
                 // to stop winit from resizing our window
-                **new_inner_size = ctx.gfx_context.window.window().inner_size();
+                **new_inner_size = winit::dpi::PhysicalSize::<u32>::from([
+                    ctx.conf.window_mode.width,
+                    ctx.conf.window_mode.height,
+                ]);
             }
             _ => (),
         },

--- a/src/event.rs
+++ b/src/event.rs
@@ -164,7 +164,7 @@ where
 {
     use crate::input::{keyboard, mouse};
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run(move |mut event, _, control_flow| {
         if !ctx.continuing {
             *control_flow = ControlFlow::Exit;
             return;
@@ -175,7 +175,7 @@ where
         let ctx = &mut ctx;
         let state = &mut state;
 
-        process_event(ctx, &event);
+        process_event(ctx, &mut event);
         match event {
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::Resized(logical_size) => {
@@ -311,7 +311,7 @@ where
 /// state it needs to, such as detecting window resizes.  If you are
 /// rolling your own event loop, you should call this on the events
 /// you receive before processing them yourself.
-pub fn process_event(ctx: &mut Context, event: &winit::event::Event<()>) {
+pub fn process_event(ctx: &mut Context, event: &mut winit::event::Event<()>) {
     match event {
         winit_event::Event::WindowEvent { event, .. } => match event {
             winit_event::WindowEvent::Resized(physical_size) => {
@@ -353,8 +353,10 @@ pub fn process_event(ctx: &mut Context, event: &winit::event::Event<()>) {
                 };
                 ctx.keyboard_context.set_key(*keycode, pressed);
             }
-            winit_event::WindowEvent::ScaleFactorChanged { .. } => {
-                // Nope.
+            winit_event::WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
+                // actively set the new_inner_size to be the current inner size
+                // to stop winit from resizing our window
+                **new_inner_size = ctx.gfx_context.window.window().inner_size();
             }
             _ => (),
         },

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -714,7 +714,7 @@ pub fn set_fullscreen(context: &mut Context, fullscreen: conf::FullscreenType) -
     set_mode(context, window_mode)
 }
 
-/// Sets the window size/resolution to the specified width and height.
+/// Sets the window size (in physical pixels) / resolution to the specified width and height.
 ///
 /// Note:   These dimensions are only interpreted as resolutions in true fullscreen mode.
 ///         If the selected resolution is not supported this function will return an Error.
@@ -789,7 +789,7 @@ pub fn size(context: &Context) -> (f32, f32) {
     (physical_size.width as f32, physical_size.height as f32)
 }
 
-/// Returns the size of the window's underlying drawable in pixels as (width, height).
+/// Returns the size of the window's underlying drawable in physical pixels as (width, height).
 /// Returns zeros if window doesn't exist.
 pub fn drawable_size(context: &Context) -> (f32, f32) {
     let gfx = &context.gfx_context;

--- a/src/tests/graphics.rs
+++ b/src/tests/graphics.rs
@@ -153,7 +153,7 @@ fn sanity_check_window_sizes() {
     std::thread::sleep(std::time::Duration::from_millis(100));
     // Maybe we need to run the event pump too?  It seems VERY flaky.
     // Sometimes you need one, sometimes you need both...
-    e.run(move |event, _, control_flow| {
+    e.run(move |mut event, _, control_flow| {
         if let winit::event::Event::RedrawEventsCleared = event {
             let size = graphics::drawable_size(&c);
             assert_eq!(w, size.0);
@@ -163,6 +163,6 @@ fn sanity_check_window_sizes() {
             return;
         }
 
-        event::process_event(&mut c, &event);
+        event::process_event(&mut c, &mut event);
     });
 }


### PR DESCRIPTION
fixes a bug discovered [here](https://github.com/ggez/ggez/issues/638#issuecomment-854378569)