### PR TITLE
implemented MSAA on canvases via a fragment shader workaround

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,8 @@ pub enum GameError {
     GamepadError(String),
     /// Something went wrong with the `lyon` shape-tesselation library.
     LyonError(String),
+    /// You tried to use MSAA on canvases with GLES, which isn't supported.
+    CanvasMSAAError,
     /// A custom error type for use by users of ggez.
     /// This lets you handle custom errors that may happen during your game (such as, trying to load a malformed file for a level)
     /// using the same mechanism you handle ggez's other errors.
@@ -61,6 +63,7 @@ impl fmt::Display for GameError {
             ),
             GameError::WindowError(ref e) => write!(f, "Window creation error: {}", e),
             GameError::CustomError(ref s) => write!(f, "Custom error: {}", s),
+            GameError::CanvasMSAAError => write!(f, "You tried to use MSAA on canvases with GLES, which isn't supported, as our implementation depends on a fragment shader workaround, which doesn't work with GLES 300"),
             _ => write!(f, "GameError {:?}", self),
         }
     }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -433,6 +433,11 @@ pub fn resources_dir(ctx: &Context) -> &path::Path {
     &ctx.filesystem.resources_path
 }
 
+/// Return the full path to the user data directory
+pub fn zip_dir(ctx: &Context) -> &path::Path {
+    &ctx.filesystem.zip_path
+}
+
 /// Returns a list of all files and directories in the resource directory,
 /// in no particular order.
 ///

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -11,22 +11,10 @@ use glam::Quat;
 
 use crate::context::DebugId;
 use crate::error::*;
+use crate::graphics::context::Fragments;
 use crate::graphics::*;
 use crate::Context;
 use crate::{conf, filesystem};
-
-/// A generic canvas independent of graphics backend. This type should
-/// never need to be used directly; use [`graphics::Canvas`](type.Canvas.html)
-/// instead.
-#[derive(Debug)]
-pub struct CanvasGeneric<Spec>
-where
-    Spec: BackendSpec,
-{
-    target: RawRenderTargetView<Spec::Resources>,
-    image: Image,
-    debug_id: DebugId,
-}
 
 /// A canvas that can be rendered to instead of the screen (sometimes referred
 /// to as "render target" or "render to texture"). Set the canvas with the
@@ -62,12 +50,25 @@ where
 /// graphics::set_canvas(ctx, None);
 /// canvas.set_blend_mode(Some(BlendMode::Premultiplied));
 /// ```
-pub type Canvas = CanvasGeneric<GlBackendSpec>;
+#[derive(Debug)]
+pub struct Canvas {
+    target: RawRenderTargetView<gfx_device_gl::Resources>,
+    image: Image,
+    ms_canvas: Option<MultiSampledCanvas>,
+    debug_id: DebugId,
+}
 
-impl<S> CanvasGeneric<S>
-where
-    S: BackendSpec,
-{
+/// A generic non-multi-sampled canvas that cannot contain another canvas. This type should
+/// never need to be used directly; use [`graphics::Canvas`](type.Canvas.html)
+/// instead.
+#[derive(Debug)]
+struct MultiSampledCanvas {
+    target: RawRenderTargetView<gfx_device_gl::Resources>,
+    image: Image,
+    fragments: u8,
+}
+
+impl Canvas {
     #[allow(clippy::new_ret_no_self)]
     /// Create a new `Canvas` with the given size and number of samples.
     ///
@@ -80,14 +81,7 @@ where
         color_format: Format,
     ) -> GameResult<Canvas> {
         let debug_id = DebugId::get(ctx);
-        let aa = match samples {
-            conf::NumSamples::One => AaMode::Single,
-            s => {
-                warn!("canvases with multisampling are currently broken! See https://github.com/ggez/ggez/issues/695");
-                AaMode::Multi(s.into())
-            }
-        };
-        let kind = Kind::D2(width, height, aa);
+        let kind = Kind::D2(width, height, AaMode::Single);
         let levels = 1;
         let factory = &mut ctx.gfx_context.factory;
         let texture_create_info = gfx::texture::Info {
@@ -112,6 +106,41 @@ where
             layer: None,
         };
         let target = factory.view_texture_as_render_target_raw(&tex, render_desc)?;
+
+        let ms_canvas = match samples {
+            conf::NumSamples::One => None,
+            s => {
+                let aa = AaMode::Multi(s.into());
+                let fragments = aa.get_num_fragments();
+                let kind = Kind::D2(width, height, aa);
+                let texture_create_info = gfx::texture::Info {
+                    kind,
+                    levels,
+                    format: color_format.0,
+                    bind: Bind::SHADER_RESOURCE | Bind::RENDER_TARGET | Bind::TRANSFER_SRC,
+                    usage: Usage::Data,
+                };
+                let tex =
+                    factory.create_texture_raw(texture_create_info, Some(color_format.1), None)?;
+                let resource = factory.view_texture_as_shader_resource_raw(&tex, resource_desc)?;
+                let target = factory.view_texture_as_render_target_raw(&tex, render_desc)?;
+
+                Some(MultiSampledCanvas {
+                    target,
+                    image: Image {
+                        texture: resource,
+                        texture_handle: tex,
+                        sampler_info: ctx.gfx_context.default_sampler_info,
+                        blend_mode: None,
+                        width,
+                        height,
+                        debug_id,
+                    },
+                    fragments,
+                })
+            }
+        };
+
         Ok(Canvas {
             target,
             image: Image {
@@ -123,6 +152,7 @@ where
                 height,
                 debug_id,
             },
+            ms_canvas,
             debug_id,
         })
     }
@@ -141,7 +171,9 @@ where
         )
     }
 
-    /// Gets the backend `Image` that is being rendered to. Note that this will be flipped but otherwise the same, use the [`to_image`](#method.to_image) function for the unflipped version.
+    /// Gets the backend `Image` that is being rendered to.
+    ///
+    /// Note that this will be flipped but otherwise the same, use the [`to_image`](#method.to_image) function for the unflipped version.
     pub fn raw_image(&self) -> &Image {
         &self.image
     }
@@ -153,12 +185,16 @@ where
     }
 
     /// Gets the backend `Target` that is being rendered to.
-    pub fn target(&self) -> &RawRenderTargetView<S::Resources> {
-        &self.target
+    pub fn target(&self) -> &RawRenderTargetView<gfx_device_gl::Resources> {
+        match &self.ms_canvas {
+            Some(ms_canvas) => &ms_canvas.target,
+            _ => &self.target,
+        }
     }
 
     /// Dumps the flipped `Canvas`'s data to a `Vec` of `u8` RBGA8 values.
     pub fn to_rgba8(&self, ctx: &mut Context) -> GameResult<Vec<u8>> {
+        self.resolve(ctx)?;
         let mut pixel_data = self.image.to_rgba8(ctx)?;
         flip_pixel_data(
             &mut pixel_data,
@@ -220,11 +256,54 @@ where
     pub fn set_filter(&mut self, mode: FilterMode) {
         self.image.set_filter(mode)
     }
+
+    /// If the canvas is multi-sampled this function resolves the internal multi-sampled texture
+    /// into a non-multi-sampled texture that can actually be drawn.
+    ///
+    /// `ggez` calls this automatically when you try to draw the canvas onto another target, or when
+    /// you copy the underlying image using [`to_image()`](#method.to_image), [`to_rgba8()`](#method.to_rgba8) or [`encode()`](#method.encode).
+    ///
+    /// You shouldn't need to call this manually, unless you want to access the [raw image](#method.raw_image)
+    /// after something has been drawn on the canvas, but before the canvas has been drawn onto another target
+    /// itself.
+    pub fn resolve(&self, ctx: &mut Context) -> GameResult {
+        if let Some(ms_canvas) = &self.ms_canvas {
+            // save the old target to restore it after the resolve has finished
+            let old_target = std::mem::replace(&mut ctx.gfx_context.data.out, self.target.clone());
+            // set resolve shader
+            let r_shader_id = ctx.gfx_context.resolve_shader.shader_id();
+            let old_shader = std::mem::replace(
+                &mut *ctx.gfx_context.current_shader.borrow_mut(),
+                Some(r_shader_id),
+            );
+            let frags = Fragments {
+                fragments: ms_canvas.fragments as i32,
+            };
+            ctx.gfx_context.encoder.update_buffer(
+                &ctx.gfx_context.resolve_shader.buffer,
+                &[frags],
+                0,
+            )?;
+            // draw the multi-sampled image onto the resolve target
+            let param = DrawParam::new().transform(glam::Mat4::from_scale_rotation_translation(
+                glam::vec3(self.image.width as f32, -(self.image.height as f32), 1.0),
+                Quat::IDENTITY,
+                glam::vec3(0.0, self.image.height as f32, 0.0),
+            ));
+            crate::graphics::image::draw_image_raw(&ms_canvas.image, ctx, param)?;
+            // restore the old target
+            ctx.gfx_context.data.out = old_target;
+            // and the old shader
+            *ctx.gfx_context.current_shader.borrow_mut() = old_shader;
+        }
+        Ok(())
+    }
 }
 
 impl Drawable for Canvas {
     fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult {
         self.debug_id.assert(ctx);
+        self.resolve(ctx)?;
 
         // We have to mess with the scale to make everything
         // be its-unit-size-in-pixels.
@@ -238,7 +317,7 @@ impl Drawable for Canvas {
 
         let new_param = flip_draw_param_vertical(param);
 
-        image::draw_image_raw(&self.image, ctx, new_param)
+        crate::graphics::image::draw_image_raw(&self.image, ctx, new_param)
     }
     fn dimensions(&self, _: &mut Context) -> Option<Rect> {
         Some(self.image.dimensions())
@@ -279,7 +358,10 @@ pub fn set_canvas(ctx: &mut Context, target: Option<&Canvas>) {
     match target {
         Some(surface) => {
             surface.debug_id.assert(ctx);
-            ctx.gfx_context.data.out = surface.target.clone();
+            ctx.gfx_context.data.out = match &surface.ms_canvas {
+                Some(ms_canvas) => ms_canvas.target.clone(),
+                _ => surface.target.clone(),
+            };
         }
         None => {
             ctx.gfx_context.data.out = ctx.gfx_context.screen_render_target.clone();

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -59,9 +59,9 @@ pub struct Canvas {
     debug_id: DebugId,
 }
 
-/// A generic non-multi-sampled canvas that cannot contain another canvas. This type should
-/// never need to be used directly; use [`graphics::Canvas`](type.Canvas.html)
-/// instead.
+/// A non-multi-sampled canvas that cannot contain another canvas.
+///
+/// Used by `Canvas` to store the multi-sampled texture.
 #[derive(Debug)]
 struct MultiSampledCanvas {
     target: RawRenderTargetView<gfx_device_gl::Resources>,

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -15,6 +15,13 @@ use crate::graphics::*;
 
 use crate::error::GameResult;
 
+// Define the input struct for our MSAA resolve shader.
+gfx_defines! {
+    constant Fragments {
+        fragments: i32 = "u_frags",
+    }
+}
+
 /// A structure that contains graphics state.
 /// For instance,
 /// window info, DPI, rendering pipeline state, etc.
@@ -51,6 +58,7 @@ where
     pub(crate) samplers: SamplerCache<B>,
 
     default_shader: ShaderId,
+    pub(crate) resolve_shader: ShaderGeneric<B, Fragments>,
     pub(crate) current_shader: Rc<RefCell<Option<ShaderId>>>,
     pub(crate) shaders: Vec<Box<dyn ShaderHandle<B>>>,
 
@@ -194,7 +202,7 @@ impl GraphicsContextGeneric<GlBackendSpec> {
             BlendMode::Premultiplied,
         ];
         let multisample_samples = window_setup.samples.into();
-        let (vs_text, fs_text) = backend.shaders();
+        let (vs_text, fs_text, fs_resolve_text) = backend.shaders();
         let (shader, draw) = create_shader(
             vs_text,
             fs_text,
@@ -207,6 +215,21 @@ impl GraphicsContextGeneric<GlBackendSpec> {
             color_format,
             debug_id,
         )?;
+        let (mut resolve_shader, mut resolve_draw) = create_shader(
+            vs_text,
+            fs_resolve_text,
+            Fragments { fragments: 1 },
+            "Fragments",
+            &mut encoder,
+            &mut factory,
+            1,
+            Some(&[BlendMode::Replace]),
+            color_format,
+            debug_id,
+        )?;
+
+        resolve_shader.id = 1;
+        resolve_draw.set_blend_mode(BlendMode::Replace)?;
 
         let rect_inst_props = factory.create_buffer(
             1,
@@ -308,8 +331,9 @@ impl GraphicsContextGeneric<GlBackendSpec> {
             samplers,
 
             default_shader: shader.shader_id(),
+            resolve_shader,
             current_shader: Rc::new(RefCell::new(None)),
-            shaders: vec![draw],
+            shaders: vec![draw, resolve_draw],
 
             glyph_brush: Rc::new(RefCell::new(glyph_brush)),
             glyph_cache,

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -125,6 +125,42 @@ where
     pub fn get_raw_texture_view(&self) -> gfx::handle::RawShaderResourceView<B::Resources> {
         self.texture.clone()
     }
+
+    /// Return the width of the image.
+    pub fn width(&self) -> u16 {
+        self.width
+    }
+
+    /// Return the height of the image.
+    pub fn height(&self) -> u16 {
+        self.height
+    }
+
+    /// Get the filter mode for the image.
+    pub fn filter(&self) -> FilterMode {
+        self.sampler_info.filter.into()
+    }
+
+    /// Set the filter mode for the image.
+    pub fn set_filter(&mut self, mode: FilterMode) {
+        self.sampler_info.filter = mode.into();
+    }
+
+    /// Returns the dimensions of the image.
+    pub fn dimensions(&self) -> Rect {
+        Rect::new(0.0, 0.0, f32::from(self.width()), f32::from(self.height()))
+    }
+
+    /// Gets the `Image`'s `WrapMode` along the X and Y axes.
+    pub fn wrap(&self) -> (WrapMode, WrapMode) {
+        (self.sampler_info.wrap_mode.0, self.sampler_info.wrap_mode.1)
+    }
+
+    /// Sets the `Image`'s `WrapMode` along the X and Y axes.
+    pub fn set_wrap(&mut self, wrap_x: WrapMode, wrap_y: WrapMode) {
+        self.sampler_info.wrap_mode.0 = wrap_x;
+        self.sampler_info.wrap_mode.1 = wrap_y;
+    }
 }
 
 /// In-GPU-memory image data available to be drawn on the screen,
@@ -297,45 +333,12 @@ impl Image {
         }
         Image::from_rgba8(context, size, size, &buffer)
     }
-
-    /// Return the width of the image.
-    pub fn width(&self) -> u16 {
-        self.width
-    }
-
-    /// Return the height of the image.
-    pub fn height(&self) -> u16 {
-        self.height
-    }
-
-    /// Get the filter mode for the image.
-    pub fn filter(&self) -> FilterMode {
-        self.sampler_info.filter.into()
-    }
-
-    /// Set the filter mode for the image.
-    pub fn set_filter(&mut self, mode: FilterMode) {
-        self.sampler_info.filter = mode.into();
-    }
-
-    /// Returns the dimensions of the image.
-    pub fn dimensions(&self) -> Rect {
-        Rect::new(0.0, 0.0, f32::from(self.width()), f32::from(self.height()))
-    }
-
-    /// Gets the `Image`'s `WrapMode` along the X and Y axes.
-    pub fn wrap(&self) -> (WrapMode, WrapMode) {
-        (self.sampler_info.wrap_mode.0, self.sampler_info.wrap_mode.1)
-    }
-
-    /// Sets the `Image`'s `WrapMode` along the X and Y axes.
-    pub fn set_wrap(&mut self, wrap_x: WrapMode, wrap_y: WrapMode) {
-        self.sampler_info.wrap_mode.0 = wrap_x;
-        self.sampler_info.wrap_mode.1 = wrap_y;
-    }
 }
 
-impl fmt::Debug for Image {
+impl<B> fmt::Debug for ImageGeneric<B>
+where
+    B: BackendSpec,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -146,7 +146,7 @@ pub trait BackendSpec: fmt::Debug {
 
     /// Returns the text of the vertex and fragment shader files
     /// to create default shaders for this backend.
-    fn shaders(&self) -> (&'static [u8], &'static [u8]);
+    fn shaders(&self) -> (&'static [u8], &'static [u8], &'static [u8]);
 
     /// Returns a string containing some backend-dependent info.
     fn info(&self, device: &Self::Device) -> String;
@@ -225,15 +225,17 @@ impl BackendSpec for GlBackendSpec {
         self.api
     }
 
-    fn shaders(&self) -> (&'static [u8], &'static [u8]) {
+    fn shaders(&self) -> (&'static [u8], &'static [u8], &'static [u8]) {
         match self.api {
             glutin::Api::OpenGl => (
                 include_bytes!("shader/basic_150.glslv"),
                 include_bytes!("shader/basic_150.glslf"),
+                include_bytes!("shader/resolve_150.glslf"),
             ),
             glutin::Api::OpenGlEs => (
                 include_bytes!("shader/basic_es300.glslv"),
                 include_bytes!("shader/basic_es300.glslf"),
+                include_bytes!("shader/resolve_es300.glslf"),
             ),
             a => panic!("Unsupported API: {:?}, should never happen", a),
         }

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -221,8 +221,8 @@ pub type ShaderId = usize;
 /// [`Shader`](type.Shader.html) instead.
 #[derive(Clone)]
 pub struct ShaderGeneric<Spec: graphics::BackendSpec, C: Structure<ConstFormat>> {
-    id: ShaderId,
-    buffer: Buffer<Spec::Resources, C>,
+    pub(crate) id: ShaderId,
+    pub(crate) buffer: Buffer<Spec::Resources, C>,
     debug_id: DebugId,
 }
 

--- a/src/graphics/shader/resolve_150.glslf
+++ b/src/graphics/shader/resolve_150.glslf
@@ -1,0 +1,24 @@
+#version 150 core
+
+uniform sampler2DMS t_Texture;
+in vec2 v_Uv;
+in vec4 v_Color;
+out vec4 Target0;
+
+layout (std140) uniform Globals {
+    mat4 u_MVP;
+};
+
+layout (std140) uniform Fragments {
+    int u_frags;
+};
+
+void main() {
+    vec2 d = textureSize(t_Texture);
+    ivec2 i = ivec2(d * v_Uv);
+    Target0 = texelFetch(t_Texture, i, 0);
+    for(int j=1; j<u_frags; ++j) {
+        Target0 = Target0 + texelFetch(t_Texture, i, j);
+    }
+    Target0 = Target0 / float(u_frags);
+}

--- a/src/graphics/shader/resolve_es300.glslf
+++ b/src/graphics/shader/resolve_es300.glslf
@@ -1,0 +1,27 @@
+#version 300 es
+
+// This shader should compile, but it shouldn't really work anywhere
+// as sampler2DMS isn't used in GLSL ES 300 yet.
+
+uniform mediump sampler2DMS t_Texture;
+in mediump vec2 v_Uv;
+in mediump vec4 v_Color;
+out mediump vec4 Target0;
+
+layout (std140) uniform Globals {
+    mediump mat4 u_MVP;
+};
+
+layout (std140) uniform Fragments {
+    int u_frags;
+};
+
+void main() {
+    ivec2 d = textureSize(t_Texture);
+    ivec2 i = d * ivec2(v_Uv);
+    Target0 = texelFetch(t_Texture, i, 0);
+    for(int j=1; j<u_frags; ++j) {
+        Target0 = Target0 + texelFetch(t_Texture, i, j);
+    }
+    Target0 = Target0 / float(u_frags);
+}


### PR DESCRIPTION
I followed the inspiration from https://github.com/gfx-rs/gfx/issues/1024 to implement a fragment shader workaround for MSAA on canvases.

It doesn't work on GLES though, as it doesn't have `sampler2DMS`, so the shader won't work. But it compiles and it doesn't crash. On my system multi-sampled canvases simply do not get drawn on GLES.

To write `Canvas::resolve` (which applies the fragment shader workaround) I had to lose `CanvasGeneric`, because `resolve` now needs to be called before `to_rgba8` to make sure the image is up to date and `resolve` needs to change the `out` pipe, which is part of `gfx_device_gl::Resources`, but not of `S::Resources` yet.

As we'll probably move on to `wgpu` in the future it shouldn't matter much though. When we do so we'll probably get rid of the generics anyway (as `wgpu` in itself is really generic enough already and noone wants to write a second graphics backend for ggez anyway, I think; if someone desires to do so, forking ggez might really be the more sane option anyway IMO).

If there was some elegant way though to keep `CanvasGeneric` and still implement `resolve` I'd of course prefer that.