### PR TITLE
Fix conversion of linear color to sRGB

### DIFF
--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -501,7 +501,7 @@ impl From<LinearColor> for Color {
             if component <= 0.003_130_8 {
                 component * 12.92
             } else {
-                (1.0 + a) * component.powf(1.0 / 2.4)
+                (1.0 + a) * component.powf(1.0 / 2.4) - a
             }
         }
         Color {


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/Srgb#From_CIE_XYZ_to_sRGB , you have to subtract 0.055 from the color value after multiplying and exponentiating in order to properly invert the sRGB gamma function.  You can verify that the conversion is correct here: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=c2aedead960001921875514d371bea5e
