### PR TITLE
Add methods to obtain references to internal sprite data in SpriteBatch

### DIFF
--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -89,9 +89,9 @@ impl SpriteBatch {
 
     /// Returns a mutable reference to the sprites.
     ///
-    /// Please note that manually altering items in this slice
-    /// will not automatically invalidate the buffer, you will
-    /// have to manually call `flush()` or `flush_range()` later.
+    /// Unlike with `MeshBatch`, manually calling `flush` after altering sprites
+    /// in this slice is currently unnecessary, as `SpriteBatch` flushes automatically
+    /// on every draw call. This might change in the future though.
     pub fn get_sprites_mut(&mut self) -> &mut [DrawParam] {
         &mut self.sprites
     }

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -82,6 +82,20 @@ impl SpriteBatch {
         }
     }
 
+    /// Returns a reference to the sprites.
+    pub fn get_sprites(&self) -> &[DrawParam] {
+        &self.sprites
+    }
+
+    /// Returns a mutable reference to the sprites.
+    ///
+    /// Please note that manually altering items in this slice
+    /// will not automatically invalidate the buffer, you will
+    /// have to manually call `flush()` or `flush_range()` later.
+    pub fn get_sprites_mut(&mut self) -> &mut [DrawParam] {
+        &mut self.sprites
+    }
+
     /// Immediately sends all data in the batch to the graphics card.
     ///
     /// Generally just calling [`graphics::draw()`](../fn.draw.html) on the `SpriteBatch`


### PR DESCRIPTION
There is currently no way, as far as I know, to remove elements from the sprite batch and this would give a decent way of doing that.

This is modeled after the same methods in MeshBatch, docstring and all. The naming could probably use some bikeshedding.