### PR TITLE
Allow renaming of resources and resources.zip

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -130,6 +130,8 @@ pub struct ContextBuilder {
     pub(crate) game_id: String,
     pub(crate) author: String,
     pub(crate) conf: conf::Conf,
+    pub(crate) resources_dir_name: String,
+    pub(crate) resources_zip_name: String,
     pub(crate) paths: Vec<path::PathBuf>,
     pub(crate) memory_zip_files: Vec<Cow<'static, [u8]>>,
     pub(crate) load_conf_file: bool,
@@ -142,6 +144,8 @@ impl ContextBuilder {
             game_id: game_id.to_string(),
             author: author.to_string(),
             conf: conf::Conf::default(),
+            resources_dir_name: "resources".to_string(),
+            resources_zip_name: "resources.zip".to_string(),
             paths: vec![],
             memory_zip_files: vec![],
             load_conf_file: true,
@@ -180,6 +184,20 @@ impl ContextBuilder {
     /// file found.
     pub fn default_conf(mut self, conf: conf::Conf) -> Self {
         self.conf = conf;
+        self
+    }
+
+    /// Sets resources dir name.
+    /// Default resources dir name is `resources`.
+    pub fn change_resources_dir_name(mut self, new_name: impl ToString) -> Self {
+        self.resources_dir_name = new_name.to_string();
+        self
+    }
+
+    /// Sets resources zip name.
+    /// Default resources dir name is `resources.zip`.
+    pub fn change_resources_zip_name(mut self, new_name: impl ToString) -> Self {
+        self.resources_zip_name = new_name.to_string();
         self
     }
 
@@ -226,8 +244,8 @@ impl ContextBuilder {
         let mut fs = Filesystem::new(
             self.game_id.as_ref(),
             self.author.as_ref(),
-            "resources",
-            "resources.zip",
+            &self.resources_dir_name,
+            &self.resources_zip_name,
         )?;
 
         for path in &self.paths {

--- a/src/context.rs
+++ b/src/context.rs
@@ -189,14 +189,14 @@ impl ContextBuilder {
 
     /// Sets resources dir name.
     /// Default resources dir name is `resources`.
-    pub fn change_resources_dir_name(mut self, new_name: impl ToString) -> Self {
+    pub fn resources_dir_name(mut self, new_name: impl ToString) -> Self {
         self.resources_dir_name = new_name.to_string();
         self
     }
 
     /// Sets resources zip name.
     /// Default resources dir name is `resources.zip`.
-    pub fn change_resources_zip_name(mut self, new_name: impl ToString) -> Self {
+    pub fn resources_zip_name(mut self, new_name: impl ToString) -> Self {
         self.resources_zip_name = new_name.to_string();
         self
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -223,7 +223,12 @@ impl ContextBuilder {
 
     /// Build the `Context`.
     pub fn build(self) -> GameResult<(Context, winit::event_loop::EventLoop<()>)> {
-        let mut fs = Filesystem::new(self.game_id.as_ref(), self.author.as_ref())?;
+        let mut fs = Filesystem::new(
+            self.game_id.as_ref(),
+            self.author.as_ref(),
+            "resources",
+            "resources.zip",
+        )?;
 
         for path in &self.paths {
             fs.mount(path, true);

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -22,6 +22,12 @@
 //!
 //! See the source of the [`files` example](https://github.com/ggez/ggez/blob/master/examples/files.rs) for more details.
 //!
+//! The names of `resources/` and `resources.zip` can be changed with the methods
+//! [`change_resources_dir_name`](../struct.ContextBuilder.html#method.change_resources_dir_name)
+//! and
+//! [`change_resources_zip_name`](../struct.ContextBuilder.html#method.change_resources_zip_name)
+//!  of ContextBuilder.
+//!
 //! Note that the file lookups WILL follow symlinks!  This module's
 //! directory isolation is intended for convenience, not security, so
 //! don't assume it will be secure.

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -23,9 +23,9 @@
 //! See the source of the [`files` example](https://github.com/ggez/ggez/blob/master/examples/files.rs) for more details.
 //!
 //! The names of `resources/` and `resources.zip` can be changed with the methods
-//! [`change_resources_dir_name`](../struct.ContextBuilder.html#method.change_resources_dir_name)
+//! [`resources_dir_name`](../struct.ContextBuilder.html#method.resources_dir_name)
 //! and
-//! [`change_resources_zip_name`](../struct.ContextBuilder.html#method.change_resources_zip_name)
+//! [`resources_zip_name`](../struct.ContextBuilder.html#method.resources_zip_name)
 //!  of ContextBuilder.
 //!
 //! Note that the file lookups WILL follow symlinks!  This module's

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -94,7 +94,12 @@ impl Filesystem {
     /// some platforms) the `author` as a portion of the user
     /// directory path.  This function is called automatically by
     /// ggez, the end user should never need to call it.
-    pub fn new(id: &str, author: &str) -> GameResult<Filesystem> {
+    pub fn new(
+        id: &str,
+        author: &str,
+        resources_dir_name: &str,
+        resources_zip_name: &str,
+    ) -> GameResult<Filesystem> {
         let mut root_path = env::current_exe()?;
 
         // Ditch the filename (if any)
@@ -122,7 +127,7 @@ impl Filesystem {
         // <game exe root>/resources/
         {
             resources_path = root_path.clone();
-            resources_path.push("resources");
+            resources_path.push(resources_dir_name);
             trace!("Resources path: {:?}", resources_path);
             let physfs = vfs::PhysicalFS::new(&resources_path, true);
             overlay.push_back(Box::new(physfs));
@@ -131,7 +136,7 @@ impl Filesystem {
         // <root>/resources.zip
         {
             resources_zip_path = root_path;
-            resources_zip_path.push("resources.zip");
+            resources_zip_path.push(resources_zip_name);
             if resources_zip_path.exists() {
                 trace!("Resources zip file: {:?}", resources_zip_path);
                 let zipfs = vfs::ZipFS::new(&resources_zip_path)?;


### PR DESCRIPTION
Hi!

This is a PR for an additional feature as the title suggests.

I wanted to change the name of `resources.zip` to `data`.
I personally think it's cooler to have `data` with no extension next to the exe than to have a file with a `.zip` extension next to it.
Of course, I understand that hiding the extension does not lead to any kind of encryption.
It's just to make it look cool, nothing more.

I added `resources_dir_name` and `resources_zip_name` as arguments when building the filesystem.
I added a method to ContextBuilder to change this setting.
The default values are set to `resources` and `resources.zip`, which are the same as before, respectively.

As a limitation, unfortunately, this setting cannot be written in `conf.toml`, because `conf.toml` must be in resources, and can only be used after the resources directory has been determined.
Therefore, this setting can only be changed via the `ContextBuilder` method.

I understand that more configuration increases complexity and may threaten "make good games, easily".
However, I believe that adding this setting will not add too much complexity since the default setting is to use the existing `resources` ans `resources.zip`.
If there are any problems, I will withdraw this PR.

Thank you for your patience.
Finally, thanks for the awesome crate!