### PR TITLE
Add `SpriteBatch::image()`

### DIFF
--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -160,6 +160,11 @@ impl SpriteBatch {
         mem::replace(&mut self.image, image)
     }
 
+    /// Returns a reference to the spritebatch's image.
+    pub fn image(&self) -> &graphics::Image {
+        &self.image
+    }
+
     /// Get the filter mode for the SpriteBatch.
     pub fn filter(&self) -> FilterMode {
         self.image.filter()


### PR DESCRIPTION
I don't see any reason why SpriteBatch's `image` member should be private to reads, so I've added a read-only property for it.