### PR TITLE
Fixes memory leak in to_rgba8 and screenshot

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -28,6 +28,7 @@ where
     pub(crate) projection: Matrix4,
     pub(crate) white_image: ImageGeneric<B>,
     pub(crate) screen_rect: Rect,
+    pub(crate) to_rgba8_buffer: gfx::handle::Buffer<B::Resources, u8>,
     color_format: gfx::format::Format,
     depth_format: gfx::format::Format,
     srgb: bool,
@@ -219,6 +220,8 @@ impl GraphicsContextGeneric<GlBackendSpec> {
 
         quad_slice.instances = Some((1, 0));
 
+        let to_rgba8_buffer = factory.create_download_buffer::<u8>(1)?;
+
         let globals_buffer = factory.create_constant_buffer(1);
         let mut samplers: SamplerCache<GlBackendSpec> = SamplerCache::new();
         let sampler_info =
@@ -283,6 +286,7 @@ impl GraphicsContextGeneric<GlBackendSpec> {
             projection: initial_projection,
             white_image,
             screen_rect: Rect::new(left, top, right - left, bottom - top),
+            to_rgba8_buffer,
             color_format,
             depth_format,
             srgb,


### PR DESCRIPTION
This fixes the memory leak by just using the global command buffer instead of creating a "local" new one, which is leaky.

I also added a download buffer handle to the gfx context, to avoid possibly recreating it all the time.
This is probably not important, but it's the first thing I tried and it works and it probably improves performance for use cases like #958, so why not keep it.