### PR TITLE
added error handling to the remaining EventHandler methods

### DIFF
--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -436,7 +436,7 @@ impl event::EventHandler<ggez::GameError> for GameState {
         keycode: KeyCode,
         _keymod: KeyMods,
         _repeat: bool,
-    ) {
+    ) -> GameResult {
         // Here we attempt to convert the Keycode into a Direction using the helper
         // we defined earlier.
         if let Some(dir) = Direction::from_keycode(keycode) {
@@ -451,6 +451,7 @@ impl event::EventHandler<ggez::GameError> for GameState {
                 self.snake.dir = dir;
             }
         }
+        Ok(())
     }
 }
 

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -546,7 +546,7 @@ impl EventHandler for MainState {
         keycode: KeyCode,
         _keymod: KeyMods,
         _repeat: bool,
-    ) {
+    ) -> GameResult {
         match keycode {
             KeyCode::Up => {
                 self.input.yaxis = 1.0;
@@ -568,9 +568,15 @@ impl EventHandler for MainState {
             KeyCode::Escape => event::quit(ctx),
             _ => (), // Do nothing
         }
+        Ok(())
     }
 
-    fn key_up_event(&mut self, _ctx: &mut Context, keycode: KeyCode, _keymod: KeyMods) {
+    fn key_up_event(
+        &mut self,
+        _ctx: &mut Context,
+        keycode: KeyCode,
+        _keymod: KeyMods,
+    ) -> GameResult {
         match keycode {
             KeyCode::Up => {
                 self.input.yaxis = 0.0;
@@ -583,6 +589,7 @@ impl EventHandler for MainState {
             }
             _ => (), // Do nothing
         }
+        Ok(())
     }
 }
 

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -314,7 +314,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
         keycode: ggez::input::keyboard::KeyCode,
         _keymods: ggez::input::keyboard::KeyMods,
         _repeat: bool,
-    ) {
+    ) -> GameResult {
         const DELTA: f32 = 0.2;
         match keycode {
             KeyCode::Up | KeyCode::Down => {
@@ -360,6 +360,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
         self.ball_animation = ball_sequence(&self.easing_enum, self.duration);
         self.player_animation =
             player_sequence(&self.easing_enum, &self.animation_type, self.duration);
+        Ok(())
     }
 }
 

--- a/examples/blend_modes.rs
+++ b/examples/blend_modes.rs
@@ -181,7 +181,7 @@ impl EventHandler for MainState {
         _keycode: ggez::event::KeyCode,
         _keymod: ggez::event::KeyMods,
         repeat: bool,
-    ) {
+    ) -> GameResult {
         if !repeat {
             if let Some(BlendMode::Alpha) = self.canvas.blend_mode() {
                 self.canvas.set_blend_mode(Some(BlendMode::Premultiplied));
@@ -191,6 +191,7 @@ impl EventHandler for MainState {
                 println!("Drawing canvas with default alpha mode");
             }
         }
+        Ok(())
     }
 }
 

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -147,10 +147,11 @@ impl event::EventHandler<ggez::GameError> for GameState {
         keycode: event::KeyCode,
         _keymods: event::KeyMods,
         _repeat: bool,
-    ) {
+    ) -> GameResult {
         if keycode == event::KeyCode::Space {
             self.batched_drawing = !self.batched_drawing;
         }
+        Ok(())
     }
 
     fn mouse_button_down_event(
@@ -159,13 +160,14 @@ impl event::EventHandler<ggez::GameError> for GameState {
         button: input::mouse::MouseButton,
         _x: f32,
         _y: f32,
-    ) {
+    ) -> GameResult {
         if button == input::mouse::MouseButton::Left && self.click_timer == 0 {
             for _ in 0..INITIAL_BUNNIES {
                 self.bunnies.push(Bunny::new(&mut self.rng));
             }
             self.click_timer = 10;
         }
+        Ok(())
     }
 }
 

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -2,8 +2,9 @@
 //! if for some reason you want to do that instead of using the `EventHandler`
 //! trait to do that for you.
 //!
-//! This is exactly how `ggez::event::run()` works, it really is not
-//! doing anything magical.  But, if you want a bit more power over
+//! This is how `ggez::event::run()` works, mostly, (if you want to see which parts were left out
+//! of this example, check [event.rs](https://github.com/ggez/ggez/blob/master/src/event.rs),
+//! it really is not doing anything magical.  But, if you want a bit more power over
 //! the control flow of your game, this is how you get it.
 //!
 //! It is functionally identical to the `super_simple.rs` example apart from that.

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -6,7 +6,7 @@ use std::convert::TryFrom;
 
 use ggez::conf;
 use ggez::event::{self, KeyCode, KeyMods};
-use ggez::graphics::{self, Color, DrawMode};
+use ggez::graphics::{self, Color, DrawMode, DrawParam};
 use ggez::timer;
 use ggez::{Context, GameResult};
 
@@ -79,7 +79,9 @@ impl event::EventHandler<ggez::GameError> for MainState {
         graphics::draw(
             ctx,
             &self.image,
-            (Point2::new(400.0, 300.0), 0.0, Color::WHITE),
+            DrawParam::new()
+                .dest(Point2::new(400.0, 300.0))
+                .color(Color::WHITE), //.offset([0.5, 0.5]),
         )?;
         graphics::draw(
             ctx,
@@ -125,11 +127,17 @@ impl event::EventHandler<ggez::GameError> for MainState {
         _btn: event::MouseButton,
         x: f32,
         y: f32,
-    ) {
+    ) -> GameResult {
         println!("Button clicked at: {} {}", x, y);
+        Ok(())
     }
 
-    fn key_up_event(&mut self, ctx: &mut Context, keycode: KeyCode, _keymod: KeyMods) {
+    fn key_up_event(
+        &mut self,
+        ctx: &mut Context,
+        keycode: KeyCode,
+        _keymod: KeyMods,
+    ) -> GameResult {
         match keycode {
             KeyCode::F => {
                 self.window_settings.toggle_fullscreen = true;
@@ -160,9 +168,10 @@ impl event::EventHandler<ggez::GameError> for MainState {
             }
             _ => {}
         }
+        Ok(())
     }
 
-    fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) {
+    fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) -> GameResult {
         println!("Resized screen to {}, {}", width, height);
         if self.window_settings.resize_projection {
             let new_rect = graphics::Rect::new(
@@ -173,6 +182,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             );
             graphics::set_screen_coordinates(ctx, new_rect).unwrap();
         }
+        Ok(())
     }
 }
 

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -53,7 +53,8 @@ impl event::EventHandler<ggez::GameError> for MainState {
                 &self.text,
                 graphics::DrawParam::new()
                     .dest(dest_point)
-                    .color(Color::from((0, 0, 0, 255))),
+                    .color(Color::from((0, 0, 0, 255)))
+                    .offset([15., 15.]),
             )?;
             graphics::set_canvas(ctx, None);
 
@@ -92,11 +93,12 @@ impl event::EventHandler<ggez::GameError> for MainState {
         _keycode: ggez::event::KeyCode,
         _keymod: ggez::event::KeyMods,
         repeat: bool,
-    ) {
+    ) -> GameResult {
         if !repeat {
             self.draw_with_canvas = !self.draw_with_canvas;
             println!("Canvas on: {}", self.draw_with_canvas);
         }
+        Ok(())
     }
 }
 

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -55,17 +55,38 @@ impl event::EventHandler<ggez::GameError> for MainState {
         Ok(())
     }
 
-    fn mouse_button_down_event(&mut self, _ctx: &mut Context, button: MouseButton, x: f32, y: f32) {
+    fn mouse_button_down_event(
+        &mut self,
+        _ctx: &mut Context,
+        button: MouseButton,
+        x: f32,
+        y: f32,
+    ) -> GameResult {
         self.mouse_down = true;
         println!("Mouse button pressed: {:?}, x: {}, y: {}", button, x, y);
+        Ok(())
     }
 
-    fn mouse_button_up_event(&mut self, _ctx: &mut Context, button: MouseButton, x: f32, y: f32) {
+    fn mouse_button_up_event(
+        &mut self,
+        _ctx: &mut Context,
+        button: MouseButton,
+        x: f32,
+        y: f32,
+    ) -> GameResult {
         self.mouse_down = false;
         println!("Mouse button released: {:?}, x: {}, y: {}", button, x, y);
+        Ok(())
     }
 
-    fn mouse_motion_event(&mut self, _ctx: &mut Context, x: f32, y: f32, xrel: f32, yrel: f32) {
+    fn mouse_motion_event(
+        &mut self,
+        _ctx: &mut Context,
+        x: f32,
+        y: f32,
+        xrel: f32,
+        yrel: f32,
+    ) -> GameResult {
         if self.mouse_down {
             // Mouse coordinates are PHYSICAL coordinates, but here we want logical coordinates.
 
@@ -87,10 +108,12 @@ impl event::EventHandler<ggez::GameError> for MainState {
             "Mouse motion, x: {}, y: {}, relative x: {}, relative y: {}",
             x, y, xrel, yrel
         );
+        Ok(())
     }
 
-    fn mouse_wheel_event(&mut self, _ctx: &mut Context, x: f32, y: f32) {
+    fn mouse_wheel_event(&mut self, _ctx: &mut Context, x: f32, y: f32) -> GameResult {
         println!("Mousewheel event, x: {}, y: {}", x, y);
+        Ok(())
     }
 
     fn key_down_event(
@@ -99,42 +122,70 @@ impl event::EventHandler<ggez::GameError> for MainState {
         keycode: KeyCode,
         keymod: KeyMods,
         repeat: bool,
-    ) {
+    ) -> GameResult {
         println!(
             "Key pressed: {:?}, modifier {:?}, repeat: {}",
             keycode, keymod, repeat
         );
+        Ok(())
     }
 
-    fn key_up_event(&mut self, _ctx: &mut Context, keycode: KeyCode, keymod: KeyMods) {
+    fn key_up_event(
+        &mut self,
+        _ctx: &mut Context,
+        keycode: KeyCode,
+        keymod: KeyMods,
+    ) -> GameResult {
         println!("Key released: {:?}, modifier {:?}", keycode, keymod);
+        Ok(())
     }
 
-    fn text_input_event(&mut self, _ctx: &mut Context, ch: char) {
+    fn text_input_event(&mut self, _ctx: &mut Context, ch: char) -> GameResult {
         println!("Text input: {}", ch);
+        Ok(())
     }
 
-    fn gamepad_button_down_event(&mut self, _ctx: &mut Context, btn: Button, id: GamepadId) {
+    fn gamepad_button_down_event(
+        &mut self,
+        _ctx: &mut Context,
+        btn: Button,
+        id: GamepadId,
+    ) -> GameResult {
         println!("Gamepad button pressed: {:?} Gamepad_Id: {:?}", btn, id);
+        Ok(())
     }
 
-    fn gamepad_button_up_event(&mut self, _ctx: &mut Context, btn: Button, id: GamepadId) {
+    fn gamepad_button_up_event(
+        &mut self,
+        _ctx: &mut Context,
+        btn: Button,
+        id: GamepadId,
+    ) -> GameResult {
         println!("Gamepad button released: {:?} Gamepad_Id: {:?}", btn, id);
+        Ok(())
     }
 
-    fn gamepad_axis_event(&mut self, _ctx: &mut Context, axis: Axis, value: f32, id: GamepadId) {
+    fn gamepad_axis_event(
+        &mut self,
+        _ctx: &mut Context,
+        axis: Axis,
+        value: f32,
+        id: GamepadId,
+    ) -> GameResult {
         println!(
             "Axis Event: {:?} Value: {} Gamepad_Id: {:?}",
             axis, value, id
         );
+        Ok(())
     }
 
-    fn focus_event(&mut self, _ctx: &mut Context, gained: bool) {
+    fn focus_event(&mut self, _ctx: &mut Context, gained: bool) -> GameResult {
         if gained {
             println!("Focus gained");
         } else {
             println!("Focus lost");
         }
+        Ok(())
     }
 }
 

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -103,7 +103,7 @@ impl EventHandler for App {
         keycode: KeyCode,
         keymod: KeyMods,
         repeat: bool,
-    ) {
+    ) -> GameResult {
         // Log the keypress to info channel!
         info!(
             "Key down event: {:?}, modifiers: {:?}, repeat: {}",
@@ -113,14 +113,16 @@ impl EventHandler for App {
             // Escape key closes the app.
             ggez::event::quit(ctx);
         }
+        Ok(())
     }
 
     /// Called when window is resized.
-    fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) {
+    fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) -> GameResult {
         match graphics::set_screen_coordinates(ctx, graphics::Rect::new(0.0, 0.0, width, height)) {
             Ok(()) => info!("Resized window to {} x {}", width, height),
             Err(e) => error!("Couldn't resize window: {}", e),
         }
+        Ok(())
     }
 }
 

--- a/examples/render_to_image.rs
+++ b/examples/render_to_image.rs
@@ -61,9 +61,9 @@ impl event::EventHandler<ggez::GameError> for MainState {
         Ok(())
     }
 
-    fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) {
+    fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) -> GameResult {
         let new_rect = graphics::Rect::new(0.0, 0.0, width, height);
-        graphics::set_screen_coordinates(ctx, new_rect).unwrap();
+        graphics::set_screen_coordinates(ctx, new_rect)
     }
 }
 

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -398,10 +398,18 @@ impl event::EventHandler<ggez::GameError> for MainState {
         Ok(())
     }
 
-    fn mouse_motion_event(&mut self, ctx: &mut Context, x: f32, y: f32, _xrel: f32, _yrel: f32) {
+    fn mouse_motion_event(
+        &mut self,
+        ctx: &mut Context,
+        x: f32,
+        y: f32,
+        _xrel: f32,
+        _yrel: f32,
+    ) -> GameResult {
         let (w, h) = graphics::drawable_size(ctx);
         let (x, y) = (x / w as f32, 1.0 - y / h as f32);
         self.torch.pos = [x, y];
+        Ok(())
     }
 }
 

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -97,7 +97,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
         keycode: input::keyboard::KeyCode,
         _keymod: input::keyboard::KeyMods,
         _repeat: bool,
-    ) {
+    ) -> GameResult {
         match keycode {
             input::keyboard::KeyCode::Key1 => self.play_detached(ctx),
             input::keyboard::KeyCode::Key2 => self.play_later(ctx),
@@ -108,6 +108,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             input::keyboard::KeyCode::Escape => event::quit(ctx),
             _ => (),
         }
+        Ok(())
     }
 }
 

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -190,9 +190,8 @@ impl event::EventHandler<ggez::GameError> for App {
         Ok(())
     }
 
-    fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) {
+    fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) -> GameResult {
         graphics::set_screen_coordinates(ctx, graphics::Rect::new(0.0, 0.0, width, height))
-            .unwrap();
     }
 }
 

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -108,12 +108,15 @@ impl event::EventHandler<ggez::GameError> for MainState {
         keycode: KeyCode,
         _keymod: KeyMods,
         _repeat: bool,
-    ) {
+    ) -> GameResult {
         if let event::KeyCode::Space = keycode {
             self.screen_bounds_idx = (self.screen_bounds_idx + 1) % self.screen_bounds.len();
-            graphics::set_screen_coordinates(ctx, self.screen_bounds[self.screen_bounds_idx])
-                .unwrap();
+            return graphics::set_screen_coordinates(
+                ctx,
+                self.screen_bounds[self.screen_bounds_idx],
+            );
         }
+        Ok(())
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -45,6 +45,34 @@ pub enum ErrorOrigin {
     Update,
     /// error originated in `draw()`
     Draw,
+    /// error originated in `mouse_button_down_event()`
+    MouseButtonDownEvent,
+    /// error originated in `mouse_button_up_event()`
+    MouseButtonUpEvent,
+    /// error originated in `mouse_motion_event()`
+    MouseMotionEvent,
+    /// error originated in `mouse_enter_or_leave()`
+    MouseEnterOrLeave,
+    /// error originated in `mouse_wheel_event()`
+    MouseWheelEvent,
+    /// error originated in `key_down_event()`
+    KeyDownEvent,
+    /// error originated in `key_up_event()`
+    KeyUpEvent,
+    /// error originated in `text_input_event()`
+    TextInputEvent,
+    /// error originated in `gamepad_button_down_event()`
+    GamepadButtonDownEvent,
+    /// error originated in `gamepad_button_up_event()`
+    GamepadButtonUpEvent,
+    /// error originated in `gamepad_axis_event()`
+    GamepadAxisEvent,
+    /// error originated in `focus_event()`
+    FocusEvent,
+    /// error originated in `quit_event()`
+    QuitEvent,
+    /// error originated in `resize_event()`
+    ResizeEvent,
 }
 
 /// A trait defining event callbacks.  This is your primary interface with
@@ -82,7 +110,8 @@ where
         _button: MouseButton,
         _x: f32,
         _y: f32,
-    ) {
+    ) -> Result<(), E> {
+        Ok(())
     }
 
     /// A mouse button was released
@@ -92,19 +121,33 @@ where
         _button: MouseButton,
         _x: f32,
         _y: f32,
-    ) {
+    ) -> Result<(), E> {
+        Ok(())
     }
 
     /// The mouse was moved; it provides both absolute x and y coordinates in the window,
     /// and relative x and y coordinates compared to its last position.
-    fn mouse_motion_event(&mut self, _ctx: &mut Context, _x: f32, _y: f32, _dx: f32, _dy: f32) {}
+    fn mouse_motion_event(
+        &mut self,
+        _ctx: &mut Context,
+        _x: f32,
+        _y: f32,
+        _dx: f32,
+        _dy: f32,
+    ) -> Result<(), E> {
+        Ok(())
+    }
 
     /// mouse entered or left window area
-    fn mouse_enter_or_leave(&mut self, _ctx: &mut Context, _entered: bool) {}
+    fn mouse_enter_or_leave(&mut self, _ctx: &mut Context, _entered: bool) -> Result<(), E> {
+        Ok(())
+    }
 
     /// The mousewheel was scrolled, vertically (y, positive away from and negative toward the user)
     /// or horizontally (x, positive to the right and negative to the left).
-    fn mouse_wheel_event(&mut self, _ctx: &mut Context, _x: f32, _y: f32) {}
+    fn mouse_wheel_event(&mut self, _ctx: &mut Context, _x: f32, _y: f32) -> Result<(), E> {
+        Ok(())
+    }
 
     /// A keyboard button was pressed.
     ///
@@ -118,50 +161,85 @@ where
         keycode: KeyCode,
         _keymods: KeyMods,
         _repeat: bool,
-    ) {
+    ) -> Result<(), E> {
         if keycode == KeyCode::Escape {
             quit(ctx);
         }
+        Ok(())
     }
 
     /// A keyboard button was released.
-    fn key_up_event(&mut self, _ctx: &mut Context, _keycode: KeyCode, _keymods: KeyMods) {}
+    fn key_up_event(
+        &mut self,
+        _ctx: &mut Context,
+        _keycode: KeyCode,
+        _keymods: KeyMods,
+    ) -> Result<(), E> {
+        Ok(())
+    }
 
     /// A unicode character was received, usually from keyboard input.
     /// This is the intended way of facilitating text input.
-    fn text_input_event(&mut self, _ctx: &mut Context, _character: char) {}
+    fn text_input_event(&mut self, _ctx: &mut Context, _character: char) -> Result<(), E> {
+        Ok(())
+    }
 
     /// A gamepad button was pressed; `id` identifies which gamepad.
     /// Use [`input::gamepad()`](../input/fn.gamepad.html) to get more info about
     /// the gamepad.
-    fn gamepad_button_down_event(&mut self, _ctx: &mut Context, _btn: Button, _id: GamepadId) {}
+    fn gamepad_button_down_event(
+        &mut self,
+        _ctx: &mut Context,
+        _btn: Button,
+        _id: GamepadId,
+    ) -> Result<(), E> {
+        Ok(())
+    }
 
     /// A gamepad button was released; `id` identifies which gamepad.
     /// Use [`input::gamepad()`](../input/fn.gamepad.html) to get more info about
     /// the gamepad.
-    fn gamepad_button_up_event(&mut self, _ctx: &mut Context, _btn: Button, _id: GamepadId) {}
+    fn gamepad_button_up_event(
+        &mut self,
+        _ctx: &mut Context,
+        _btn: Button,
+        _id: GamepadId,
+    ) -> Result<(), E> {
+        Ok(())
+    }
 
     /// A gamepad axis moved; `id` identifies which gamepad.
     /// Use [`input::gamepad()`](../input/fn.gamepad.html) to get more info about
     /// the gamepad.
-    fn gamepad_axis_event(&mut self, _ctx: &mut Context, _axis: Axis, _value: f32, _id: GamepadId) {
+    fn gamepad_axis_event(
+        &mut self,
+        _ctx: &mut Context,
+        _axis: Axis,
+        _value: f32,
+        _id: GamepadId,
+    ) -> Result<(), E> {
+        Ok(())
     }
 
     /// Called when the window is shown or hidden.
-    fn focus_event(&mut self, _ctx: &mut Context, _gained: bool) {}
+    fn focus_event(&mut self, _ctx: &mut Context, _gained: bool) -> Result<(), E> {
+        Ok(())
+    }
 
     /// Called upon a quit event.  If it returns true,
     /// the game does not exit (the quit event is cancelled).
-    fn quit_event(&mut self, _ctx: &mut Context) -> bool {
+    fn quit_event(&mut self, _ctx: &mut Context) -> Result<bool, E> {
         debug!("quit_event() callback called, quitting...");
-        false
+        Ok(false)
     }
 
     /// Called when the user resizes the window, or when it is resized
     /// via [`graphics::set_mode()`](../graphics/fn.set_mode.html).
-    fn resize_event(&mut self, _ctx: &mut Context, _width: f32, _height: f32) {}
+    fn resize_event(&mut self, _ctx: &mut Context, _width: f32, _height: f32) -> Result<(), E> {
+        Ok(())
+    }
 
-    /// Something went wrong, causing a `GameError`.
+    /// Something went wrong, causing a `GameError` (or some other kind of error, depending on what you specified).
     /// If this returns true, the error was fatal, so the event loop ends, aborting the game.
     fn on_error(&mut self, _ctx: &mut Context, _origin: ErrorOrigin, _e: E) -> bool {
         true
@@ -180,6 +258,7 @@ pub fn quit(ctx: &mut Context) {
 ///
 /// It does not try to do any type of framerate limiting.  See the
 /// documentation for the [`timer`](../timer/index.html) module for more info.
+#[allow(clippy::needless_return)] // necessary as the returns used here are actually necessary to break early from the event loop
 pub fn run<S: 'static, E>(mut ctx: Context, event_loop: EventLoop<()>, mut state: S) -> !
 where
     S: EventHandler<E>,
@@ -203,18 +282,34 @@ where
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::Resized(logical_size) => {
                     // let actual_size = logical_size;
-                    state.resize_event(ctx, logical_size.width as f32, logical_size.height as f32);
+                    let res = state.resize_event(
+                        ctx,
+                        logical_size.width as f32,
+                        logical_size.height as f32,
+                    );
+                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::ResizeEvent) {
+                        return;
+                    };
                 }
                 WindowEvent::CloseRequested => {
-                    if !state.quit_event(ctx) {
+                    let res = state.quit_event(ctx);
+                    if let Ok(false) = state.quit_event(ctx) {
                         quit(ctx);
+                    } else if catch_error(ctx, res, state, control_flow, ErrorOrigin::QuitEvent) {
+                        return;
                     }
                 }
                 WindowEvent::Focused(gained) => {
-                    state.focus_event(ctx, gained);
+                    let res = state.focus_event(ctx, gained);
+                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::FocusEvent) {
+                        return;
+                    };
                 }
                 WindowEvent::ReceivedCharacter(ch) => {
-                    state.text_input_event(ctx, ch);
+                    let res = state.text_input_event(ctx, ch);
+                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::TextInputEvent) {
+                        return;
+                    };
                 }
                 WindowEvent::ModifiersChanged(mods) => {
                     ctx.keyboard_context.set_modifiers(KeyMods::from(mods))
@@ -229,7 +324,15 @@ where
                     ..
                 } => {
                     let repeat = keyboard::is_key_repeated(ctx);
-                    state.key_down_event(ctx, keycode, ctx.keyboard_context.active_mods(), repeat);
+                    let res = state.key_down_event(
+                        ctx,
+                        keycode,
+                        ctx.keyboard_context.active_mods(),
+                        repeat,
+                    );
+                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::KeyDownEvent) {
+                        return;
+                    };
                 }
                 WindowEvent::KeyboardInput {
                     input:
@@ -240,7 +343,10 @@ where
                         },
                     ..
                 } => {
-                    state.key_up_event(ctx, keycode, ctx.keyboard_context.active_mods());
+                    let res = state.key_up_event(ctx, keycode, ctx.keyboard_context.active_mods());
+                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::KeyUpEvent) {
+                        return;
+                    };
                 }
                 WindowEvent::MouseWheel { delta, .. } => {
                     let (x, y) = match delta {
@@ -251,7 +357,10 @@ where
                             (x, y)
                         }
                     };
-                    state.mouse_wheel_event(ctx, x, y);
+                    let res = state.mouse_wheel_event(ctx, x, y);
+                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::MouseWheelEvent) {
+                        return;
+                    };
                 }
                 WindowEvent::MouseInput {
                     state: element_state,
@@ -261,17 +370,41 @@ where
                     let position = mouse::position(ctx);
                     match element_state {
                         ElementState::Pressed => {
-                            state.mouse_button_down_event(ctx, button, position.x, position.y)
+                            let res =
+                                state.mouse_button_down_event(ctx, button, position.x, position.y);
+                            if catch_error(
+                                ctx,
+                                res,
+                                state,
+                                control_flow,
+                                ErrorOrigin::MouseButtonDownEvent,
+                            ) {
+                                return;
+                            };
                         }
                         ElementState::Released => {
-                            state.mouse_button_up_event(ctx, button, position.x, position.y)
+                            let res =
+                                state.mouse_button_up_event(ctx, button, position.x, position.y);
+                            if catch_error(
+                                ctx,
+                                res,
+                                state,
+                                control_flow,
+                                ErrorOrigin::MouseButtonUpEvent,
+                            ) {
+                                return;
+                            };
                         }
                     }
                 }
                 WindowEvent::CursorMoved { .. } => {
                     let position = mouse::position(ctx);
                     let delta = mouse::last_delta(ctx);
-                    state.mouse_motion_event(ctx, position.x, position.y, delta.x, delta.y);
+                    let res =
+                        state.mouse_motion_event(ctx, position.x, position.y, delta.x, delta.y);
+                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::MouseMotionEvent) {
+                        return;
+                    };
                 }
                 _x => {
                     // trace!("ignoring window event {:?}", x);
@@ -296,36 +429,56 @@ where
                     {
                         match event {
                             gilrs::EventType::ButtonPressed(button, _) => {
-                                state.gamepad_button_down_event(ctx, button, GamepadId(id));
+                                let res =
+                                    state.gamepad_button_down_event(ctx, button, GamepadId(id));
+                                if catch_error(
+                                    ctx,
+                                    res,
+                                    state,
+                                    control_flow,
+                                    ErrorOrigin::GamepadButtonDownEvent,
+                                ) {
+                                    return;
+                                };
                             }
                             gilrs::EventType::ButtonReleased(button, _) => {
-                                state.gamepad_button_up_event(ctx, button, GamepadId(id));
+                                let res = state.gamepad_button_up_event(ctx, button, GamepadId(id));
+                                if catch_error(
+                                    ctx,
+                                    res,
+                                    state,
+                                    control_flow,
+                                    ErrorOrigin::GamepadButtonUpEvent,
+                                ) {
+                                    return;
+                                };
                             }
                             gilrs::EventType::AxisChanged(axis, value, _) => {
-                                state.gamepad_axis_event(ctx, axis, value, GamepadId(id));
+                                let res = state.gamepad_axis_event(ctx, axis, value, GamepadId(id));
+                                if catch_error(
+                                    ctx,
+                                    res,
+                                    state,
+                                    control_flow,
+                                    ErrorOrigin::GamepadAxisEvent,
+                                ) {
+                                    return;
+                                };
                             }
                             _ => {}
                         }
                     }
                 }
 
-                if let Err(e) = state.update(ctx) {
-                    error!("Error on EventHandler::update(): {:?}", e);
-                    eprintln!("Error on EventHandler::update(): {:?}", e);
-                    if state.on_error(ctx, ErrorOrigin::Update, e) {
-                        *control_flow = ControlFlow::Exit;
-                        return;
-                    }
-                }
+                let res = state.update(ctx);
+                if catch_error(ctx, res, state, control_flow, ErrorOrigin::Update) {
+                    return;
+                };
 
-                if let Err(e) = state.draw(ctx) {
-                    error!("Error on EventHandler::draw(): {:?}", e);
-                    eprintln!("Error on EventHandler::draw(): {:?}", e);
-                    if state.on_error(ctx, ErrorOrigin::Draw, e) {
-                        *control_flow = ControlFlow::Exit;
-                        return;
-                    }
-                }
+                let res = state.draw(ctx);
+                if catch_error(ctx, res, state, control_flow, ErrorOrigin::Draw) {
+                    return;
+                };
 
                 // reset the mouse delta for the next frame
                 // necessary because it's calculated cumulatively each cycle
@@ -336,6 +489,28 @@ where
             Event::LoopDestroyed => (),
         }
     })
+}
+
+fn catch_error<T, E, S: 'static>(
+    ctx: &mut Context,
+    event_result: Result<T, E>,
+    state: &mut S,
+    control_flow: &mut ControlFlow,
+    origin: ErrorOrigin,
+) -> bool
+where
+    E: std::error::Error,
+    S: EventHandler<E>,
+{
+    if let Err(e) = event_result {
+        error!("Error on EventHandler {:?}: {:?}", origin, e);
+        eprintln!("Error on EventHandler {:?}: {:?}", origin, e);
+        if state.on_error(ctx, origin, e) {
+            *control_flow = ControlFlow::Exit;
+            return true;
+        }
+    }
+    false
 }
 
 /// Feeds an `Event` into the `Context` so it can update any internal


### PR DESCRIPTION
Closes #800

This PR adds the same error handling capabilities that are currently provided for `EventHandler::draw` and `EventHandler::update` to all the remaining methods of `EventHandler`.

This excludes `EventHandler::on_error`, for which adding this could lead to infinite recursion if a user isn't careful. Also it seems a bit silly to add error handling to the error handling function itself, as you'd still need to handle errors caused by the error handling inside that function anyway.