### PR TITLE
Modified the input module somewhat

### DIFF
--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -79,6 +79,14 @@ pub fn main() -> GameResult {
                 // necessary because it's calculated cumulatively each cycle
                 ctx.mouse_context.reset_delta();
 
+                // Copy the state of the keyboard into the KeyboardContext and
+                // the mouse into the MouseContext.
+                // Not required for this example but important if you want to
+                // use the functions keyboard::is_key_just_pressed/released and
+                // mouse::is_button_just_pressed/released.
+                ctx.keyboard_context.save_keyboard_state();
+                ctx.mouse_context.save_mouse_state();
+
                 ggez::timer::yield_now();
             }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -522,6 +522,11 @@ where
                 // reset the mouse delta for the next frame
                 // necessary because it's calculated cumulatively each cycle
                 ctx.mouse_context.reset_delta();
+
+				// Copy the state of the keyboard into the KeyboardContext
+                // and the mouse into the MouseContext
+                ctx.keyboard_context.save_keyboard_state();
+                ctx.mouse_context.save_mouse_state();
             }
             Event::RedrawRequested(_) => (),
             Event::RedrawEventsCleared => (),

--- a/src/event.rs
+++ b/src/event.rs
@@ -523,7 +523,7 @@ where
                 // necessary because it's calculated cumulatively each cycle
                 ctx.mouse_context.reset_delta();
 
-				// Copy the state of the keyboard into the KeyboardContext
+                // Copy the state of the keyboard into the KeyboardContext
                 // and the mouse into the MouseContext
                 ctx.keyboard_context.save_keyboard_state();
                 ctx.mouse_context.save_mouse_state();

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -213,7 +213,10 @@ impl KeyboardContext {
         self.active_modifiers
     }
 
-    pub(crate) fn save_keyboard_state(&mut self) {
+    /// Copies the current state of the keyboard into the context. If you are writing your own event loop
+    /// you need to call this at the end of every update in order to use the functions `is_key_just_pressed`
+    /// and `is_key_just_released`. Otherwise this is handled for you.
+    pub fn save_keyboard_state(&mut self) {
         self.previously_pressed_set = self.pressed_keys_set.clone();
     }
 }

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -76,7 +76,10 @@ impl MouseContext {
         !self.buttons_pressed.contains(&button) && self.previous_buttons_pressed.contains(&button)
     }
 
-    pub(crate) fn save_mouse_state(&mut self) {
+    /// Copies the current state of the mouse buttons into the context. If you are writing your own event loop
+    /// you need to call this at the end of every update in order to use the functions `is_button_just_pressed`
+    /// and `is_button_just_released`. Otherwise this is handled for you.
+    pub fn save_mouse_state(&mut self) {
         self.previous_buttons_pressed = self.buttons_pressed.clone();
     }
 }


### PR DESCRIPTION
I've added some functions to the keyboard and mouse contexts that can detect whether a button is pressed/released on a certain frame (i.e., pressed this frame but released last frame and vice versa). I also changed the mouse state to be represented with a HashSet, just to keep it consistent with the keyboard.

This requires an extra variable in `KeyboardContext` and `MouseContext` that represents the state of the keyboard/mouse on the previous frame. Alternatively you could represent the state as a `HashMap<KeyCode, (bool, bool)>`, but I don't know if changing this each frame would be more or less efficient than just cloning to a new variable.