### PR TITLE
EventHandler Error handling

### DIFF
--- a/examples/01_super_simple.rs
+++ b/examples/01_super_simple.rs
@@ -17,7 +17,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
         self.pos_x = self.pos_x % 800.0 + 1.0;
         Ok(())

--- a/examples/02_hello_world.rs
+++ b/examples/02_hello_world.rs
@@ -29,7 +29,7 @@ impl MainState {
 //
 // The `EventHandler` trait also contains callbacks for event handling
 // that you can override if you wish, but the defaults are fine.
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
         Ok(())
     }

--- a/examples/03_drawing.rs
+++ b/examples/03_drawing.rs
@@ -100,7 +100,7 @@ fn build_textured_triangle(ctx: &mut Context) -> GameResult<graphics::Mesh> {
     mb.build(ctx)
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
 

--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -377,7 +377,7 @@ impl GameState {
 
 /// Now we implement EventHandler for GameState. This provides an interface
 /// that ggez will call automatically when different events happen.
-impl event::EventHandler for GameState {
+impl event::EventHandler<ggez::GameError> for GameState {
     /// Update will happen on every frame before it is drawn. This is where we update
     /// our game state to react to whatever is happening in the game world.
     fn update(&mut self, ctx: &mut Context) -> GameResult {

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -434,7 +434,7 @@ fn draw_actor(
 /// ggez with callbacks for updating and drawing our game, as well as
 /// handling input events.
 /// **********************************************************************
-impl EventHandler for MainState {
+impl EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
 

--- a/examples/blend_modes.rs
+++ b/examples/blend_modes.rs
@@ -122,7 +122,7 @@ impl MainState {
     }
 }
 
-impl EventHandler for MainState {
+impl EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, _: &mut Context) -> GameResult<()> {
         Ok(())
     }

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -77,7 +77,7 @@ impl GameState {
     }
 }
 
-impl event::EventHandler for GameState {
+impl event::EventHandler<ggez::GameError> for GameState {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
         if self.click_timer > 0 {
             self.click_timer -= 1;

--- a/examples/canvas_subframe.rs
+++ b/examples/canvas_subframe.rs
@@ -87,7 +87,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         if timer::ticks(ctx) % 100 == 0 {
             println!("Delta frame time: {:?} ", timer::delta(ctx));

--- a/examples/colorspace.rs
+++ b/examples/colorspace.rs
@@ -120,7 +120,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
         Ok(())
     }

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -202,7 +202,7 @@ void main() {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
         self.rotation += 0.01;
         Ok(())

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -46,7 +46,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
         while timer::check_update_time(ctx, DESIRED_FPS) {

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -33,7 +33,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
         Ok(())
     }

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -72,7 +72,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
         while timer::check_update_time(ctx, DESIRED_FPS) {

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -22,7 +22,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         if input::keyboard::is_key_pressed(ctx, KeyCode::A) {
             println!("The A key is pressed");

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -76,7 +76,7 @@ impl App {
 }
 
 /// Where the app meets the `ggez`.
-impl EventHandler for App {
+impl EventHandler<ggez::GameError> for App {
     /// This is where the logic should happen.
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;

--- a/examples/meshbatch.rs
+++ b/examples/meshbatch.rs
@@ -62,7 +62,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     #[allow(clippy::needless_range_loop)]
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         if timer::ticks(ctx) % 100 == 0 {

--- a/examples/render_to_image.rs
+++ b/examples/render_to_image.rs
@@ -21,7 +21,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
         Ok(())
     }

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -36,7 +36,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         self.dim.rate = 0.5 + (((timer::ticks(ctx) as f32) / 100.0).cos() / 2.0);
         Ok(())

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -320,7 +320,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         if timer::ticks(ctx) % 100 == 0 {
             println!("Average FPS: {}", timer::fps(ctx));

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -66,7 +66,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
         Ok(())
     }

--- a/examples/spritebatch.rs
+++ b/examples/spritebatch.rs
@@ -24,7 +24,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         if timer::ticks(ctx) % 100 == 0 {
             println!("Delta frame time: {:?} ", timer::delta(ctx));

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -112,7 +112,7 @@ impl App {
     }
 }
 
-impl event::EventHandler for App {
+impl event::EventHandler<ggez::GameError> for App {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
         while timer::check_update_time(ctx, DESIRED_FPS) {}

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -76,7 +76,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
         self.pos_x = self.pos_x % 800.0 + 1.0;
         Ok(())


### PR DESCRIPTION
This is a first shot at fixing #800.
Instead of having to write error handling wrappers for each EventHandler function one can now just implement `EventHandler::on_error` to achieve customized error handling.

This still doesn't give users much freedom to handle their own kinds of errors though. Their only option for this, at this point, is to create a `GameError::CustomError(String)`, which is much better than nothing, but not ideal yet.