### PR TITLE
Use subcontexts directly instead of free functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,13 @@ name = "ggez"
 path = "src/lib.rs"
 
 [features]
-default = ["c_dependencies"]
+default = ["c_dependencies", "audio", "gamepad"]
 bzip2 = ["zip/bzip2"]
 mp3 = ["rodio/mp3"]
 multithread-image-decoding = ["image/hdr", "image/jpeg_rayon"]
 c_dependencies = ["bzip2", "mp3"]
+audio = ["rodio"]
+gamepad = ["gilrs"]
 
 [dependencies]
 bitflags = "1"
@@ -49,7 +51,7 @@ old_school_gfx_glutin_ext = "0.28"
 glutin = "0.28"
 winit = "0.26"
 image = {version = "0.23.12", default-features = false, features = ["gif", "png", "pnm", "tga", "tiff", "webp", "bmp", "dxt", ] }
-rodio = { version = "0.14", default-features = false, features = ["flac", "vorbis", "wav"] }
+rodio = { version = "0.14", optional = true, default-features = false, features = ["flac", "vorbis", "wav"] }
 serde = "1"
 serde_derive = "1"
 toml = "0.5"
@@ -59,7 +61,7 @@ smart-default = "0.6"
 glam = { version = "0.20", features = ["mint"]}
 # Has to be the same version of mint that our math lib uses here.
 mint = "0.5"
-gilrs = "0.8"
+gilrs = { version = "0.8", optional = true }
 approx = "0.5"
 bytemuck = "1.7"
 

--- a/examples/02_hello_world.rs
+++ b/examples/02_hello_world.rs
@@ -45,7 +45,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
         self.frames += 1;
         if (self.frames % 100) == 0 {
-            println!("FPS: {}", ggez::timer::fps(ctx));
+            println!("FPS: {}", ctx.time.fps());
         }
 
         Ok(())

--- a/examples/03_drawing.rs
+++ b/examples/03_drawing.rs
@@ -4,7 +4,6 @@ use glam::*;
 
 use ggez::event;
 use ggez::graphics::{self, Color, DrawMode, DrawParam};
-use ggez::timer;
 use ggez::{Context, GameResult};
 use std::env;
 use std::path;
@@ -104,7 +103,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
 
-        while timer::check_update_time(ctx, DESIRED_FPS) {
+        while ctx.time.check_update_time(DESIRED_FPS) {
             self.rotation += 0.01;
         }
         Ok(())

--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -20,7 +20,7 @@ use oorandom::Rand32;
 // Next we need to actually `use` the pieces of ggez that we are going
 // to need frequently.
 use ggez::event::{KeyCode, KeyMods};
-use ggez::{event, graphics, timer, Context, GameResult};
+use ggez::{event, graphics, Context, GameResult};
 
 // We'll bring in some things from `std` to help us in the future.
 use std::collections::LinkedList;
@@ -384,7 +384,7 @@ impl event::EventHandler<ggez::GameError> for GameState {
         // Rely on ggez's built-in timer for deciding when to update the game, and how many times.
         // If the update is early, there will be no cycles, otherwises, the logic will run once for each
         // frame fitting in the time since the last update.
-        while timer::check_update_time(ctx, DESIRED_FPS) {
+        while ctx.time.check_update_time(DESIRED_FPS) {
             // We check to see if the game is over. If not, we'll update. If so, we'll just do nothing.
             if !self.gameover {
                 // Here we do the actual updating of our game world. First we tell the snake to update itself,

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -438,7 +438,7 @@ impl EventHandler for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
 
-        while timer::check_update_time(ctx, DESIRED_FPS) {
+        while ctx.time.check_update_time(DESIRED_FPS) {
             let seconds = 1.0 / (DESIRED_FPS as f32);
 
             // Update the player state based on the user input.

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -321,7 +321,7 @@ struct MainState {
 
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        println!("Game resource path: {:?}", ctx.filesystem);
+        println!("Game resource path: {:?}", ctx.fs);
 
         print_instructions();
 

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -254,7 +254,7 @@ fn draw_info(ctx: &mut Context, info: String, position: Point2<f32>) -> GameResu
 
 impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        let secs = ggez::timer::delta(ctx).as_secs_f64();
+        let secs = ctx.time.delta().as_secs_f64();
         // advance the ball animation and reverse it once it reaches its end
         self.ball_animation.advance_and_maybe_reverse(secs);
         // advance the player animation and wrap around back to the beginning once it reaches its end

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -132,7 +132,7 @@ impl event::EventHandler<ggez::GameError> for GameState {
             &format!(
                 "BunnyMark - {} bunnies - {:.0} FPS - batched drawing: {}",
                 self.bunnies.len(),
-                timer::fps(ctx),
+                ctx.time.fps(),
                 self.batched_drawing
             ),
         );

--- a/examples/canvas_subframe.rs
+++ b/examples/canvas_subframe.rs
@@ -4,7 +4,6 @@
 
 use ggez::event;
 use ggez::graphics::{self, Color};
-use ggez::timer;
 use ggez::{Context, GameResult};
 use std::env;
 use std::f32::consts::TAU;
@@ -81,9 +80,9 @@ impl MainState {
 
 impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if timer::ticks(ctx) % 100 == 0 {
-            println!("Delta frame time: {:?} ", timer::delta(ctx));
-            println!("Average FPS: {}", timer::fps(ctx));
+        if ctx.time.ticks() % 100 == 0 {
+            println!("Delta frame time: {:?} ", ctx.time.delta());
+            println!("Average FPS: {}", ctx.time.fps());
         }
 
         // Bounce the rect if necessary

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -254,7 +254,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
         graphics::present(ctx)?;
         self.frames += 1;
         if (self.frames % 10) == 0 {
-            println!("FPS: {}", ggez::timer::fps(ctx));
+            println!("FPS: {}", ctx.time.fps());
         }
         Ok(())
     }

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -77,15 +77,15 @@ pub fn main() -> GameResult {
 
                 // reset the mouse delta for the next frame
                 // necessary because it's calculated cumulatively each cycle
-                ctx.mouse.reset_delta();
+                ctx.input.mouse.reset_delta();
 
                 // Copy the state of the keyboard into the KeyboardContext and
                 // the mouse into the MouseContext.
                 // Not required for this example but important if you want to
                 // use the functions keyboard::is_key_just_pressed/released and
                 // mouse::is_button_just_pressed/released.
-                ctx.keyboard.save_keyboard_state();
-                ctx.mouse.save_mouse_state();
+                ctx.input.keyboard.save_keyboard_state();
+                ctx.input.mouse.save_mouse_state();
 
                 ggez::timer::yield_now();
             }

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -56,7 +56,7 @@ pub fn main() -> GameResult {
             Event::MainEventsCleared => {
                 // Tell the timer stuff a frame has happened.
                 // Without this the FPS timer functions and such won't work.
-                ctx.timer.tick();
+                ctx.time.tick();
 
                 // Update
                 position += 1.0;

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -56,7 +56,7 @@ pub fn main() -> GameResult {
             Event::MainEventsCleared => {
                 // Tell the timer stuff a frame has happened.
                 // Without this the FPS timer functions and such won't work.
-                ctx.timer_context.tick();
+                ctx.timer.tick();
 
                 // Update
                 position += 1.0;
@@ -77,15 +77,15 @@ pub fn main() -> GameResult {
 
                 // reset the mouse delta for the next frame
                 // necessary because it's calculated cumulatively each cycle
-                ctx.mouse_context.reset_delta();
+                ctx.mouse.reset_delta();
 
                 // Copy the state of the keyboard into the KeyboardContext and
                 // the mouse into the MouseContext.
                 // Not required for this example but important if you want to
                 // use the functions keyboard::is_key_just_pressed/released and
                 // mouse::is_button_just_pressed/released.
-                ctx.keyboard_context.save_keyboard_state();
-                ctx.mouse_context.save_mouse_state();
+                ctx.keyboard.save_keyboard_state();
+                ctx.mouse.save_mouse_state();
 
                 ggez::timer::yield_now();
             }

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -77,15 +77,15 @@ pub fn main() -> GameResult {
 
                 // reset the mouse delta for the next frame
                 // necessary because it's calculated cumulatively each cycle
-                ctx.input.mouse.reset_delta();
+                ctx.mouse.reset_delta();
 
                 // Copy the state of the keyboard into the KeyboardContext and
                 // the mouse into the MouseContext.
                 // Not required for this example but important if you want to
                 // use the functions keyboard::is_key_just_pressed/released and
                 // mouse::is_button_just_pressed/released.
-                ctx.input.keyboard.save_keyboard_state();
-                ctx.input.mouse.save_mouse_state();
+                ctx.keyboard.save_keyboard_state();
+                ctx.mouse.save_mouse_state();
 
                 ggez::timer::yield_now();
             }

--- a/examples/files.rs
+++ b/examples/files.rs
@@ -27,12 +27,12 @@ pub fn main() -> GameResult {
 
     let (ctx, _) = &mut cb.build()?;
 
-    println!("Full filesystem info: {:#?}", ctx.filesystem);
+    println!("Full filesystem info: {:#?}", ctx.fs);
 
     println!("Resource stats:");
-    filesystem::print_all(ctx);
+    ctx.fs.print_all();
 
-    let dir_contents: Vec<_> = filesystem::read_dir(ctx, "/")?.collect();
+    let dir_contents: Vec<_> = ctx.fs.read_dir("/")?.collect();
     println!("Directory has {} things in it:", dir_contents.len());
     for itm in dir_contents {
         println!("   {:?}", itm);
@@ -44,19 +44,19 @@ pub fn main() -> GameResult {
     let test_file = path::Path::new("/testfile.txt");
     let bytes = b"test";
     {
-        let mut file = filesystem::create(ctx, test_file)?;
+        let mut file = ctx.fs.create(test_file)?;
         file.write_all(bytes)?;
     }
     println!("Wrote to test file");
     {
         let options = filesystem::OpenOptions::new().append(true);
-        let mut file = filesystem::open_options(ctx, test_file, options)?;
+        let mut file = ctx.fs.open_options(test_file, options)?;
         file.write_all(bytes)?;
     }
     println!("Appended to test file");
     {
         let mut buffer = Vec::new();
-        let mut file = filesystem::open(ctx, test_file)?;
+        let mut file = ctx.fs.open(test_file)?;
         file.read_to_end(&mut buffer)?;
         println!(
             "Read from test file: {:?}",
@@ -66,26 +66,26 @@ pub fn main() -> GameResult {
 
     println!();
     println!("Let's read the default conf file");
-    if let Ok(_conf) = filesystem::read_config(ctx) {
+    if let Ok(_conf) = ctx.fs.read_config() {
         println!("Found existing conf file, its contents are:");
-        let mut file = filesystem::open(ctx, "/conf.toml")?;
+        let mut file = ctx.fs.open("/conf.toml")?;
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer)?;
         println!("{}", str::from_utf8(&buffer).unwrap());
 
         println!("Now deleting it, re-run the example to recreate it.");
-        filesystem::delete(ctx, "/conf.toml")?;
+        ctx.fs.delete("/conf.toml")?;
     } else {
         println!("No existing conf file found, saving one out");
         let c = conf::Conf::new();
-        filesystem::write_config(ctx, &c)?;
+        ctx.fs.write_config(&c)?;
         println!("Should now be a 'conf.toml' file under user config dir");
     }
 
     println!();
     println!("Now let's try to read a file that does not exist");
     {
-        if let Err(e) = filesystem::open(ctx, "/jfkdlasfjdsa") {
+        if let Err(e) = ctx.fs.open("/jfkdlasfjdsa") {
             // The error message contains a big hairy list of each
             // directory tried and what error it got from it.
             println!("Got the error: {:#?}", e);

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -7,7 +7,6 @@ use std::convert::TryFrom;
 use ggez::conf;
 use ggez::event::{self, KeyCode, KeyMods};
 use ggez::graphics::{self, Color, DrawMode, DrawParam};
-use ggez::timer;
 use ggez::{Context, GameResult};
 
 use argh::FromArgs;
@@ -49,7 +48,7 @@ impl MainState {
 impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
-        while timer::check_update_time(ctx, DESIRED_FPS) {
+        while ctx.time.check_update_time(DESIRED_FPS) {
             self.angle += 0.01;
 
             if self.window_settings.toggle_fullscreen {
@@ -67,7 +66,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::clear(ctx, Color::BLACK);
-        let rotation = timer::ticks(ctx) % 1000;
+        let rotation = ctx.time.ticks() % 1000;
         let circle = graphics::Mesh::new_circle(
             ctx,
             DrawMode::stroke(3.0),

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -81,7 +81,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
         self.frames += 1;
         if (self.frames % 100) == 0 {
-            println!("FPS: {}", ggez::timer::fps(ctx));
+            println!("FPS: {}", ctx.time.fps());
         }
 
         Ok(())

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -75,13 +75,13 @@ impl MainState {
 impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
-        while timer::check_update_time(ctx, DESIRED_FPS) {
+        while ctx.time.check_update_time(DESIRED_FPS) {
             self.a += self.direction;
             if self.a > 250 || self.a <= 0 {
                 self.direction *= -1;
 
-                println!("Delta frame time: {:?} ", timer::delta(ctx));
-                println!("Average FPS: {}", timer::fps(ctx));
+                println!("Delta frame time: {:?} ", ctx.time.delta());
+                println!("Average FPS: {}", ctx.time.fps());
             }
         }
         Ok(())

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -1,7 +1,6 @@
 use ggez::audio;
 use ggez::audio::SoundSource;
 use ggez::event;
-use ggez::filesystem;
 use ggez::graphics::{self, Color};
 use ggez::timer;
 use ggez::{Context, GameResult};
@@ -44,7 +43,7 @@ impl MainState {
     }
 
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        filesystem::print_all(ctx);
+        ctx.fs.print_all();
 
         let image = graphics::Image::new(ctx, "/dragon1.png")?;
 

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -24,14 +24,18 @@ impl MainState {
 
 impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if ctx.keyboard.is_key_pressed(KeyCode::A) {
+        if ctx.input.keyboard.is_key_pressed(KeyCode::A) {
             println!("The A key is pressed");
-            if ctx.keyboard.is_mod_active(input::keyboard::KeyMods::SHIFT) {
+            if ctx
+                .input
+                .keyboard
+                .is_mod_active(input::keyboard::KeyMods::SHIFT)
+            {
                 println!("The shift key is held too.");
             }
             println!(
                 "Full list of pressed keys: {:?}",
-                ctx.keyboard.pressed_keys()
+                ctx.input.keyboard.pressed_keys()
             );
         }
         Ok(())

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -24,14 +24,14 @@ impl MainState {
 
 impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if input::keyboard::is_key_pressed(ctx, KeyCode::A) {
+        if ctx.keyboard.is_key_pressed(KeyCode::A) {
             println!("The A key is pressed");
-            if input::keyboard::is_mod_active(ctx, input::keyboard::KeyMods::SHIFT) {
+            if ctx.keyboard.is_mod_active(input::keyboard::KeyMods::SHIFT) {
                 println!("The shift key is held too.");
             }
             println!(
                 "Full list of pressed keys: {:?}",
-                input::keyboard::pressed_keys(ctx)
+                ctx.keyboard.pressed_keys()
             );
         }
         Ok(())

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -24,18 +24,14 @@ impl MainState {
 
 impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if ctx.input.keyboard.is_key_pressed(KeyCode::A) {
+        if ctx.keyboard.is_key_pressed(KeyCode::A) {
             println!("The A key is pressed");
-            if ctx
-                .input
-                .keyboard
-                .is_mod_active(input::keyboard::KeyMods::SHIFT)
-            {
+            if ctx.keyboard.is_mod_active(input::keyboard::KeyMods::SHIFT) {
                 println!("The shift key is held too.");
             }
             println!(
                 "Full list of pressed keys: {:?}",
-                ctx.input.keyboard.pressed_keys()
+                ctx.keyboard.pressed_keys()
             );
         }
         Ok(())

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -81,7 +81,7 @@ impl EventHandler for App {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
         // This tries to throttle updates to desired value.
-        while timer::check_update_time(ctx, DESIRED_FPS) {
+        while ctx.time.check_update_time(DESIRED_FPS) {
             // Since we don't have any non-callback logic, all we do is append our logs.
             self.file_logger.update()?;
         }

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -10,7 +10,7 @@ use log::*;
 
 use ggez::conf::{WindowMode, WindowSetup};
 use ggez::event::{EventHandler, KeyCode, KeyMods};
-use ggez::filesystem::{self, File};
+use ggez::filesystem::File;
 use ggez::graphics;
 use ggez::timer;
 use ggez::{Context, ContextBuilder, GameResult};
@@ -35,11 +35,11 @@ impl FileLogger {
         receiver: mpsc::Receiver<String>,
     ) -> GameResult<FileLogger> {
         // This (re)creates a file and opens it for appending.
-        let file = filesystem::create(ctx, path::Path::new(path))?;
+        let file = ctx.fs.create(path::Path::new(path))?;
         debug!(
             "Created log file {:?} in {:?}",
             path,
-            filesystem::user_config_dir(ctx)
+            ctx.fs.user_config_dir()
         );
         Ok(FileLogger { file, receiver })
     }

--- a/examples/meshbatch.rs
+++ b/examples/meshbatch.rs
@@ -2,7 +2,6 @@
 
 use ggez::event;
 use ggez::graphics::{self, Color};
-use ggez::timer;
 use ggez::{Context, GameResult};
 use glam::*;
 use oorandom::Rand32;
@@ -65,13 +64,13 @@ impl MainState {
 impl event::EventHandler<ggez::GameError> for MainState {
     #[allow(clippy::needless_range_loop)]
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if timer::ticks(ctx) % 100 == 0 {
-            println!("Delta frame time: {:?} ", timer::delta(ctx));
-            println!("Average FPS: {}", timer::fps(ctx));
+        if ctx.time.ticks() % 100 == 0 {
+            println!("Delta frame time: {:?} ", ctx.time.delta());
+            println!("Average FPS: {}", ctx.time.fps());
         }
 
         // Update first 50 instances in the mesh batch
-        let delta_time = (timer::delta(ctx).as_secs_f64() * 1000.0) as f32;
+        let delta_time = (ctx.time.delta().as_secs_f64() * 1000.0) as f32;
         let instances = self.mesh_batch.get_instance_params_mut();
         for i in 0..50 {
             if let graphics::Transform::Values {

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -4,7 +4,6 @@ use gfx::{self, *};
 
 use ggez::event;
 use ggez::graphics::{self, Color, DrawMode};
-use ggez::timer;
 use ggez::{Context, GameResult};
 use std::env;
 use std::path;
@@ -38,7 +37,7 @@ impl MainState {
 
 impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        self.dim.rate = 0.5 + (((timer::ticks(ctx) as f32) / 100.0).cos() / 2.0);
+        self.dim.rate = 0.5 + (((ctx.time.ticks() as f32) / 100.0).cos() / 2.0);
         Ok(())
     }
 

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -6,7 +6,6 @@ use gfx::{self, *};
 use ggez::conf;
 use ggez::event;
 use ggez::graphics::{self, BlendMode, Canvas, Color, DrawParam, Drawable, Shader};
-use ggez::timer;
 use ggez::{Context, GameResult};
 use glam::Vec2;
 use std::env;
@@ -322,14 +321,14 @@ impl MainState {
 
 impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if timer::ticks(ctx) % 100 == 0 {
-            println!("Average FPS: {}", timer::fps(ctx));
+        if ctx.time.ticks() % 100 == 0 {
+            println!("Average FPS: {}", ctx.time.fps());
         }
 
-        self.torch.glow = LIGHT_GLOW_FACTOR
-            * (timer::time_since_start(ctx).as_secs_f32() * LIGHT_GLOW_RATE).cos();
+        self.torch.glow =
+            LIGHT_GLOW_FACTOR * (ctx.time.time_since_start().as_secs_f32() * LIGHT_GLOW_RATE).cos();
         self.static_light.glow = LIGHT_GLOW_FACTOR
-            * (timer::time_since_start(ctx).as_secs_f32() * LIGHT_GLOW_RATE * 0.75).sin();
+            * (ctx.time.time_since_start().as_secs_f32() * LIGHT_GLOW_RATE * 0.75).sin();
         Ok(())
     }
 

--- a/examples/spritebatch.rs
+++ b/examples/spritebatch.rs
@@ -5,7 +5,6 @@
 
 use ggez::event;
 use ggez::graphics::{self, Color};
-use ggez::timer;
 use ggez::{Context, GameResult};
 use glam::*;
 use std::env;
@@ -27,9 +26,9 @@ impl MainState {
 
 impl event::EventHandler<ggez::GameError> for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if timer::ticks(ctx) % 100 == 0 {
-            println!("Delta frame time: {:?} ", timer::delta(ctx));
-            println!("Average FPS: {}", timer::fps(ctx));
+        if ctx.time.ticks() % 100 == 0 {
+            println!("Delta frame time: {:?} ", ctx.time.delta());
+            println!("Average FPS: {}", ctx.time.fps());
         }
         Ok(())
     }
@@ -37,7 +36,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         graphics::clear(ctx, Color::BLACK);
 
-        let time = (timer::time_since_start(ctx).as_secs_f64() * 1000.0) as u32;
+        let time = (ctx.time.time_since_start().as_secs_f64() * 1000.0) as u32;
         let cycle = 10_000;
         for x in 0..150 {
             for y in 0..150 {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -115,7 +115,7 @@ impl App {
 impl event::EventHandler<ggez::GameError> for App {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
         const DESIRED_FPS: u32 = 60;
-        while timer::check_update_time(ctx, DESIRED_FPS) {}
+        while ctx.time.check_update_time(DESIRED_FPS) {}
         Ok(())
     }
 
@@ -125,7 +125,7 @@ impl event::EventHandler<ggez::GameError> for App {
         // `Text` can be used in "immediate mode", but it's slightly less efficient
         // in most cases, and horrifically less efficient in a few select ones
         // (using `.width()` or `.height()`, for example).
-        let fps = timer::fps(ctx);
+        let fps = ctx.time.fps();
         let fps_display = Text::new(format!("FPS: {}", fps));
         // When drawing through these calls, `DrawParam` will work as they are documented.
         graphics::draw(ctx, &fps_display, (Vec2::new(200.0, 0.0), Color::WHITE))?;

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -52,7 +52,7 @@ impl AudioContext {
 
 impl fmt::Debug for AudioContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "<RodioAudioContext: {:p}>", self)
+        write!(f, "<AudioContext: {:p}>", self)
     }
 }
 
@@ -380,7 +380,7 @@ impl SoundSource for Source {
         // This is most ugly because in order to create a new sink
         // we need a `device`. However, we can only get the default
         // device without having access to a context. Currently that's
-        // fine because the `RodioAudioContext` uses the default device too,
+        // fine because the `AudioContext` uses the default device too,
         // but it may cause problems in the future if devices become
         // customizable.
 
@@ -566,7 +566,7 @@ impl SoundSource for SpatialSource {
         // This is most ugly because in order to create a new sink
         // we need a `device`. However, we can only get the default
         // device without having access to a context. Currently that's
-        // fine because the `RodioAudioContext` uses the default device too,
+        // fine because the `AudioContext` uses the default device too,
         // but it may cause problems in the future if devices become
         // customizable.
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -29,7 +29,7 @@ pub struct AudioContext {
 }
 
 impl AudioContext {
-    /// Create new `RodioAudioContext`.
+    /// Create new `AudioContext`.
     pub fn new() -> GameResult<Self> {
         let (stream, stream_handle) = rodio::OutputStream::try_default().map_err(|_e| {
             GameError::AudioError(String::from(

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -3,6 +3,7 @@
 //! It consists of two main types: [`SoundData`](struct.SoundData.html)
 //! is just an array of raw sound data bytes, and a [`Source`](struct.Source.html) is a
 //! `SoundData` connected to a particular sound channel ready to be played.
+#![cfg(feature = "audio")]
 
 use std::fmt;
 use std::io;
@@ -19,27 +20,16 @@ use crate::error::GameError;
 use crate::error::GameResult;
 use crate::filesystem;
 
-/// A trait object defining an audio context, allowing us to someday
-/// use something other than `rodio` if we really want.
-///
-/// End-users usually don't need to mess with this, but it's there
-/// if you want to bypass `ggez`'s sound functionality and write your
-/// own.
-pub trait AudioContext {
-    /// Returns the audio device.
-    fn device(&self) -> &rodio::OutputStreamHandle;
-}
-
 /// A struct that contains all information for tracking sound info.
 ///
 /// You generally don't have to create this yourself, it will be part
 /// of your `Context` object.
-pub(crate) struct RodioAudioContext {
+pub struct AudioContext {
     _stream: rodio::OutputStream,
     stream_handle: rodio::OutputStreamHandle,
 }
 
-impl RodioAudioContext {
+impl AudioContext {
     /// Create new `RodioAudioContext`.
     pub fn new() -> GameResult<Self> {
         let (stream, stream_handle) = rodio::OutputStream::try_default().map_err(|_e| {
@@ -54,27 +44,16 @@ impl RodioAudioContext {
     }
 }
 
-impl AudioContext for RodioAudioContext {
-    fn device(&self) -> &rodio::OutputStreamHandle {
+impl AudioContext {
+    /// Returns the audio device.
+    pub fn device(&self) -> &rodio::OutputStreamHandle {
         &self.stream_handle
     }
 }
 
-impl fmt::Debug for RodioAudioContext {
+impl fmt::Debug for AudioContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<RodioAudioContext: {:p}>", self)
-    }
-}
-
-/// A structure that implements `AudioContext` but does nothing; serves as a
-/// stub for when you don't need audio.  Will panic if you try to actually
-/// play sound from it.
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct NullAudioContext;
-
-impl AudioContext for NullAudioContext {
-    fn device(&self) -> &rodio::OutputStreamHandle {
-        panic!("Audio module disabled")
     }
 }
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -315,7 +315,7 @@ impl Source {
                 "Could not decode the given audio data".to_string(),
             ));
         }
-        let sink = rodio::Sink::try_new(context.audio_context.device())?;
+        let sink = rodio::Sink::try_new(context.audio.device())?;
         let cursor = io::Cursor::new(data);
         Ok(Source {
             sink,
@@ -365,7 +365,7 @@ impl SoundSource for Source {
         self.stop(ctx)?;
         self.play_later()?;
 
-        let new_sink = rodio::Sink::try_new(ctx.audio_context.device())?;
+        let new_sink = rodio::Sink::try_new(ctx.audio.device())?;
         let old_sink = mem::replace(&mut self.sink, new_sink);
         old_sink.detach();
 
@@ -409,7 +409,7 @@ impl SoundSource for Source {
         // We also need to carry over information from the previous sink.
         let volume = self.volume();
 
-        let device = ctx.audio_context.device();
+        let device = ctx.audio.device();
         self.sink = rodio::Sink::try_new(device)?;
         self.state.play_time.store(0, Ordering::SeqCst);
 
@@ -479,7 +479,7 @@ impl SpatialSource {
             ));
         }
         let sink = rodio::SpatialSink::try_new(
-            context.audio_context.device(),
+            context.audio.device(),
             [0.0, 0.0, 0.0],
             [-1.0, 0.0, 0.0],
             [1.0, 0.0, 0.0],
@@ -539,7 +539,7 @@ impl SoundSource for SpatialSource {
         self.stop(ctx)?;
         self.play_later()?;
 
-        let device = ctx.audio_context.device();
+        let device = ctx.audio.device();
         let new_sink = rodio::SpatialSink::try_new(
             device,
             self.emitter_position.into(),
@@ -595,7 +595,7 @@ impl SoundSource for SpatialSource {
         // We also need to carry over information from the previous sink.
         let volume = self.volume();
 
-        let device = ctx.audio_context.device();
+        let device = ctx.audio.device();
         self.sink = rodio::SpatialSink::try_new(
             device,
             self.emitter_position.into(),

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use crate::context::Context;
 use crate::error::GameError;
 use crate::error::GameResult;
-use crate::filesystem;
 
 /// A struct that contains all information for tracking sound info.
 ///
@@ -66,7 +65,7 @@ impl SoundData {
     /// Load the file at the given path and create a new `SoundData` from it.
     pub fn new<P: AsRef<path::Path>>(context: &mut Context, path: P) -> GameResult<Self> {
         let path = path.as_ref();
-        let file = &mut filesystem::open(context, path)?;
+        let file = &mut context.fs.open(path)?;
         SoundData::from_read(file)
     }
 

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -366,49 +366,6 @@ impl From<NumSamples> for u8 {
     }
 }
 
-/// Defines which submodules to enable in ggez.
-/// If one tries to use a submodule that is not enabled,
-/// it will panic.  Currently, not all subsystems can be
-/// disabled.
-///
-/// Defaults:
-///
-/// ```rust
-/// # use ggez::conf::*;
-/// # fn main() { assert_eq!(
-/// ModuleConf {
-///     gamepad: true,
-///     audio: true,
-/// }
-/// # , ModuleConf::default()); }
-/// ```
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, SmartDefault)]
-pub struct ModuleConf {
-    /// The gamepad input module.
-    #[default = true]
-    pub gamepad: bool,
-
-    /// The audio module.
-    #[default = true]
-    pub audio: bool,
-}
-
-impl ModuleConf {
-    /// Sets whether or not to enable the gamepad input module.
-    #[must_use]
-    pub fn gamepad(mut self, gamepad: bool) -> Self {
-        self.gamepad = gamepad;
-        self
-    }
-
-    /// Sets whether or not to enable the audio module.
-    #[must_use]
-    pub fn audio(mut self, audio: bool) -> Self {
-        self.audio = audio;
-        self
-    }
-}
-
 /// A structure containing configuration data
 /// for the game engine.
 ///
@@ -433,8 +390,6 @@ pub struct Conf {
     pub window_setup: WindowSetup,
     /// Graphics backend configuration
     pub backend: Backend,
-    /// Which modules to enable.
-    pub modules: ModuleConf,
 }
 
 impl Conf {
@@ -471,13 +426,6 @@ impl Conf {
     #[must_use]
     pub fn backend(mut self, backend: Backend) -> Self {
         self.backend = backend;
-        self
-    }
-
-    /// Sets the backend
-    #[must_use]
-    pub fn modules(mut self, modules: ModuleConf) -> Self {
-        self.modules = modules;
         self
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -40,7 +40,7 @@ pub struct Context {
     /// Graphics state.
     pub(crate) gfx: crate::graphics::context::GraphicsContext,
     /// Timer state.
-    pub timer: timer::TimeContext,
+    pub time: timer::TimeContext,
     /// Audio context.
     pub audio: Box<dyn audio::AudioContext>,
     /// Keyboard context.
@@ -108,7 +108,7 @@ impl Context {
             filesystem: fs,
             gfx: graphics_context,
             continuing: true,
-            timer: timer_context,
+            time: timer_context,
             audio: audio_context,
             keyboard: keyboard_context,
             gamepad: gamepad_context,

--- a/src/context.rs
+++ b/src/context.rs
@@ -35,20 +35,20 @@ use crate::timer;
 /// public and stable API is `ggez`'s module-level functions and
 /// types.
 pub struct Context {
-    /// Filesystem state
+    /// Filesystem state.
     pub filesystem: Filesystem,
-    /// Graphics state
-    pub(crate) gfx_context: crate::graphics::context::GraphicsContext,
-    /// Timer state
-    pub timer_context: timer::TimeContext,
-    /// Audio context
-    pub audio_context: Box<dyn audio::AudioContext>,
-    /// Keyboard context
-    pub keyboard_context: keyboard::KeyboardContext,
-    /// Mouse context
-    pub mouse_context: mouse::MouseContext,
-    /// Gamepad context
-    pub gamepad_context: Box<dyn gamepad::GamepadContext>,
+    /// Graphics state.
+    pub(crate) gfx: crate::graphics::context::GraphicsContext,
+    /// Timer state.
+    pub timer: timer::TimeContext,
+    /// Audio context.
+    pub audio: Box<dyn audio::AudioContext>,
+    /// Keyboard context.
+    pub keyboard: keyboard::KeyboardContext,
+    /// Mouse context.
+    pub mouse: mouse::MouseContext,
+    /// Gamepad context.
+    pub gamepad: Box<dyn gamepad::GamepadContext>,
 
     /// The Conf object the Context was created with.
     /// It's here just so that we can see the original settings,
@@ -106,13 +106,13 @@ impl Context {
         let ctx = Context {
             conf,
             filesystem: fs,
-            gfx_context: graphics_context,
+            gfx: graphics_context,
             continuing: true,
-            timer_context,
-            audio_context,
-            keyboard_context,
-            gamepad_context,
-            mouse_context,
+            timer: timer_context,
+            audio: audio_context,
+            keyboard: keyboard_context,
+            gamepad: gamepad_context,
+            mouse: mouse_context,
 
             debug_id,
         };

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,13 +42,15 @@ pub struct Context {
     /// Timer state.
     pub time: timer::TimeContext,
     /// Audio context.
-    pub audio: Box<dyn audio::AudioContext>,
+    #[cfg(feature = "audio")]
+    pub audio: audio::AudioContext,
     /// Keyboard context.
     pub keyboard: keyboard::KeyboardContext,
     /// Mouse context.
     pub mouse: mouse::MouseContext,
     /// Gamepad context.
-    pub gamepad: Box<dyn gamepad::GamepadContext>,
+    #[cfg(feature = "gamepad")]
+    pub gamepad: gamepad::GamepadContext,
 
     /// The Conf object the Context was created with.
     /// It's here just so that we can see the original settings,
@@ -79,11 +81,7 @@ impl Context {
         mut fs: Filesystem,
     ) -> GameResult<(Context, winit::event_loop::EventLoop<()>)> {
         let debug_id = DebugId::new();
-        let audio_context: Box<dyn audio::AudioContext> = if conf.modules.audio {
-            Box::new(audio::RodioAudioContext::new()?)
-        } else {
-            Box::new(audio::NullAudioContext::default())
-        };
+        let audio_context = audio::AudioContext::new()?;
         let events_loop = winit::event_loop::EventLoop::new();
         let timer_context = timer::TimeContext::new();
         let backend_spec = graphics::GlBackendSpec::from(conf.backend);
@@ -97,11 +95,7 @@ impl Context {
         )?;
         let mouse_context = mouse::MouseContext::new();
         let keyboard_context = keyboard::KeyboardContext::new();
-        let gamepad_context: Box<dyn gamepad::GamepadContext> = if conf.modules.gamepad {
-            Box::new(gamepad::GilrsGamepadContext::new()?)
-        } else {
-            Box::new(gamepad::NullGamepadContext::default())
-        };
+        let gamepad_context = gamepad::GamepadContext::new()?;
 
         let ctx = Context {
             conf,
@@ -170,13 +164,6 @@ impl ContextBuilder {
     #[must_use]
     pub fn backend(mut self, backend: conf::Backend) -> Self {
         self.conf.backend = backend;
-        self
-    }
-
-    /// Sets the modules configuration.
-    #[must_use]
-    pub fn modules(mut self, modules: conf::ModuleConf) -> Self {
-        self.conf.modules = modules;
         self
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -44,8 +44,12 @@ pub struct Context {
     /// Audio context.
     #[cfg(feature = "audio")]
     pub audio: audio::AudioContext,
-    /// Input context.
-    pub input: input::InputContext,
+    /// Keyboard input context.
+    pub keyboard: input::keyboard::KeyboardContext,
+    /// Mouse input context.
+    pub mouse: input::mouse::MouseContext,
+    /// Gamepad input context.
+    pub gamepad: input::gamepad::GamepadContext,
 
     /// The Conf object the Context was created with.
     /// It's here just so that we can see the original settings,
@@ -88,7 +92,6 @@ impl Context {
             backend_spec,
             debug_id,
         )?;
-        let input_context = input::InputContext::new()?;
 
         let ctx = Context {
             conf,
@@ -97,7 +100,9 @@ impl Context {
             continuing: true,
             time: timer_context,
             audio: audio_context,
-            input: input_context,
+            keyboard: input::keyboard::KeyboardContext::new(),
+            mouse: input::mouse::MouseContext::new(),
+            gamepad: input::gamepad::GamepadContext::new()?,
 
             debug_id,
         };

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,7 @@ use crate::conf;
 use crate::error::GameResult;
 use crate::filesystem::Filesystem;
 use crate::graphics;
-use crate::input::{gamepad, keyboard, mouse};
+use crate::input;
 use crate::timer;
 
 /// A `Context` is an object that holds on to global resources.
@@ -44,13 +44,8 @@ pub struct Context {
     /// Audio context.
     #[cfg(feature = "audio")]
     pub audio: audio::AudioContext,
-    /// Keyboard context.
-    pub keyboard: keyboard::KeyboardContext,
-    /// Mouse context.
-    pub mouse: mouse::MouseContext,
-    /// Gamepad context.
-    #[cfg(feature = "gamepad")]
-    pub gamepad: gamepad::GamepadContext,
+    /// Input context.
+    pub input: input::InputContext,
 
     /// The Conf object the Context was created with.
     /// It's here just so that we can see the original settings,
@@ -93,9 +88,7 @@ impl Context {
             backend_spec,
             debug_id,
         )?;
-        let mouse_context = mouse::MouseContext::new();
-        let keyboard_context = keyboard::KeyboardContext::new();
-        let gamepad_context = gamepad::GamepadContext::new()?;
+        let input_context = input::InputContext::new()?;
 
         let ctx = Context {
             conf,
@@ -104,9 +97,7 @@ impl Context {
             continuing: true,
             time: timer_context,
             audio: audio_context,
-            keyboard: keyboard_context,
-            gamepad: gamepad_context,
-            mouse: mouse_context,
+            input: input_context,
 
             debug_id,
         };

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,6 +3,7 @@ use std::fmt;
 /// without having to mess around figuring it out.
 pub use winit;
 
+#[cfg(feature = "audio")]
 use crate::audio;
 use crate::conf;
 use crate::error::GameResult;
@@ -49,6 +50,7 @@ pub struct Context {
     /// Mouse input context.
     pub mouse: input::mouse::MouseContext,
     /// Gamepad input context.
+    #[cfg(feature = "gamepad")]
     pub gamepad: input::gamepad::GamepadContext,
 
     /// The Conf object the Context was created with.
@@ -80,6 +82,7 @@ impl Context {
         mut fs: Filesystem,
     ) -> GameResult<(Context, winit::event_loop::EventLoop<()>)> {
         let debug_id = DebugId::new();
+        #[cfg(feature = "audio")]
         let audio_context = audio::AudioContext::new()?;
         let events_loop = winit::event_loop::EventLoop::new();
         let timer_context = timer::TimeContext::new();
@@ -99,9 +102,11 @@ impl Context {
             gfx: graphics_context,
             continuing: true,
             time: timer_context,
+            #[cfg(feature = "audio")]
             audio: audio_context,
             keyboard: input::keyboard::KeyboardContext::new(),
             mouse: input::mouse::MouseContext::new(),
+            #[cfg(feature = "gamepad")]
             gamepad: input::gamepad::GamepadContext::new()?,
 
             debug_id,

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,7 +36,7 @@ use crate::timer;
 /// types.
 pub struct Context {
     /// Filesystem state.
-    pub filesystem: Filesystem,
+    pub fs: Filesystem,
     /// Graphics state.
     pub(crate) gfx: crate::graphics::context::GraphicsContext,
     /// Timer state.
@@ -92,7 +92,7 @@ impl Context {
 
         let ctx = Context {
             conf,
-            filesystem: fs,
+            fs,
             gfx: graphics_context,
             continuing: true,
             time: timer_context,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,9 +3,6 @@ use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
 
-use rodio::decoder::DecoderError;
-use rodio::PlayError;
-
 /// An enum containing all kinds of game framework errors.
 #[derive(Debug, Clone)]
 pub enum GameError {
@@ -111,15 +108,17 @@ impl From<zip::result::ZipError> for GameError {
     }
 }
 
-impl From<DecoderError> for GameError {
-    fn from(e: DecoderError) -> GameError {
+#[cfg(feature = "audio")]
+impl From<rodio::decoder::DecoderError> for GameError {
+    fn from(e: rodio::decoder::DecoderError) -> GameError {
         let errstr = format!("Audio decoder error: {:?}", e);
         GameError::AudioError(errstr)
     }
 }
 
-impl From<PlayError> for GameError {
-    fn from(e: PlayError) -> GameError {
+#[cfg(feature = "audio")]
+impl From<rodio::PlayError> for GameError {
+    fn from(e: rodio::PlayError) -> GameError {
         let errstr = format!("Audio playing error: {:?}", e);
         GameError::AudioError(errstr)
     }
@@ -223,6 +222,7 @@ impl From<glutin::ContextError> for GameError {
     }
 }
 
+#[cfg(feature = "gamepad")]
 impl From<gilrs::Error> for GameError {
     fn from(s: gilrs::Error) -> GameError {
         let errstr = format!("Gamepad error: {}", s);

--- a/src/event.rs
+++ b/src/event.rs
@@ -15,6 +15,13 @@ use winit::{self, dpi};
 /// A mouse button.
 pub use winit::event::MouseButton;
 
+/// An analog axis of some device (gamepad thumbstick, joystick...).
+#[cfg(feature = "gamepad")]
+pub use gilrs::Axis;
+/// A button of some device (gamepad, joystick...).
+#[cfg(feature = "gamepad")]
+pub use gilrs::Button;
+
 /// `winit` events; nested in a module for re-export neatness.
 pub mod winit_event {
     pub use super::winit::event::{

--- a/src/event.rs
+++ b/src/event.rs
@@ -355,7 +355,7 @@ where
                         },
                     ..
                 } => {
-                    let repeat = keyboard::is_key_repeated(ctx);
+                    let repeat = ctx.keyboard.is_key_repeated();
                     let res =
                         state.key_down_event(ctx, keycode, ctx.keyboard.active_mods(), repeat);
                     if catch_error(ctx, res, state, control_flow, ErrorOrigin::KeyDownEvent) {
@@ -455,7 +455,7 @@ where
                 // you include `timer_context.tick()` and
                 // `ctx.process_event()` calls.  These update ggez's
                 // internal state however necessary.
-                ctx.timer.tick();
+                ctx.time.tick();
 
                 // Handle gamepad events if necessary.
                 if ctx.conf.modules.gamepad {

--- a/src/event.rs
+++ b/src/event.rs
@@ -296,7 +296,7 @@ where
     S: EventHandler<E>,
     E: std::error::Error,
 {
-    use crate::input::{keyboard, mouse};
+    use crate::input::mouse;
 
     event_loop.run(move |mut event, _, control_flow| {
         if !ctx.continuing {
@@ -458,48 +458,46 @@ where
                 ctx.time.tick();
 
                 // Handle gamepad events if necessary.
-                if ctx.conf.modules.gamepad {
-                    while let Some(gilrs::Event { id, event, .. }) = ctx.gamepad.next_event() {
-                        match event {
-                            gilrs::EventType::ButtonPressed(button, _) => {
-                                let res =
-                                    state.gamepad_button_down_event(ctx, button, GamepadId(id));
-                                if catch_error(
-                                    ctx,
-                                    res,
-                                    state,
-                                    control_flow,
-                                    ErrorOrigin::GamepadButtonDownEvent,
-                                ) {
-                                    return;
-                                };
-                            }
-                            gilrs::EventType::ButtonReleased(button, _) => {
-                                let res = state.gamepad_button_up_event(ctx, button, GamepadId(id));
-                                if catch_error(
-                                    ctx,
-                                    res,
-                                    state,
-                                    control_flow,
-                                    ErrorOrigin::GamepadButtonUpEvent,
-                                ) {
-                                    return;
-                                };
-                            }
-                            gilrs::EventType::AxisChanged(axis, value, _) => {
-                                let res = state.gamepad_axis_event(ctx, axis, value, GamepadId(id));
-                                if catch_error(
-                                    ctx,
-                                    res,
-                                    state,
-                                    control_flow,
-                                    ErrorOrigin::GamepadAxisEvent,
-                                ) {
-                                    return;
-                                };
-                            }
-                            _ => {}
+                #[cfg(feature = "gamepad")]
+                while let Some(gilrs::Event { id, event, .. }) = ctx.gamepad.next_event() {
+                    match event {
+                        gilrs::EventType::ButtonPressed(button, _) => {
+                            let res = state.gamepad_button_down_event(ctx, button, GamepadId(id));
+                            if catch_error(
+                                ctx,
+                                res,
+                                state,
+                                control_flow,
+                                ErrorOrigin::GamepadButtonDownEvent,
+                            ) {
+                                return;
+                            };
                         }
+                        gilrs::EventType::ButtonReleased(button, _) => {
+                            let res = state.gamepad_button_up_event(ctx, button, GamepadId(id));
+                            if catch_error(
+                                ctx,
+                                res,
+                                state,
+                                control_flow,
+                                ErrorOrigin::GamepadButtonUpEvent,
+                            ) {
+                                return;
+                            };
+                        }
+                        gilrs::EventType::AxisChanged(axis, value, _) => {
+                            let res = state.gamepad_axis_event(ctx, axis, value, GamepadId(id));
+                            if catch_error(
+                                ctx,
+                                res,
+                                state,
+                                control_flow,
+                                ErrorOrigin::GamepadAxisEvent,
+                            ) {
+                                return;
+                            };
+                        }
+                        _ => {}
                     }
                 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -15,11 +15,6 @@ use winit::{self, dpi};
 /// A mouse button.
 pub use winit::event::MouseButton;
 
-/// An analog axis of some device (gamepad thumbstick, joystick...).
-pub use gilrs::Axis;
-/// A button of some device (gamepad, joystick...).
-pub use gilrs::Button;
-
 /// `winit` events; nested in a module for re-export neatness.
 pub mod winit_event {
     pub use super::winit::event::{
@@ -27,6 +22,7 @@ pub mod winit_event {
         TouchPhase, WindowEvent,
     };
 }
+#[cfg(feature = "gamepad")]
 pub use crate::input::gamepad::GamepadId;
 pub use crate::input::keyboard::{KeyCode, KeyMods};
 use crate::GameError;
@@ -219,10 +215,11 @@ where
     /// A gamepad button was pressed; `id` identifies which gamepad.
     /// Use [`input::gamepad()`](../input/fn.gamepad.html) to get more info about
     /// the gamepad.
+    #[cfg(feature = "gamepad")]
     fn gamepad_button_down_event(
         &mut self,
         _ctx: &mut Context,
-        _btn: Button,
+        _btn: gilrs::Button,
         _id: GamepadId,
     ) -> Result<(), E> {
         Ok(())
@@ -231,10 +228,11 @@ where
     /// A gamepad button was released; `id` identifies which gamepad.
     /// Use [`input::gamepad()`](../input/fn.gamepad.html) to get more info about
     /// the gamepad.
+    #[cfg(feature = "gamepad")]
     fn gamepad_button_up_event(
         &mut self,
         _ctx: &mut Context,
-        _btn: Button,
+        _btn: gilrs::Button,
         _id: GamepadId,
     ) -> Result<(), E> {
         Ok(())
@@ -243,10 +241,11 @@ where
     /// A gamepad axis moved; `id` identifies which gamepad.
     /// Use [`input::gamepad()`](../input/fn.gamepad.html) to get more info about
     /// the gamepad.
+    #[cfg(feature = "gamepad")]
     fn gamepad_axis_event(
         &mut self,
         _ctx: &mut Context,
-        _axis: Axis,
+        _axis: gilrs::Axis,
         _value: f32,
         _id: GamepadId,
     ) -> Result<(), E> {

--- a/src/event.rs
+++ b/src/event.rs
@@ -196,11 +196,11 @@ where
         x: f64,
         y: f64,
     ) -> Result<(), E> {
-        ctx.input.mouse.handle_move(x as f32, y as f32);
+        ctx.mouse.handle_move(x as f32, y as f32);
 
         match phase {
             TouchPhase::Started => {
-                ctx.input.mouse.set_button(MouseButton::Left, true);
+                ctx.mouse.set_button(MouseButton::Left, true);
                 self.mouse_button_down_event(ctx, MouseButton::Left, x as f32, y as f32)?;
             }
             TouchPhase::Moved => {
@@ -208,7 +208,7 @@ where
                 self.mouse_motion_event(ctx, x as f32, y as f32, diff.x, diff.y)?;
             }
             TouchPhase::Ended | TouchPhase::Cancelled => {
-                ctx.input.mouse.set_button(MouseButton::Left, false);
+                ctx.mouse.set_button(MouseButton::Left, false);
                 self.mouse_button_up_event(ctx, MouseButton::Left, x as f32, y as f32)?;
             }
         }
@@ -344,7 +344,7 @@ where
                     };
                 }
                 WindowEvent::ModifiersChanged(mods) => {
-                    ctx.input.keyboard.set_modifiers(KeyMods::from(mods))
+                    ctx.keyboard.set_modifiers(KeyMods::from(mods))
                 }
                 WindowEvent::KeyboardInput {
                     input:
@@ -355,13 +355,9 @@ where
                         },
                     ..
                 } => {
-                    let repeat = ctx.input.keyboard.is_key_repeated();
-                    let res = state.key_down_event(
-                        ctx,
-                        keycode,
-                        ctx.input.keyboard.active_mods(),
-                        repeat,
-                    );
+                    let repeat = ctx.keyboard.is_key_repeated();
+                    let res =
+                        state.key_down_event(ctx, keycode, ctx.keyboard.active_mods(), repeat);
                     if catch_error(ctx, res, state, control_flow, ErrorOrigin::KeyDownEvent) {
                         return;
                     };
@@ -375,7 +371,7 @@ where
                         },
                     ..
                 } => {
-                    let res = state.key_up_event(ctx, keycode, ctx.input.keyboard.active_mods());
+                    let res = state.key_up_event(ctx, keycode, ctx.keyboard.active_mods());
                     if catch_error(ctx, res, state, control_flow, ErrorOrigin::KeyUpEvent) {
                         return;
                     };
@@ -399,7 +395,7 @@ where
                     button,
                     ..
                 } => {
-                    let position = ctx.input.mouse.position();
+                    let position = ctx.mouse.position();
                     match element_state {
                         ElementState::Pressed => {
                             let res =
@@ -430,7 +426,7 @@ where
                     }
                 }
                 WindowEvent::CursorMoved { .. } => {
-                    let position = ctx.input.mouse.position();
+                    let position = ctx.mouse.position();
                     let delta = mouse::last_delta(ctx);
                     let res =
                         state.mouse_motion_event(ctx, position.x, position.y, delta.x, delta.y);
@@ -463,7 +459,7 @@ where
 
                 // Handle gamepad events if necessary.
                 #[cfg(feature = "gamepad")]
-                while let Some(gilrs::Event { id, event, .. }) = ctx.input.gamepad.next_event() {
+                while let Some(gilrs::Event { id, event, .. }) = ctx.gamepad.next_event() {
                     match event {
                         gilrs::EventType::ButtonPressed(button, _) => {
                             let res = state.gamepad_button_down_event(ctx, button, GamepadId(id));
@@ -517,12 +513,12 @@ where
 
                 // reset the mouse delta for the next frame
                 // necessary because it's calculated cumulatively each cycle
-                ctx.input.mouse.reset_delta();
+                ctx.mouse.reset_delta();
 
                 // Copy the state of the keyboard into the KeyboardContext
                 // and the mouse into the MouseContext
-                ctx.input.keyboard.save_keyboard_state();
-                ctx.input.mouse.save_mouse_state();
+                ctx.keyboard.save_keyboard_state();
+                ctx.mouse.save_mouse_state();
             }
             Event::RedrawRequested(_) => (),
             Event::RedrawEventsCleared => (),
@@ -568,8 +564,7 @@ pub fn process_event(ctx: &mut Context, event: &mut winit::event::Event<()>) {
                 position: physical_position,
                 ..
             } => {
-                ctx.input
-                    .mouse
+                ctx.mouse
                     .handle_move(physical_position.x as f32, physical_position.y as f32);
             }
             winit_event::WindowEvent::MouseInput { button, state, .. } => {
@@ -577,10 +572,9 @@ pub fn process_event(ctx: &mut Context, event: &mut winit::event::Event<()>) {
                     winit_event::ElementState::Pressed => true,
                     winit_event::ElementState::Released => false,
                 };
-                ctx.input.mouse.set_button(*button, pressed);
+                ctx.mouse.set_button(*button, pressed);
             }
             winit_event::WindowEvent::ModifiersChanged(mods) => ctx
-                .input
                 .keyboard
                 .set_modifiers(crate::input::keyboard::KeyMods::from(*mods)),
             winit_event::WindowEvent::KeyboardInput {
@@ -596,7 +590,7 @@ pub fn process_event(ctx: &mut Context, event: &mut winit::event::Event<()>) {
                     winit_event::ElementState::Pressed => true,
                     winit_event::ElementState::Released => false,
                 };
-                ctx.input.keyboard.set_key(*keycode, pressed);
+                ctx.keyboard.set_key(*keycode, pressed);
             }
             winit_event::WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
                 if !ctx.conf.window_mode.resize_on_scale_factor_change {

--- a/src/event.rs
+++ b/src/event.rs
@@ -200,7 +200,7 @@ where
 
         match phase {
             TouchPhase::Started => {
-                ctx.mouse_context.set_button(MouseButton::Left, true);
+                ctx.mouse.set_button(MouseButton::Left, true);
                 self.mouse_button_down_event(ctx, MouseButton::Left, x as f32, y as f32)?;
             }
             TouchPhase::Moved => {
@@ -208,7 +208,7 @@ where
                 self.mouse_motion_event(ctx, x as f32, y as f32, diff.x, diff.y)?;
             }
             TouchPhase::Ended | TouchPhase::Cancelled => {
-                ctx.mouse_context.set_button(MouseButton::Left, false);
+                ctx.mouse.set_button(MouseButton::Left, false);
                 self.mouse_button_up_event(ctx, MouseButton::Left, x as f32, y as f32)?;
             }
         }
@@ -344,7 +344,7 @@ where
                     };
                 }
                 WindowEvent::ModifiersChanged(mods) => {
-                    ctx.keyboard_context.set_modifiers(KeyMods::from(mods))
+                    ctx.keyboard.set_modifiers(KeyMods::from(mods))
                 }
                 WindowEvent::KeyboardInput {
                     input:
@@ -356,12 +356,8 @@ where
                     ..
                 } => {
                     let repeat = keyboard::is_key_repeated(ctx);
-                    let res = state.key_down_event(
-                        ctx,
-                        keycode,
-                        ctx.keyboard_context.active_mods(),
-                        repeat,
-                    );
+                    let res =
+                        state.key_down_event(ctx, keycode, ctx.keyboard.active_mods(), repeat);
                     if catch_error(ctx, res, state, control_flow, ErrorOrigin::KeyDownEvent) {
                         return;
                     };
@@ -375,7 +371,7 @@ where
                         },
                     ..
                 } => {
-                    let res = state.key_up_event(ctx, keycode, ctx.keyboard_context.active_mods());
+                    let res = state.key_up_event(ctx, keycode, ctx.keyboard.active_mods());
                     if catch_error(ctx, res, state, control_flow, ErrorOrigin::KeyUpEvent) {
                         return;
                     };
@@ -384,7 +380,7 @@ where
                     let (x, y) = match delta {
                         MouseScrollDelta::LineDelta(x, y) => (x, y),
                         MouseScrollDelta::PixelDelta(pos) => {
-                            let scale_factor = ctx.gfx_context.window.window().scale_factor();
+                            let scale_factor = ctx.gfx.window.window().scale_factor();
                             let dpi::LogicalPosition { x, y } = pos.to_logical::<f32>(scale_factor);
                             (x, y)
                         }
@@ -459,13 +455,11 @@ where
                 // you include `timer_context.tick()` and
                 // `ctx.process_event()` calls.  These update ggez's
                 // internal state however necessary.
-                ctx.timer_context.tick();
+                ctx.timer.tick();
 
                 // Handle gamepad events if necessary.
                 if ctx.conf.modules.gamepad {
-                    while let Some(gilrs::Event { id, event, .. }) =
-                        ctx.gamepad_context.next_event()
-                    {
+                    while let Some(gilrs::Event { id, event, .. }) = ctx.gamepad.next_event() {
                         match event {
                             gilrs::EventType::ButtonPressed(button, _) => {
                                 let res =
@@ -521,12 +515,12 @@ where
 
                 // reset the mouse delta for the next frame
                 // necessary because it's calculated cumulatively each cycle
-                ctx.mouse_context.reset_delta();
+                ctx.mouse.reset_delta();
 
                 // Copy the state of the keyboard into the KeyboardContext
                 // and the mouse into the MouseContext
-                ctx.keyboard_context.save_keyboard_state();
-                ctx.mouse_context.save_mouse_state();
+                ctx.keyboard.save_keyboard_state();
+                ctx.mouse.save_mouse_state();
             }
             Event::RedrawRequested(_) => (),
             Event::RedrawEventsCleared => (),
@@ -565,8 +559,8 @@ pub fn process_event(ctx: &mut Context, event: &mut winit::event::Event<()>) {
     if let winit_event::Event::WindowEvent { event, .. } = event {
         match event {
             winit_event::WindowEvent::Resized(physical_size) => {
-                ctx.gfx_context.window.resize(*physical_size);
-                ctx.gfx_context.resize_viewport();
+                ctx.gfx.window.resize(*physical_size);
+                ctx.gfx.resize_viewport();
             }
             winit_event::WindowEvent::CursorMoved {
                 position: physical_position,
@@ -583,10 +577,10 @@ pub fn process_event(ctx: &mut Context, event: &mut winit::event::Event<()>) {
                     winit_event::ElementState::Pressed => true,
                     winit_event::ElementState::Released => false,
                 };
-                ctx.mouse_context.set_button(*button, pressed);
+                ctx.mouse.set_button(*button, pressed);
             }
             winit_event::WindowEvent::ModifiersChanged(mods) => ctx
-                .keyboard_context
+                .keyboard
                 .set_modifiers(crate::input::keyboard::KeyMods::from(*mods)),
             winit_event::WindowEvent::KeyboardInput {
                 input:
@@ -601,7 +595,7 @@ pub fn process_event(ctx: &mut Context, event: &mut winit::event::Event<()>) {
                     winit_event::ElementState::Pressed => true,
                     winit_event::ElementState::Released => false,
                 };
-                ctx.keyboard_context.set_key(*keycode, pressed);
+                ctx.keyboard.set_key(*keycode, pressed);
             }
             winit_event::WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
                 if !ctx.conf.window_mode.resize_on_scale_factor_change {

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -382,7 +382,7 @@ impl Filesystem {
 /// Opens the given path and returns the resulting `File`
 /// in read-only mode.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.open` instead")]
+#[deprecated(note = "Use `ctx.fs.open` instead")]
 pub fn open<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult<File> {
     ctx.fs.open(path)
 }
@@ -391,7 +391,7 @@ pub fn open<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult<File> {
 /// Note that even if you open a file read-only, it can only access
 /// files in the user directory.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.open_options` instead")]
+#[deprecated(note = "Use `ctx.fs.open_options` instead")]
 pub fn open_options<P: AsRef<path::Path>>(
     ctx: &Context,
     path: P,
@@ -403,7 +403,7 @@ pub fn open_options<P: AsRef<path::Path>>(
 /// Creates a new file in the user directory and opens it
 /// to be written to, truncating it if it already exists.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.create` instead")]
+#[deprecated(note = "Use `ctx.fs.create` instead")]
 pub fn create<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult<File> {
     ctx.fs.create(path)
 }
@@ -412,14 +412,14 @@ pub fn create<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult<File> 
 /// with the given name.  Any parents to that directory
 /// that do not exist will be created.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.create_dir` instead")]
+#[deprecated(note = "Use `ctx.fs.create_dir` instead")]
 pub fn create_dir<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult {
     ctx.fs.create_dir(path.as_ref())
 }
 
 /// Deletes the specified file in the user dir.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.delete` instead")]
+#[deprecated(note = "Use `ctx.fs.delete` instead")]
 pub fn delete<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult {
     ctx.fs.delete(path.as_ref())
 }
@@ -427,42 +427,42 @@ pub fn delete<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult {
 /// Deletes the specified directory in the user dir,
 /// and all its contents!
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.delete_dir` instead")]
+#[deprecated(note = "Use `ctx.fs.delete_dir` instead")]
 pub fn delete_dir<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult {
     ctx.fs.delete_dir(path.as_ref())
 }
 
 /// Check whether a file or directory exists.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.exists` instead")]
+#[deprecated(note = "Use `ctx.fs.exists` instead")]
 pub fn exists<P: AsRef<path::Path>>(ctx: &Context, path: P) -> bool {
     ctx.fs.exists(path.as_ref())
 }
 
 /// Check whether a path points at a file.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.is_file` instead")]
+#[deprecated(note = "Use `ctx.fs.is_file` instead")]
 pub fn is_file<P: AsRef<path::Path>>(ctx: &Context, path: P) -> bool {
     ctx.fs.is_file(path)
 }
 
 /// Check whether a path points at a directory.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.is_dir` instead")]
+#[deprecated(note = "Use `ctx.fs.is_dir` instead")]
 pub fn is_dir<P: AsRef<path::Path>>(ctx: &Context, path: P) -> bool {
     ctx.fs.is_dir(path)
 }
 
 /// Return the full path to the user data directory.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.user_data_dir` instead")]
+#[deprecated(note = "Use `ctx.fs.user_data_dir` instead")]
 pub fn user_data_dir(ctx: &Context) -> &path::Path {
     &ctx.fs.user_data_dir
 }
 
 /// Return the full path to the user config directory.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.user_config_dir` instead")]
+#[deprecated(note = "Use `ctx.fs.user_config_dir` instead")]
 pub fn user_config_dir(ctx: &Context) -> &path::Path {
     &ctx.fs.user_config_dir
 }
@@ -470,14 +470,14 @@ pub fn user_config_dir(ctx: &Context) -> &path::Path {
 /// Returns the full path to the resource directory
 /// (even if it doesn't exist)
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.resources_dir` instead")]
+#[deprecated(note = "Use `ctx.fs.resources_dir` instead")]
 pub fn resources_dir(ctx: &Context) -> &path::Path {
     &ctx.fs.resources_dir
 }
 
 /// Return the full path to the user data directory
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.zip_dir` instead")]
+#[deprecated(note = "Use `ctx.fs.zip_dir` instead")]
 pub fn zip_dir(ctx: &Context) -> &path::Path {
     &ctx.fs.zip_dir
 }
@@ -487,7 +487,7 @@ pub fn zip_dir(ctx: &Context) -> &path::Path {
 ///
 /// Lists the base directory if an empty path is given.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.read_dir` instead")]
+#[deprecated(note = "Use `ctx.fs.read_dir` instead")]
 pub fn read_dir<P: AsRef<path::Path>>(
     ctx: &Context,
     path: P,
@@ -498,7 +498,7 @@ pub fn read_dir<P: AsRef<path::Path>>(
 /// Prints the contents of all data directories.
 /// Useful for debugging.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.print_all` instead")]
+#[deprecated(note = "Use `ctx.fs.print_all` instead")]
 pub fn print_all(ctx: &Context) {
     ctx.fs.print_all()
 }
@@ -510,7 +510,7 @@ pub fn print_all(ctx: &Context) {
 /// See the [`logging` example](https://github.com/ggez/ggez/blob/master/examples/eventloop.rs)
 /// for how to collect log information.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.log_all` instead")]
+#[deprecated(note = "Use `ctx.fs.log_all` instead")]
 pub fn log_all(ctx: &Context) {
     ctx.fs.log_all()
 }
@@ -523,7 +523,7 @@ pub fn log_all(ctx: &Context) {
 /// But it can be very nice for debugging and dev purposes, such as
 /// by pushing `$CARGO_MANIFEST_DIR/resources` to it
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.mount` instead")]
+#[deprecated(note = "Use `ctx.fs.mount` instead")]
 pub fn mount(ctx: &mut Context, path: &path::Path, readonly: bool) {
     ctx.fs.mount(path, readonly)
 }
@@ -532,7 +532,7 @@ pub fn mount(ctx: &mut Context, path: &path::Path, readonly: bool) {
 /// loads it if it finds it.
 /// If it can't read it for some reason, returns an error.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.read_config` instead")]
+#[deprecated(note = "Use `ctx.fs.read_config` instead")]
 pub fn read_config(ctx: &Context) -> GameResult<conf::Conf> {
     ctx.fs.read_config()
 }
@@ -540,7 +540,7 @@ pub fn read_config(ctx: &Context) -> GameResult<conf::Conf> {
 /// Takes a `Conf` object and saves it to the user directory,
 /// overwriting any file already there.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::fs.write_config` instead")]
+#[deprecated(note = "Use `ctx.fs.write_config` instead")]
 pub fn write_config(ctx: &Context, conf: &conf::Conf) -> GameResult {
     ctx.fs.write_config(conf)
 }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -140,7 +140,7 @@ impl Canvas {
         let debug_id = DebugId::get(ctx);
         let kind = Kind::D2(width, height, AaMode::Single);
         let levels = 1;
-        let factory = &mut ctx.gfx_context.factory;
+        let factory = &mut ctx.gfx.factory;
         let texture_create_info = gfx::texture::Info {
             kind,
             levels,
@@ -192,7 +192,7 @@ impl Canvas {
                     image: Image {
                         texture: resource,
                         texture_handle: tex,
-                        sampler_info: ctx.gfx_context.default_sampler_info,
+                        sampler_info: ctx.gfx.default_sampler_info,
                         blend_mode: None,
                         width,
                         height,
@@ -208,7 +208,7 @@ impl Canvas {
             image: Image {
                 texture: resource,
                 texture_handle: tex,
-                sampler_info: ctx.gfx_context.default_sampler_info,
+                sampler_info: ctx.gfx.default_sampler_info,
                 blend_mode: None,
                 width,
                 height,
@@ -291,21 +291,17 @@ impl Canvas {
     pub fn resolve(&self, ctx: &mut Context) -> GameResult {
         if let Some(ms_canvas) = &self.ms_canvas {
             // save the old target to restore it after the resolve has finished
-            let old_target = std::mem::replace(&mut ctx.gfx_context.data.out, self.target.clone());
+            let old_target = std::mem::replace(&mut ctx.gfx.data.out, self.target.clone());
             // set resolve shader
-            let r_shader_id = ctx.gfx_context.resolve_shader.shader_id();
-            let old_shader = std::mem::replace(
-                &mut *ctx.gfx_context.current_shader.borrow_mut(),
-                Some(r_shader_id),
-            );
+            let r_shader_id = ctx.gfx.resolve_shader.shader_id();
+            let old_shader =
+                std::mem::replace(&mut *ctx.gfx.current_shader.borrow_mut(), Some(r_shader_id));
             let frags = Fragments {
                 fragments: ms_canvas.fragments as i32,
             };
-            ctx.gfx_context.encoder.update_buffer(
-                &ctx.gfx_context.resolve_shader.buffer,
-                &[frags],
-                0,
-            )?;
+            ctx.gfx
+                .encoder
+                .update_buffer(&ctx.gfx.resolve_shader.buffer, &[frags], 0)?;
             // draw the multi-sampled image onto the resolve target
             let param = DrawParam::new().transform(glam::Mat4::from_scale_rotation_translation(
                 glam::vec3(self.image.width as f32, -(self.image.height as f32), 1.0),
@@ -314,9 +310,9 @@ impl Canvas {
             ));
             crate::graphics::image::draw_image_raw(&ms_canvas.image, ctx, param)?;
             // restore the old target
-            ctx.gfx_context.data.out = old_target;
+            ctx.gfx.data.out = old_target;
             // and the old shader
-            *ctx.gfx_context.current_shader.borrow_mut() = old_shader;
+            *ctx.gfx.current_shader.borrow_mut() = old_shader;
         }
         Ok(())
     }
@@ -380,13 +376,13 @@ pub fn set_canvas(ctx: &mut Context, target: Option<&Canvas>) {
     match target {
         Some(surface) => {
             surface.debug_id.assert(ctx);
-            ctx.gfx_context.data.out = match &surface.ms_canvas {
+            ctx.gfx.data.out = match &surface.ms_canvas {
                 Some(ms_canvas) => ms_canvas.target.clone(),
                 _ => surface.target.clone(),
             };
         }
         None => {
-            ctx.gfx_context.data.out = ctx.gfx_context.screen_render_target.clone();
+            ctx.gfx.data.out = ctx.gfx.screen_render_target.clone();
         }
     };
 }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -9,13 +9,13 @@ use gfx::texture::{AaMode, Kind};
 use gfx::Factory;
 use glam::Quat;
 
+use crate::conf;
 use crate::conf::Backend::OpenGLES;
 use crate::context::DebugId;
 use crate::error::*;
 use crate::graphics::context::Fragments;
 use crate::graphics::*;
 use crate::Context;
-use crate::{conf, filesystem};
 
 /// A generic canvas independent of graphics backend. This type should
 /// never need to be used directly; use [`graphics::Canvas`](type.Canvas.html)
@@ -264,7 +264,7 @@ impl Canvas {
     ) -> GameResult {
         use std::io;
         let data = self.to_rgba8(ctx)?;
-        let f = filesystem::create(ctx, path)?;
+        let f = ctx.fs.create(path)?;
         let writer = &mut io::BufWriter::new(f);
         let color_format = ::image::ColorType::Rgba8;
         match format {

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -8,7 +8,6 @@ use ::image;
 use crate::context::{Context, DebugId};
 use crate::error::GameError;
 use crate::error::GameResult;
-use crate::filesystem;
 use crate::graphics;
 use crate::graphics::shader::*;
 use crate::graphics::*;
@@ -187,7 +186,7 @@ impl Image {
             .extension()
             .map_or_else(|| None, image::ImageFormat::from_extension);
         let mut buf = Vec::new();
-        let mut reader = context.filesystem.open(path)?;
+        let mut reader = context.fs.open(path)?;
         let _ = reader.read_to_end(&mut buf)?;
         if let Some(format) = format {
             Self::from_bytes_with_format(context, &buf, format)
@@ -305,7 +304,7 @@ impl Image {
     ) -> GameResult {
         use std::io;
         let data = self.to_rgba8(ctx)?;
-        let f = filesystem::create(ctx, path)?;
+        let f = ctx.fs.create(path)?;
         let writer = &mut io::BufWriter::new(f);
         let color_format = image::ColorType::Rgba8;
         match format {

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -238,10 +238,10 @@ impl Image {
         rgba: &[u8],
     ) -> GameResult<Self> {
         let debug_id = DebugId::get(context);
-        let color_format = context.gfx_context.color_format();
+        let color_format = context.gfx.color_format();
         Self::make_raw(
-            &mut *context.gfx_context.factory,
-            &context.gfx_context.default_sampler_info,
+            &mut *context.gfx.factory,
+            &context.gfx.default_sampler_info,
             width,
             height,
             rgba,
@@ -255,7 +255,7 @@ impl Image {
         use gfx::memory::Typed;
         use gfx::traits::FactoryExt;
 
-        let gfx = &mut ctx.gfx_context;
+        let gfx = &mut ctx.gfx;
         let w = self.width;
         let h = self.height;
 
@@ -389,7 +389,7 @@ impl Drawable for Image {
 }
 
 pub(crate) fn draw_image_raw(image: &Image, ctx: &mut Context, param: DrawParam) -> GameResult {
-    let gfx = &mut ctx.gfx_context;
+    let gfx = &mut ctx.gfx;
 
     gfx.update_instance_properties(param)?;
     let sampler = gfx

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -696,14 +696,14 @@ impl Mesh {
             "No vertices in MeshBuilder; should never happen since we already checked this",
         );
         let (vbuf, slice) = ctx
-            .gfx_context
+            .gfx
             .factory
             .create_vertex_buffer_with_slice(&verts[..], indices);
         Ok(Mesh {
             buffer: vbuf,
             slice,
             blend_mode: None,
-            image: texture.unwrap_or_else(|| ctx.gfx_context.white_image.clone()),
+            image: texture.unwrap_or_else(|| ctx.gfx.white_image.clone()),
             debug_id: DebugId::get(ctx),
             rect,
         })
@@ -730,7 +730,7 @@ impl Mesh {
         // <https://docs.rs/gfx/0.17.1/gfx/traits/trait.Factory.html#tymethod.create_buffer_raw>,
         // and fill in the bits between with the appropriate values.
         let (vbuf, slice) = ctx
-            .gfx_context
+            .gfx
             .factory
             .create_vertex_buffer_with_slice(verts, indices);
         self.buffer = vbuf;
@@ -755,7 +755,7 @@ impl Mesh {
 impl Drawable for Mesh {
     fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult {
         self.debug_id.assert(ctx);
-        let gfx = &mut ctx.gfx_context;
+        let gfx = &mut ctx.gfx;
         gfx.update_instance_properties(param)?;
 
         gfx.data.vbuf = self.buffer.clone();
@@ -934,11 +934,11 @@ impl MeshBatch {
 
             let new_properties: Vec<InstanceProperties> = slice
                 .iter()
-                .map(|param| param.to_instance_properties(ctx.gfx_context.is_srgb()))
+                .map(|param| param.to_instance_properties(ctx.gfx.is_srgb()))
                 .collect();
 
             if needs_new_buffer {
-                let new_buffer = ctx.gfx_context.factory.create_buffer(
+                let new_buffer = ctx.gfx.factory.create_buffer(
                     new_properties.len(),
                     gfx::buffer::Role::Vertex,
                     gfx::memory::Usage::Dynamic,
@@ -947,13 +947,13 @@ impl MeshBatch {
 
                 self.instance_buffer = Some(new_buffer);
 
-                ctx.gfx_context.encoder.update_buffer(
+                ctx.gfx.encoder.update_buffer(
                     self.instance_buffer.as_ref().expect("Can never fail"),
                     new_properties.as_slice(),
                     0,
                 )?;
             } else {
-                ctx.gfx_context.encoder.update_buffer(
+                ctx.gfx.encoder.update_buffer(
                     self.instance_buffer.as_ref().expect("Should never fail"),
                     new_properties.as_slice(),
                     first_param,
@@ -987,7 +987,7 @@ impl MeshBatch {
             let mut slice = self.mesh.slice.clone();
             slice.instances = Some((self.instance_params.len() as u32, 0));
 
-            let gfx = &mut ctx.gfx_context;
+            let gfx = &mut ctx.gfx;
 
             // In the batch we multiply the transform for each item in the batch
             // with the transform given in the `DrawParam` here.

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -746,7 +746,7 @@ pub fn set_window_icon<P: AsRef<Path>>(context: &mut Context, path: Option<P>) -
     let icon = match path {
         Some(p) => {
             let p: &Path = p.as_ref();
-            Some(context::load_icon(p, &mut context.filesystem)?)
+            Some(context::load_icon(p, &mut context.fs)?)
         }
         None => None,
     };

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -453,7 +453,7 @@ impl From<gfx::buffer::CreationError> for GameError {
 
 /// Clear the screen to the background color.
 pub fn clear(ctx: &mut Context, color: Color) {
-    let gfx = &mut ctx.gfx_context;
+    let gfx = &mut ctx.gfx;
     let linear_color: types::LinearColor = color.into();
     let c: [f32; 4] = linear_color.into();
     gfx.encoder.clear_raw(&gfx.data.out, c.into());
@@ -476,7 +476,7 @@ where
 ///
 /// Unsets any active canvas.
 pub fn present(ctx: &mut Context) -> GameResult<()> {
-    let gfx = &mut ctx.gfx_context;
+    let gfx = &mut ctx.gfx;
     gfx.data.out = gfx.screen_render_target.clone();
     // We might want to give the user more control over when the
     // encoder gets flushed eventually, if we want them to be able
@@ -494,7 +494,7 @@ pub fn screenshot(ctx: &mut Context) -> GameResult<Image> {
     use gfx::memory::Typed;
     use gfx::traits::FactoryExt;
 
-    let gfx = &mut ctx.gfx_context;
+    let gfx = &mut ctx.gfx;
     let (w, h, _depth, aa) = gfx.data.out.get_dimensions();
     if aa != gfx_core::texture::AaMode::Single {
         // Details see https://github.com/ggez/ggez/issues/751
@@ -586,7 +586,7 @@ fn flip_pixel_data(rgba: &mut Vec<u8>, width: usize, height: usize) {
 
 /// Get the default filter mode for new images.
 pub fn default_filter(ctx: &Context) -> FilterMode {
-    let gfx = &ctx.gfx_context;
+    let gfx = &ctx.gfx;
     gfx.default_sampler_info.filter.into()
 }
 
@@ -594,19 +594,19 @@ pub fn default_filter(ctx: &Context) -> FilterMode {
 /// It is supposed to be human-readable and will change; do not try to parse
 /// information out of it!
 pub fn renderer_info(ctx: &Context) -> GameResult<String> {
-    let backend_info = ctx.gfx_context.backend_spec.info(&*ctx.gfx_context.device);
+    let backend_info = ctx.gfx.backend_spec.info(&*ctx.gfx.device);
     Ok(format!(
         "Requested {:?} {}.{} Core profile, actually got {}.",
-        ctx.gfx_context.backend_spec.api,
-        ctx.gfx_context.backend_spec.major,
-        ctx.gfx_context.backend_spec.minor,
+        ctx.gfx.backend_spec.api,
+        ctx.gfx.backend_spec.major,
+        ctx.gfx.backend_spec.minor,
         backend_info
     ))
 }
 
 /// Returns the screen color format used by the context
 pub fn get_window_color_format(ctx: &Context) -> gfx::format::Format {
-    ctx.gfx_context.color_format()
+    ctx.gfx.color_format()
 }
 
 /// Returns a rectangle defining the coordinate system of the screen.
@@ -615,14 +615,14 @@ pub fn get_window_color_format(ctx: &Context) -> gfx::format::Format {
 /// If the Y axis increases downwards, the `height` of the `Rect`
 /// will be negative.
 pub fn screen_coordinates(ctx: &Context) -> Rect {
-    ctx.gfx_context.screen_rect
+    ctx.gfx.screen_rect
 }
 
 /// Sets the default filter mode used to scale images.
 ///
 /// This does not apply retroactively to already created images.
 pub fn set_default_filter(ctx: &mut Context, mode: FilterMode) {
-    let gfx = &mut ctx.gfx_context;
+    let gfx = &mut ctx.gfx;
     let new_mode = mode.into();
     let sampler_info = texture::SamplerInfo::new(new_mode, texture::WrapMode::Clamp);
     // We create the sampler now so we don't end up creating it at some
@@ -642,7 +642,7 @@ pub fn set_default_filter(ctx: &mut Context, mode: FilterMode) {
 /// The `Rect`'s x and y will define the top-left corner of the screen,
 /// and that plus its w and h will define the bottom-right corner.
 pub fn set_screen_coordinates(context: &mut Context, rect: Rect) -> GameResult {
-    let gfx = &mut context.gfx_context;
+    let gfx = &mut context.gfx;
     gfx.set_projection_rect(rect);
     gfx.reset_global_mvp()
 }
@@ -656,7 +656,7 @@ where
     M: Into<mint::ColumnMatrix4<f32>>,
 {
     let transform = Matrix4::from(transform.into());
-    let gfx = &mut context.gfx_context;
+    let gfx = &mut context.gfx;
     let curr = gfx.projection();
     gfx.set_projection(transform * curr);
 }
@@ -672,7 +672,7 @@ where
     M: Into<mint::ColumnMatrix4<f32>>,
 {
     let proj = Matrix4::from(proj.into());
-    let gfx = &mut context.gfx_context;
+    let gfx = &mut context.gfx;
     gfx.set_projection(proj);
 }
 
@@ -683,19 +683,19 @@ where
 /// Alternatively it's also set (and sent to the graphics card) when
 /// [`set_screen_coordinates()`](fn.set_screen_coordinates.html) is called.
 pub fn apply_projection(context: &mut Context) -> GameResult {
-    let gfx = &mut context.gfx_context;
+    let gfx = &mut context.gfx;
     gfx.reset_global_mvp()
 }
 
 /// Gets a copy of the context's raw projection matrix.
 pub fn projection(context: &Context) -> mint::ColumnMatrix4<f32> {
-    let gfx = &context.gfx_context;
+    let gfx = &context.gfx;
     gfx.projection().into()
 }
 
 /// Sets the blend mode of the currently active shader program
 pub fn set_blend_mode(ctx: &mut Context, mode: BlendMode) -> GameResult {
-    ctx.gfx_context.set_blend_mode(mode)
+    ctx.gfx.set_blend_mode(mode)
 }
 
 /// Sets the window mode, such as the size and other properties.
@@ -708,7 +708,7 @@ pub fn set_blend_mode(ctx: &mut Context, mode: BlendMode) -> GameResult {
 /// changing the window size to make sure everything is what you want
 /// it to be.
 pub fn set_mode(context: &mut Context, mut mode: WindowMode) -> GameResult {
-    let gfx = &mut context.gfx_context;
+    let gfx = &mut context.gfx;
     let result = gfx.set_window_mode(mode);
     if let Err(GameError::WindowError(_)) = result {
         // true fullscreen could not be set because the video mode matching the resolution is missing
@@ -750,13 +750,13 @@ pub fn set_window_icon<P: AsRef<Path>>(context: &mut Context, path: Option<P>) -
         }
         None => None,
     };
-    context.gfx_context.window.window().set_window_icon(icon);
+    context.gfx.window.window().set_window_icon(icon);
     Ok(())
 }
 
 /// Sets the window title.
 pub fn set_window_title(context: &Context, title: &str) {
-    context.gfx_context.window.window().set_title(title);
+    context.gfx.window.window().set_title(title);
 }
 
 /// Sets the window position.
@@ -764,17 +764,13 @@ pub fn set_window_position<P: Into<winit::dpi::Position>>(
     context: &Context,
     position: P,
 ) -> GameResult<()> {
-    context
-        .gfx_context
-        .window
-        .window()
-        .set_outer_position(position);
+    context.gfx.window.window().set_outer_position(position);
     Ok(())
 }
 
 /// Gets the window position.
 pub fn get_window_position(context: &Context) -> GameResult<winit::dpi::PhysicalPosition<i32>> {
-    match context.gfx_context.window.window().outer_position() {
+    match context.gfx.window.window().outer_position() {
         Ok(position) => Ok(position),
         Err(e) => Err(GameError::WindowError(e.to_string())),
     }
@@ -785,7 +781,7 @@ pub fn get_window_position(context: &Context) -> GameResult<winit::dpi::Physical
 /// would provide all the functions you need without having
 /// to dip into Glutin itself.  But life isn't always ideal.
 pub fn window(context: &Context) -> &glutin::window::Window {
-    let gfx = &context.gfx_context;
+    let gfx = &context.gfx;
     gfx.window.window()
 }
 
@@ -793,7 +789,7 @@ pub fn window(context: &Context) -> &glutin::window::Window {
 pub fn supported_resolutions(
     ctx: &crate::Context,
 ) -> impl Iterator<Item = winit::dpi::PhysicalSize<u32>> {
-    let gfx = &ctx.gfx_context;
+    let gfx = &ctx.gfx;
     let window = gfx.window.window();
     let monitor = window.current_monitor().unwrap();
     monitor.video_modes().map(|v_mode| v_mode.size())
@@ -803,7 +799,7 @@ pub fn supported_resolutions(
 /// including borders, titlebar, etc.
 /// Returns zeros if the window doesn't exist.
 pub fn size(context: &Context) -> (f32, f32) {
-    let gfx = &context.gfx_context;
+    let gfx = &context.gfx;
     let window = gfx.window.window();
     let physical_size = window.outer_size();
     (physical_size.width as f32, physical_size.height as f32)
@@ -812,7 +808,7 @@ pub fn size(context: &Context) -> (f32, f32) {
 /// Returns the size of the window's underlying drawable in physical pixels as (width, height).
 /// Returns zeros if window doesn't exist.
 pub fn drawable_size(context: &Context) -> (f32, f32) {
-    let gfx = &context.gfx_context;
+    let gfx = &context.gfx;
     let window = gfx.window.window();
     let physical_size = window.inner_size();
     (physical_size.width as f32, physical_size.height as f32)
@@ -820,7 +816,7 @@ pub fn drawable_size(context: &Context) -> (f32, f32) {
 
 /// Return raw window context
 pub fn window_raw(context: &mut Context) -> &mut glutin::WindowedContext<glutin::PossiblyCurrent> {
-    &mut context.gfx_context.window
+    &mut context.gfx.window
 }
 
 /// Deletes all cached font data.
@@ -845,9 +841,9 @@ pub fn clear_font_cache(ctx: &mut Context) {
     let glyph_state = Rc::new(RefCell::new(spritebatch::SpriteBatch::new(
         glyph_cache.clone(),
     )));
-    ctx.gfx_context.glyph_brush = Rc::new(RefCell::new(glyph_brush));
-    ctx.gfx_context.glyph_cache = glyph_cache;
-    ctx.gfx_context.glyph_state = glyph_state;
+    ctx.gfx.glyph_brush = Rc::new(RefCell::new(glyph_brush));
+    ctx.gfx.glyph_cache = glyph_cache;
+    ctx.gfx.glyph_state = glyph_state;
 }
 
 #[allow(clippy::type_complexity)]
@@ -870,7 +866,7 @@ pub fn gfx_objects(
     gfx::handle::RawDepthStencilView<<GlBackendSpec as BackendSpec>::Resources>,
     gfx::handle::RawRenderTargetView<<GlBackendSpec as BackendSpec>::Resources>,
 ) {
-    let gfx = &mut context.gfx_context;
+    let gfx = &mut context.gfx;
     let f = &mut gfx.factory;
     let d = gfx.device.as_mut();
     let e = &mut gfx.encoder;

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -365,21 +365,21 @@ where
         blend_modes: Option<&[BlendMode]>,
     ) -> GameResult<Shader<C>> {
         let debug_id = DebugId::get(ctx);
-        let color_format = ctx.gfx_context.color_format();
+        let color_format = ctx.gfx.color_format();
         let (mut shader, draw) = create_shader(
             vertex_source,
             pixel_source,
             consts,
             name,
-            &mut ctx.gfx_context.encoder,
-            &mut *ctx.gfx_context.factory,
-            ctx.gfx_context.multisample_samples,
+            &mut ctx.gfx.encoder,
+            &mut *ctx.gfx.factory,
+            ctx.gfx.multisample_samples,
             blend_modes,
             color_format,
             debug_id,
         )?;
-        shader.id = ctx.gfx_context.shaders.len();
-        ctx.gfx_context.shaders.push(draw);
+        shader.id = ctx.gfx.shaders.len();
+        ctx.gfx.shaders.push(draw);
 
         Ok(shader)
     }
@@ -391,9 +391,7 @@ where
 {
     /// Send data to the GPU for use with the `Shader`
     pub fn send(&self, ctx: &mut Context, consts: C) -> GameResult {
-        ctx.gfx_context
-            .encoder
-            .update_buffer(&self.buffer, &[consts], 0)?;
+        ctx.gfx.encoder.update_buffer(&self.buffer, &[consts], 0)?;
         Ok(())
     }
 
@@ -499,7 +497,7 @@ where
     C: Structure<ConstFormat>,
 {
     ps.debug_id.assert(ctx);
-    let cell = Rc::clone(&ctx.gfx_context.current_shader);
+    let cell = Rc::clone(&ctx.gfx.current_shader);
     let previous_shader = *cell.borrow();
     set_shader(ctx, ps);
     ShaderLock {
@@ -514,7 +512,7 @@ where
     C: Structure<ConstFormat>,
 {
     ps.debug_id.assert(ctx);
-    *ctx.gfx_context.current_shader.borrow_mut() = Some(ps.id);
+    *ctx.gfx.current_shader.borrow_mut() = Some(ps.id);
 }
 
 /// Clears the the current shader for the `Context`, restoring the default shader.
@@ -522,7 +520,7 @@ where
 /// However, calling this and then dropping a [`ShaderLock`](struct.ShaderLock.html)
 /// will still set the shader to whatever was set when the `ShaderLock` was created.
 pub fn clear_shader(ctx: &mut Context) {
-    *ctx.gfx_context.current_shader.borrow_mut() = None;
+    *ctx.gfx.current_shader.borrow_mut() = None;
 }
 
 #[derive(Debug)]

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -330,13 +330,13 @@ where
     ) -> GameResult<Shader<C>> {
         let vertex_source = {
             let mut buf = Vec::new();
-            let mut reader = ctx.filesystem.open(vertex_path)?;
+            let mut reader = ctx.fs.open(vertex_path)?;
             let _ = reader.read_to_end(&mut buf)?;
             buf
         };
         let pixel_source = {
             let mut buf = Vec::new();
-            let mut reader = ctx.filesystem.open(pixel_path)?;
+            let mut reader = ctx.fs.open(pixel_path)?;
             let _ = reader.read_to_end(&mut buf)?;
             buf
         };

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -126,11 +126,11 @@ impl SpriteBatch {
                     Transform::Matrix(_) => *param,
                 };
                 let primitive_param = new_param;
-                primitive_param.to_instance_properties(ctx.gfx_context.is_srgb())
+                primitive_param.to_instance_properties(ctx.gfx.is_srgb())
             })
             .collect::<Vec<_>>();
 
-        let gfx = &mut ctx.gfx_context;
+        let gfx = &mut ctx.gfx;
         if gfx.data.rect_instance_properties.len() < self.sprites.len() {
             gfx.data.rect_instance_properties = gfx.factory.create_buffer(
                 self.sprites.len(),
@@ -181,7 +181,7 @@ impl graphics::Drawable for SpriteBatch {
         // Awkwardly we must update values on all sprites and such.
         // Also awkwardly we have this chain of colors with differing priorities.
         self.flush(ctx, &self.image)?;
-        let gfx = &mut ctx.gfx_context;
+        let gfx = &mut ctx.gfx;
         let sampler = gfx
             .samplers
             .get_or_insert(self.image.sampler_info, gfx.factory.as_mut());

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -422,8 +422,7 @@ impl Font {
     where
         P: AsRef<path::Path> + fmt::Debug,
     {
-        use crate::filesystem;
-        let mut stream = filesystem::open(context, path.as_ref())?;
+        let mut stream = context.fs.open(path.as_ref())?;
         let mut buf = Vec::new();
         let _ = stream.read_to_end(&mut buf)?;
 

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -340,7 +340,7 @@ impl Text {
 
     /// Returns a Vec containing the coordinates of the formatted and wrapped text.
     pub fn glyph_positions(&self, context: &Context) -> std::cell::Ref<Vec<mint::Point2<f32>>> {
-        self.calculate_glyph_positions(&mut context.gfx_context.glyph_brush.borrow_mut())
+        self.calculate_glyph_positions(&mut context.gfx.glyph_brush.borrow_mut())
     }
 
     /// Calculates, caches, and returns width and height of formatted and wrapped text.
@@ -379,7 +379,7 @@ impl Text {
 
     /// Returns a Rect containing the width and height of the formatted and wrapped text.
     pub fn dimensions(&self, context: &Context) -> Rect {
-        self.calculate_dimensions(&mut context.gfx_context.glyph_brush.borrow_mut())
+        self.calculate_dimensions(&mut context.gfx.glyph_brush.borrow_mut())
     }
 
     /// Returns the width of formatted and wrapped text, in screen coordinates.
@@ -436,7 +436,7 @@ impl Font {
         // Take a Cow here to avoid this clone where unnecessary?
         // Nah, let's not complicate things more than necessary.
         let font = glyph_brush::ab_glyph::FontArc::try_from_vec(bytes.to_vec()).unwrap();
-        let font_id = context.gfx_context.glyph_brush.borrow_mut().add_font(font);
+        let font_id = context.gfx.glyph_brush.borrow_mut().add_font(font);
 
         Ok(Font { font_id })
     }
@@ -459,7 +459,7 @@ impl Default for Font {
 /// Obtains the font cache.
 pub fn font_cache(context: &Context) -> FontCache {
     FontCache {
-        glyph_brush: context.gfx_context.glyph_brush.clone(),
+        glyph_brush: context.gfx.glyph_brush.clone(),
     }
 }
 
@@ -473,11 +473,7 @@ where
 {
     let p = Point2::from(relative_dest.into());
     let varied_section = batch.generate_varied_section(p, color);
-    context
-        .gfx_context
-        .glyph_brush
-        .borrow_mut()
-        .queue(varied_section);
+    context.gfx.glyph_brush.borrow_mut().queue(varied_section);
 }
 
 /// Exposes `glyph_brush`'s drawing API in case `ggez`'s text drawing is insufficient.
@@ -488,7 +484,7 @@ where
     S: Into<Cow<'a, Section<'a>>>,
     G: GlyphPositioner,
 {
-    let brush = &mut context.gfx_context.glyph_brush.borrow_mut();
+    let brush = &mut context.gfx.glyph_brush.borrow_mut();
     match custom_layout {
         Some(layout) => brush.queue_custom_layout(section, layout),
         None => brush.queue(section),
@@ -516,10 +512,10 @@ where
 {
     let param: DrawParam = param.into();
 
-    let gb = &mut ctx.gfx_context.glyph_brush;
-    let encoder = &mut ctx.gfx_context.encoder;
-    let gc = &ctx.gfx_context.glyph_cache.texture_handle;
-    let backend = &ctx.gfx_context.backend_spec;
+    let gb = &mut ctx.gfx.glyph_brush;
+    let encoder = &mut ctx.gfx.encoder;
+    let gc = &ctx.gfx.glyph_cache.texture_handle;
+    let backend = &ctx.gfx.backend_spec;
 
     let action = gb.borrow_mut().process_queued(
         |rect, tex_data| update_texture::<GlBackendSpec>(backend, encoder, gc, rect, tex_data),
@@ -527,7 +523,7 @@ where
     );
     match action {
         Ok(glyph_brush::BrushAction::ReDraw) => {
-            let spritebatch = ctx.gfx_context.glyph_state.clone();
+            let spritebatch = ctx.gfx.glyph_state.clone();
             let spritebatch = &mut *spritebatch.borrow_mut();
             spritebatch.set_blend_mode(blend);
             spritebatch.set_filter(filter);
@@ -535,7 +531,7 @@ where
         }
         Ok(glyph_brush::BrushAction::Draw(drawparams)) => {
             // Gotta clone the image to avoid double-borrow's.
-            let spritebatch = ctx.gfx_context.glyph_state.clone();
+            let spritebatch = ctx.gfx.glyph_state.clone();
             let spritebatch = &mut *spritebatch.borrow_mut();
             spritebatch.clear();
             spritebatch.set_blend_mode(blend);
@@ -555,11 +551,11 @@ where
                 u16::try_from(new_height).unwrap(),
                 &data,
             )?;
-            ctx.gfx_context.glyph_cache = new_glyph_cache.clone();
-            let spritebatch = ctx.gfx_context.glyph_state.clone();
+            ctx.gfx.glyph_cache = new_glyph_cache.clone();
+            let spritebatch = ctx.gfx.glyph_state.clone();
             let spritebatch = &mut *spritebatch.borrow_mut();
             let _ = spritebatch.set_image(new_glyph_cache);
-            ctx.gfx_context
+            ctx.gfx
                 .glyph_brush
                 .borrow_mut()
                 .resize_texture(new_width, new_height);

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -20,10 +20,10 @@ pub trait GamepadContext {
     /// Returns a gamepad event.
     fn next_event(&mut self) -> Option<Event>;
 
-    /// returns the `Gamepad` associated with an id.
+    /// Returns the `Gamepad` associated with an `id`.
     fn gamepad(&self, id: GamepadId) -> Gamepad;
 
-    /// returns an iterator over the connected `Gamepad`s.
+    /// Return an iterator of all the `Gamepads` that are connected.
     fn gamepads(&self) -> GamepadsIterator;
 }
 
@@ -108,11 +108,15 @@ impl GamepadContext for NullGamepadContext {
 }
 
 /// Returns the `Gamepad` associated with an `id`.
+// TODO: Add deprecation version
+#[deprecated(note = "Use `Context::gamepad_context.gamepad` instead")]
 pub fn gamepad(ctx: &Context, id: GamepadId) -> Gamepad {
     ctx.gamepad_context.gamepad(id)
 }
 
 /// Return an iterator of all the `Gamepads` that are connected.
+// TODO: Add deprecation version
+#[deprecated(note = "Use `Context::gamepad_context.gamepads` instead")]
 pub fn gamepads(ctx: &Context) -> GamepadsIterator {
     ctx.gamepad_context.gamepads()
 }

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -84,14 +84,14 @@ impl<'a> Iterator for GamepadsIterator<'a> {
 // TODO: Add deprecation version
 #[deprecated(note = "Use `Context::gamepad.gamepad` instead")]
 pub fn gamepad(ctx: &Context, id: GamepadId) -> Gamepad {
-    ctx.gamepad.gamepad(id)
+    ctx.input.gamepad.gamepad(id)
 }
 
 /// Return an iterator of all the `Gamepads` that are connected.
 // TODO: Add deprecation version
 #[deprecated(note = "Use `Context::gamepad.gamepads` instead")]
 pub fn gamepads(ctx: &Context) -> GamepadsIterator {
-    ctx.gamepad.gamepads()
+    ctx.input.gamepad.gamepads()
 }
 
 // Properties gamepads might want:

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -3,6 +3,8 @@
 //! This is going to be a bit of a work-in-progress as gamepad input
 //! gets fleshed out.  The `gilrs` crate needs help to add better
 //! cross-platform support.  Why not give it a hand?
+#![cfg(feature = "gamepad")]
+
 use gilrs::ConnectedGamepadsIterator;
 use std::fmt;
 
@@ -15,53 +17,44 @@ pub struct GamepadId(pub(crate) gilrs::GamepadId);
 use crate::context::Context;
 use crate::error::GameResult;
 
-/// Trait object defining a gamepad/joystick context.
-pub trait GamepadContext {
-    /// Returns a gamepad event.
-    fn next_event(&mut self) -> Option<Event>;
-
-    /// Returns the `Gamepad` associated with an `id`.
-    fn gamepad(&self, id: GamepadId) -> Gamepad;
-
-    /// Return an iterator of all the `Gamepads` that are connected.
-    fn gamepads(&self) -> GamepadsIterator;
-}
-
 /// A structure that contains gamepad state using `gilrs`.
-pub struct GilrsGamepadContext {
+pub struct GamepadContext {
     pub(crate) gilrs: Gilrs,
 }
 
-impl fmt::Debug for GilrsGamepadContext {
+impl fmt::Debug for GamepadContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<GilrsGamepadContext: {:p}>", self)
     }
 }
 
-impl GilrsGamepadContext {
+impl GamepadContext {
     pub(crate) fn new() -> GameResult<Self> {
         let gilrs = Gilrs::new()?;
-        Ok(GilrsGamepadContext { gilrs })
+        Ok(GamepadContext { gilrs })
     }
 }
 
-impl From<Gilrs> for GilrsGamepadContext {
+impl From<Gilrs> for GamepadContext {
     /// Converts from a `Gilrs` custom instance to a `GilrsGamepadContext`
     fn from(gilrs: Gilrs) -> Self {
         Self { gilrs }
     }
 }
 
-impl GamepadContext for GilrsGamepadContext {
-    fn next_event(&mut self) -> Option<Event> {
+impl GamepadContext {
+    /// Returns a gamepad event.
+    pub fn next_event(&mut self) -> Option<Event> {
         self.gilrs.next_event()
     }
 
-    fn gamepad(&self, id: GamepadId) -> Gamepad {
+    /// Returns the `Gamepad` associated with an `id`.
+    pub fn gamepad(&self, id: GamepadId) -> Gamepad {
         self.gilrs.gamepad(id.0)
     }
 
-    fn gamepads(&self) -> GamepadsIterator {
+    /// Return an iterator of all the `Gamepads` that are connected.
+    pub fn gamepads(&self) -> GamepadsIterator {
         GamepadsIterator {
             wrapped: self.gilrs.gamepads(),
         }
@@ -87,36 +80,16 @@ impl<'a> Iterator for GamepadsIterator<'a> {
     }
 }
 
-/// A structure that implements [`GamepadContext`](trait.GamepadContext.html)
-/// but does nothing; a stub for when you don't need it or are
-/// on a platform that `gilrs` doesn't support.
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct NullGamepadContext {}
-
-impl GamepadContext for NullGamepadContext {
-    fn next_event(&mut self) -> Option<Event> {
-        panic!("Gamepad module disabled")
-    }
-
-    fn gamepad(&self, _id: GamepadId) -> Gamepad {
-        panic!("Gamepad module disabled")
-    }
-
-    fn gamepads(&self) -> GamepadsIterator {
-        panic!("Gamepad module disabled")
-    }
-}
-
 /// Returns the `Gamepad` associated with an `id`.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::gamepad_context.gamepad` instead")]
+#[deprecated(note = "Use `Context::gamepad.gamepad` instead")]
 pub fn gamepad(ctx: &Context, id: GamepadId) -> Gamepad {
     ctx.gamepad.gamepad(id)
 }
 
 /// Return an iterator of all the `Gamepads` that are connected.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::gamepad_context.gamepads` instead")]
+#[deprecated(note = "Use `Context::gamepad.gamepads` instead")]
 pub fn gamepads(ctx: &Context) -> GamepadsIterator {
     ctx.gamepad.gamepads()
 }
@@ -151,6 +124,6 @@ mod tests {
 
     #[test]
     fn gilrs_init() {
-        assert!(GilrsGamepadContext::new().is_ok());
+        assert!(GamepadContext::new().is_ok());
     }
 }

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -111,14 +111,14 @@ impl GamepadContext for NullGamepadContext {
 // TODO: Add deprecation version
 #[deprecated(note = "Use `Context::gamepad_context.gamepad` instead")]
 pub fn gamepad(ctx: &Context, id: GamepadId) -> Gamepad {
-    ctx.gamepad_context.gamepad(id)
+    ctx.gamepad.gamepad(id)
 }
 
 /// Return an iterator of all the `Gamepads` that are connected.
 // TODO: Add deprecation version
 #[deprecated(note = "Use `Context::gamepad_context.gamepads` instead")]
 pub fn gamepads(ctx: &Context) -> GamepadsIterator {
-    ctx.gamepad_context.gamepads()
+    ctx.gamepad.gamepads()
 }
 
 // Properties gamepads might want:

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -82,14 +82,14 @@ impl<'a> Iterator for GamepadsIterator<'a> {
 
 /// Returns the `Gamepad` associated with an `id`.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::gamepad.gamepad` instead")]
+#[deprecated(note = "Use `ctx.gamepad.gamepad` instead")]
 pub fn gamepad(ctx: &Context, id: GamepadId) -> Gamepad {
     ctx.input.gamepad.gamepad(id)
 }
 
 /// Return an iterator of all the `Gamepads` that are connected.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::gamepad.gamepads` instead")]
+#[deprecated(note = "Use `ctx.gamepad.gamepads` instead")]
 pub fn gamepads(ctx: &Context) -> GamepadsIterator {
     ctx.input.gamepad.gamepads()
 }

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -84,14 +84,14 @@ impl<'a> Iterator for GamepadsIterator<'a> {
 // TODO: Add deprecation version
 #[deprecated(note = "Use `ctx.gamepad.gamepad` instead")]
 pub fn gamepad(ctx: &Context, id: GamepadId) -> Gamepad {
-    ctx.input.gamepad.gamepad(id)
+    ctx.gamepad.gamepad(id)
 }
 
 /// Return an iterator of all the `Gamepads` that are connected.
 // TODO: Add deprecation version
 #[deprecated(note = "Use `ctx.gamepad.gamepads` instead")]
 pub fn gamepads(ctx: &Context) -> GamepadsIterator {
-    ctx.input.gamepad.gamepads()
+    ctx.gamepad.gamepads()
 }
 
 // Properties gamepads might want:

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -241,21 +241,21 @@ impl Default for KeyboardContext {
 
 /// Checks if a key is currently pressed down.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.keyboard.is_key_pressed` instead")]
+#[deprecated(note = "Use `ctx.input.keyboard.is_key_pressed` instead")]
 pub fn is_key_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.input.keyboard.is_key_pressed(key)
 }
 
 /// Checks if a key has been pressed down this frame.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.keyboard.is_key_just_pressed` instead")]
+#[deprecated(note = "Use `ctx.input.keyboard.is_key_just_pressed` instead")]
 pub fn is_key_just_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.input.keyboard.is_key_just_pressed(key)
 }
 
 /// Checks if a key has been released this frame.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.keyboard.is_key_just_released` instead")]
+#[deprecated(note = "Use `ctx.input.keyboard.is_key_just_released` instead")]
 pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
     ctx.input.keyboard.is_key_just_released(key)
 }
@@ -263,28 +263,28 @@ pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
 /// Checks if the last keystroke sent by the system is repeated,
 /// like when a key is held down for a period of time.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.keyboard.is_key_repeated` instead")]
+#[deprecated(note = "Use `ctx.input.keyboard.is_key_repeated` instead")]
 pub fn is_key_repeated(ctx: &Context) -> bool {
     ctx.input.keyboard.is_key_repeated()
 }
 
 /// Returns a reference to the set of currently pressed keys.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.keyboard.pressed_keys` instead")]
+#[deprecated(note = "Use `ctx.input.keyboard.pressed_keys` instead")]
 pub fn pressed_keys(ctx: &Context) -> &HashSet<KeyCode> {
     ctx.input.keyboard.pressed_keys()
 }
 
 /// Checks if keyboard modifier (or several) is active.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.keyboard.is_mod_active` instead")]
+#[deprecated(note = "Use `ctx.input.keyboard.is_mod_active` instead")]
 pub fn is_mod_active(ctx: &Context, keymods: KeyMods) -> bool {
     ctx.input.keyboard.is_mod_active(keymods)
 }
 
 /// Returns currently active keyboard modifiers.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.keyboard.active_mods` instead")]
+#[deprecated(note = "Use `ctx.input.keyboard.active_mods` instead")]
 pub fn active_mods(ctx: &Context) -> KeyMods {
     ctx.input.keyboard.active_mods()
 }

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -240,18 +240,21 @@ impl Default for KeyboardContext {
 }
 
 /// Checks if a key is currently pressed down.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.keyboard.is_key_pressed` instead")]
 pub fn is_key_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.input.keyboard.is_key_pressed(key)
 }
 
 /// Checks if a key has been pressed down this frame.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.keyboard.is_key_just_pressed` instead")]
 pub fn is_key_just_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.input.keyboard.is_key_just_pressed(key)
 }
 
 /// Checks if a key has been released this frame.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.keyboard.is_key_just_released` instead")]
 pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
     ctx.input.keyboard.is_key_just_released(key)
@@ -259,24 +262,28 @@ pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
 
 /// Checks if the last keystroke sent by the system is repeated,
 /// like when a key is held down for a period of time.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.keyboard.is_key_repeated` instead")]
 pub fn is_key_repeated(ctx: &Context) -> bool {
     ctx.input.keyboard.is_key_repeated()
 }
 
 /// Returns a reference to the set of currently pressed keys.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.keyboard.pressed_keys` instead")]
 pub fn pressed_keys(ctx: &Context) -> &HashSet<KeyCode> {
     ctx.input.keyboard.pressed_keys()
 }
 
 /// Checks if keyboard modifier (or several) is active.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.keyboard.is_mod_active` instead")]
 pub fn is_mod_active(ctx: &Context, keymods: KeyMods) -> bool {
     ctx.input.keyboard.is_mod_active(keymods)
 }
 
 /// Returns currently active keyboard modifiers.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.keyboard.active_mods` instead")]
 pub fn active_mods(ctx: &Context) -> KeyMods {
     ctx.input.keyboard.active_mods()

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -241,52 +241,52 @@ impl Default for KeyboardContext {
 
 /// Checks if a key is currently pressed down.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.keyboard.is_key_pressed` instead")]
+#[deprecated(note = "Use `ctx.keyboard.is_key_pressed` instead")]
 pub fn is_key_pressed(ctx: &Context, key: KeyCode) -> bool {
-    ctx.input.keyboard.is_key_pressed(key)
+    ctx.keyboard.is_key_pressed(key)
 }
 
 /// Checks if a key has been pressed down this frame.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.keyboard.is_key_just_pressed` instead")]
+#[deprecated(note = "Use `ctx.keyboard.is_key_just_pressed` instead")]
 pub fn is_key_just_pressed(ctx: &Context, key: KeyCode) -> bool {
-    ctx.input.keyboard.is_key_just_pressed(key)
+    ctx.keyboard.is_key_just_pressed(key)
 }
 
 /// Checks if a key has been released this frame.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.keyboard.is_key_just_released` instead")]
+#[deprecated(note = "Use `ctx.keyboard.is_key_just_released` instead")]
 pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
-    ctx.input.keyboard.is_key_just_released(key)
+    ctx.keyboard.is_key_just_released(key)
 }
 
 /// Checks if the last keystroke sent by the system is repeated,
 /// like when a key is held down for a period of time.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.keyboard.is_key_repeated` instead")]
+#[deprecated(note = "Use `ctx.keyboard.is_key_repeated` instead")]
 pub fn is_key_repeated(ctx: &Context) -> bool {
-    ctx.input.keyboard.is_key_repeated()
+    ctx.keyboard.is_key_repeated()
 }
 
 /// Returns a reference to the set of currently pressed keys.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.keyboard.pressed_keys` instead")]
+#[deprecated(note = "Use `ctx.keyboard.pressed_keys` instead")]
 pub fn pressed_keys(ctx: &Context) -> &HashSet<KeyCode> {
-    ctx.input.keyboard.pressed_keys()
+    ctx.keyboard.pressed_keys()
 }
 
 /// Checks if keyboard modifier (or several) is active.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.keyboard.is_mod_active` instead")]
+#[deprecated(note = "Use `ctx.keyboard.is_mod_active` instead")]
 pub fn is_mod_active(ctx: &Context, keymods: KeyMods) -> bool {
-    ctx.input.keyboard.is_mod_active(keymods)
+    ctx.keyboard.is_mod_active(keymods)
 }
 
 /// Returns currently active keyboard modifiers.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.keyboard.active_mods` instead")]
+#[deprecated(note = "Use `ctx.keyboard.active_mods` instead")]
 pub fn active_mods(ctx: &Context) -> KeyMods {
-    ctx.input.keyboard.active_mods()
+    ctx.keyboard.active_mods()
 }
 
 #[cfg(test)]

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -139,10 +139,6 @@ impl KeyboardContext {
         }
     }
 
-    pub fn set_modifiers(&mut self, keymods: KeyMods) {
-        self.active_modifiers = keymods;
-    }
-
     /// Checks if a key is currently pressed down.
     pub fn is_key_pressed(&self, key: KeyCode) -> bool {
         self.pressed_keys_set.contains(&key)
@@ -190,7 +186,7 @@ impl KeyboardContext {
         self.previously_pressed_set = self.pressed_keys_set.clone();
     }
 
-    fn set_key(&mut self, key: KeyCode, pressed: bool) {
+    pub(crate) fn set_key(&mut self, key: KeyCode, pressed: bool) {
         if pressed {
             let _ = self.pressed_keys_set.insert(key);
             self.last_pressed = self.current_pressed;
@@ -201,6 +197,10 @@ impl KeyboardContext {
         }
 
         self.set_key_modifier(key, pressed);
+    }
+
+    pub(crate) fn set_modifiers(&mut self, keymods: KeyMods) {
+        self.active_modifiers = keymods;
     }
 
     /// Take a modifier key code and alter our state.
@@ -242,44 +242,44 @@ impl Default for KeyboardContext {
 /// Checks if a key is currently pressed down.
 #[deprecated(note = "Use `Context::keyboard_context.is_key_pressed` instead")]
 pub fn is_key_pressed(ctx: &Context, key: KeyCode) -> bool {
-    ctx.keyboard_context.is_key_pressed(key)
+    ctx.keyboard.is_key_pressed(key)
 }
 
 /// Checks if a key has been pressed down this frame.
 #[deprecated(note = "Use `Context::keyboard_context.is_key_just_pressed` instead")]
 pub fn is_key_just_pressed(ctx: &Context, key: KeyCode) -> bool {
-    ctx.keyboard_context.is_key_just_pressed(key)
+    ctx.keyboard.is_key_just_pressed(key)
 }
 
 /// Checks if a key has been released this frame.
 #[deprecated(note = "Use `Context::keyboard_context.is_key_just_released` instead")]
 pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
-    ctx.keyboard_context.is_key_just_released(key)
+    ctx.keyboard.is_key_just_released(key)
 }
 
 /// Checks if the last keystroke sent by the system is repeated,
 /// like when a key is held down for a period of time.
 #[deprecated(note = "Use `Context::keyboard_context.is_key_repeated` instead")]
 pub fn is_key_repeated(ctx: &Context) -> bool {
-    ctx.keyboard_context.is_key_repeated()
+    ctx.keyboard.is_key_repeated()
 }
 
 /// Returns a reference to the set of currently pressed keys.
 #[deprecated(note = "Use `Context::keyboard_context.pressed_keys` instead")]
 pub fn pressed_keys(ctx: &Context) -> &HashSet<KeyCode> {
-    ctx.keyboard_context.pressed_keys()
+    ctx.keyboard.pressed_keys()
 }
 
 /// Checks if keyboard modifier (or several) is active.
 #[deprecated(note = "Use `Context::keyboard_context.is_mod_active` instead")]
 pub fn is_mod_active(ctx: &Context, keymods: KeyMods) -> bool {
-    ctx.keyboard_context.is_mod_active(keymods)
+    ctx.keyboard.is_mod_active(keymods)
 }
 
 /// Returns currently active keyboard modifiers.
 #[deprecated(note = "Use `Context::keyboard_context.active_mods` instead")]
 pub fn active_mods(ctx: &Context) -> KeyMods {
-    ctx.keyboard_context.active_mods()
+    ctx.keyboard.active_mods()
 }
 
 #[cfg(test)]

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -139,7 +139,58 @@ impl KeyboardContext {
         }
     }
 
-    pub(crate) fn set_key(&mut self, key: KeyCode, pressed: bool) {
+    pub fn set_modifiers(&mut self, keymods: KeyMods) {
+        self.active_modifiers = keymods;
+    }
+
+    /// Checks if a key is currently pressed down.
+    pub fn is_key_pressed(&self, key: KeyCode) -> bool {
+        self.pressed_keys_set.contains(&key)
+    }
+
+    /// Checks if a key has been pressed down this frame.
+    pub fn is_key_just_pressed(&self, key: KeyCode) -> bool {
+        self.pressed_keys_set.contains(&key) && !self.previously_pressed_set.contains(&key)
+    }
+
+    /// Checks if a key has been released this frame.
+    pub fn is_key_just_released(&self, key: KeyCode) -> bool {
+        !self.pressed_keys_set.contains(&key) && self.previously_pressed_set.contains(&key)
+    }
+
+    /// Checks if the last keystroke sent by the system is repeated,
+    /// like when a key is held down for a period of time.
+    pub fn is_key_repeated(&self) -> bool {
+        if self.last_pressed.is_some() {
+            self.last_pressed == self.current_pressed
+        } else {
+            false
+        }
+    }
+
+    /// Returns a reference to the set of currently pressed keys.
+    pub fn pressed_keys(&self) -> &HashSet<KeyCode> {
+        &self.pressed_keys_set
+    }
+
+    /// Checks if keyboard modifier (or several) is active.
+    pub fn is_mod_active(&self, keymods: KeyMods) -> bool {
+        self.active_mods().contains(keymods)
+    }
+
+    /// Returns currently active keyboard modifiers.
+    pub fn active_mods(&self) -> KeyMods {
+        self.active_modifiers
+    }
+
+    /// Copies the current state of the keyboard into the context. If you are writing your own event loop
+    /// you need to call this at the end of every update in order to use the functions `is_key_just_pressed`
+    /// and `is_key_just_released`. Otherwise this is handled for you.
+    pub fn save_keyboard_state(&mut self) {
+        self.previously_pressed_set = self.pressed_keys_set.clone();
+    }
+
+    fn set_key(&mut self, key: KeyCode, pressed: bool) {
         if pressed {
             let _ = self.pressed_keys_set.insert(key);
             self.last_pressed = self.current_pressed;
@@ -180,45 +231,6 @@ impl KeyboardContext {
             }
         }
     }
-
-    pub(crate) fn set_modifiers(&mut self, keymods: KeyMods) {
-        self.active_modifiers = keymods;
-    }
-
-    pub(crate) fn is_key_pressed(&self, key: KeyCode) -> bool {
-        self.pressed_keys_set.contains(&key)
-    }
-
-    pub(crate) fn is_key_just_pressed(&self, key: KeyCode) -> bool {
-        self.pressed_keys_set.contains(&key) && !self.previously_pressed_set.contains(&key)
-    }
-
-    pub(crate) fn is_key_just_released(&self, key: KeyCode) -> bool {
-        !self.pressed_keys_set.contains(&key) && self.previously_pressed_set.contains(&key)
-    }
-
-    pub(crate) fn is_key_repeated(&self) -> bool {
-        if self.last_pressed.is_some() {
-            self.last_pressed == self.current_pressed
-        } else {
-            false
-        }
-    }
-
-    pub(crate) fn pressed_keys(&self) -> &HashSet<KeyCode> {
-        &self.pressed_keys_set
-    }
-
-    pub(crate) fn active_mods(&self) -> KeyMods {
-        self.active_modifiers
-    }
-
-    /// Copies the current state of the keyboard into the context. If you are writing your own event loop
-    /// you need to call this at the end of every update in order to use the functions `is_key_just_pressed`
-    /// and `is_key_just_released`. Otherwise this is handled for you.
-    pub fn save_keyboard_state(&mut self) {
-        self.previously_pressed_set = self.pressed_keys_set.clone();
-    }
 }
 
 impl Default for KeyboardContext {
@@ -228,37 +240,44 @@ impl Default for KeyboardContext {
 }
 
 /// Checks if a key is currently pressed down.
+#[deprecated(note = "Use `Context::keyboard_context.is_key_pressed` instead")]
 pub fn is_key_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.keyboard_context.is_key_pressed(key)
 }
 
 /// Checks if a key has been pressed down this frame.
+#[deprecated(note = "Use `Context::keyboard_context.is_key_just_pressed` instead")]
 pub fn is_key_just_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.keyboard_context.is_key_just_pressed(key)
 }
 
 /// Checks if a key has been released this frame.
+#[deprecated(note = "Use `Context::keyboard_context.is_key_just_released` instead")]
 pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
     ctx.keyboard_context.is_key_just_released(key)
 }
 
 /// Checks if the last keystroke sent by the system is repeated,
 /// like when a key is held down for a period of time.
+#[deprecated(note = "Use `Context::keyboard_context.is_key_repeated` instead")]
 pub fn is_key_repeated(ctx: &Context) -> bool {
     ctx.keyboard_context.is_key_repeated()
 }
 
 /// Returns a reference to the set of currently pressed keys.
+#[deprecated(note = "Use `Context::keyboard_context.pressed_keys` instead")]
 pub fn pressed_keys(ctx: &Context) -> &HashSet<KeyCode> {
     ctx.keyboard_context.pressed_keys()
 }
 
 /// Checks if keyboard modifier (or several) is active.
+#[deprecated(note = "Use `Context::keyboard_context.is_mod_active` instead")]
 pub fn is_mod_active(ctx: &Context, keymods: KeyMods) -> bool {
-    ctx.keyboard_context.active_mods().contains(keymods)
+    ctx.keyboard_context.is_mod_active(keymods)
 }
 
 /// Returns currently active keyboard modifiers.
+#[deprecated(note = "Use `Context::keyboard_context.active_mods` instead")]
 pub fn active_mods(ctx: &Context) -> KeyMods {
     ctx.keyboard_context.active_mods()
 }

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -240,44 +240,44 @@ impl Default for KeyboardContext {
 }
 
 /// Checks if a key is currently pressed down.
-#[deprecated(note = "Use `Context::keyboard.is_key_pressed` instead")]
+#[deprecated(note = "Use `Context::input.keyboard.is_key_pressed` instead")]
 pub fn is_key_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.input.keyboard.is_key_pressed(key)
 }
 
 /// Checks if a key has been pressed down this frame.
-#[deprecated(note = "Use `Context::keyboard.is_key_just_pressed` instead")]
+#[deprecated(note = "Use `Context::input.keyboard.is_key_just_pressed` instead")]
 pub fn is_key_just_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.input.keyboard.is_key_just_pressed(key)
 }
 
 /// Checks if a key has been released this frame.
-#[deprecated(note = "Use `Context::keyboard.is_key_just_released` instead")]
+#[deprecated(note = "Use `Context::input.keyboard.is_key_just_released` instead")]
 pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
     ctx.input.keyboard.is_key_just_released(key)
 }
 
 /// Checks if the last keystroke sent by the system is repeated,
 /// like when a key is held down for a period of time.
-#[deprecated(note = "Use `Context::keyboard.is_key_repeated` instead")]
+#[deprecated(note = "Use `Context::input.keyboard.is_key_repeated` instead")]
 pub fn is_key_repeated(ctx: &Context) -> bool {
     ctx.input.keyboard.is_key_repeated()
 }
 
 /// Returns a reference to the set of currently pressed keys.
-#[deprecated(note = "Use `Context::keyboard.pressed_keys` instead")]
+#[deprecated(note = "Use `Context::input.keyboard.pressed_keys` instead")]
 pub fn pressed_keys(ctx: &Context) -> &HashSet<KeyCode> {
     ctx.input.keyboard.pressed_keys()
 }
 
 /// Checks if keyboard modifier (or several) is active.
-#[deprecated(note = "Use `Context::keyboard.is_mod_active` instead")]
+#[deprecated(note = "Use `Context::input.keyboard.is_mod_active` instead")]
 pub fn is_mod_active(ctx: &Context, keymods: KeyMods) -> bool {
     ctx.input.keyboard.is_mod_active(keymods)
 }
 
 /// Returns currently active keyboard modifiers.
-#[deprecated(note = "Use `Context::keyboard.active_mods` instead")]
+#[deprecated(note = "Use `Context::input.keyboard.active_mods` instead")]
 pub fn active_mods(ctx: &Context) -> KeyMods {
     ctx.input.keyboard.active_mods()
 }

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -242,44 +242,44 @@ impl Default for KeyboardContext {
 /// Checks if a key is currently pressed down.
 #[deprecated(note = "Use `Context::keyboard.is_key_pressed` instead")]
 pub fn is_key_pressed(ctx: &Context, key: KeyCode) -> bool {
-    ctx.keyboard.is_key_pressed(key)
+    ctx.input.keyboard.is_key_pressed(key)
 }
 
 /// Checks if a key has been pressed down this frame.
 #[deprecated(note = "Use `Context::keyboard.is_key_just_pressed` instead")]
 pub fn is_key_just_pressed(ctx: &Context, key: KeyCode) -> bool {
-    ctx.keyboard.is_key_just_pressed(key)
+    ctx.input.keyboard.is_key_just_pressed(key)
 }
 
 /// Checks if a key has been released this frame.
 #[deprecated(note = "Use `Context::keyboard.is_key_just_released` instead")]
 pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
-    ctx.keyboard.is_key_just_released(key)
+    ctx.input.keyboard.is_key_just_released(key)
 }
 
 /// Checks if the last keystroke sent by the system is repeated,
 /// like when a key is held down for a period of time.
 #[deprecated(note = "Use `Context::keyboard.is_key_repeated` instead")]
 pub fn is_key_repeated(ctx: &Context) -> bool {
-    ctx.keyboard.is_key_repeated()
+    ctx.input.keyboard.is_key_repeated()
 }
 
 /// Returns a reference to the set of currently pressed keys.
 #[deprecated(note = "Use `Context::keyboard.pressed_keys` instead")]
 pub fn pressed_keys(ctx: &Context) -> &HashSet<KeyCode> {
-    ctx.keyboard.pressed_keys()
+    ctx.input.keyboard.pressed_keys()
 }
 
 /// Checks if keyboard modifier (or several) is active.
 #[deprecated(note = "Use `Context::keyboard.is_mod_active` instead")]
 pub fn is_mod_active(ctx: &Context, keymods: KeyMods) -> bool {
-    ctx.keyboard.is_mod_active(keymods)
+    ctx.input.keyboard.is_mod_active(keymods)
 }
 
 /// Returns currently active keyboard modifiers.
 #[deprecated(note = "Use `Context::keyboard.active_mods` instead")]
 pub fn active_mods(ctx: &Context) -> KeyMods {
-    ctx.keyboard.active_mods()
+    ctx.input.keyboard.active_mods()
 }
 
 #[cfg(test)]

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -240,44 +240,44 @@ impl Default for KeyboardContext {
 }
 
 /// Checks if a key is currently pressed down.
-#[deprecated(note = "Use `Context::keyboard_context.is_key_pressed` instead")]
+#[deprecated(note = "Use `Context::keyboard.is_key_pressed` instead")]
 pub fn is_key_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.keyboard.is_key_pressed(key)
 }
 
 /// Checks if a key has been pressed down this frame.
-#[deprecated(note = "Use `Context::keyboard_context.is_key_just_pressed` instead")]
+#[deprecated(note = "Use `Context::keyboard.is_key_just_pressed` instead")]
 pub fn is_key_just_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.keyboard.is_key_just_pressed(key)
 }
 
 /// Checks if a key has been released this frame.
-#[deprecated(note = "Use `Context::keyboard_context.is_key_just_released` instead")]
+#[deprecated(note = "Use `Context::keyboard.is_key_just_released` instead")]
 pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
     ctx.keyboard.is_key_just_released(key)
 }
 
 /// Checks if the last keystroke sent by the system is repeated,
 /// like when a key is held down for a period of time.
-#[deprecated(note = "Use `Context::keyboard_context.is_key_repeated` instead")]
+#[deprecated(note = "Use `Context::keyboard.is_key_repeated` instead")]
 pub fn is_key_repeated(ctx: &Context) -> bool {
     ctx.keyboard.is_key_repeated()
 }
 
 /// Returns a reference to the set of currently pressed keys.
-#[deprecated(note = "Use `Context::keyboard_context.pressed_keys` instead")]
+#[deprecated(note = "Use `Context::keyboard.pressed_keys` instead")]
 pub fn pressed_keys(ctx: &Context) -> &HashSet<KeyCode> {
     ctx.keyboard.pressed_keys()
 }
 
 /// Checks if keyboard modifier (or several) is active.
-#[deprecated(note = "Use `Context::keyboard_context.is_mod_active` instead")]
+#[deprecated(note = "Use `Context::keyboard.is_mod_active` instead")]
 pub fn is_mod_active(ctx: &Context, keymods: KeyMods) -> bool {
     ctx.keyboard.is_mod_active(keymods)
 }
 
 /// Returns currently active keyboard modifiers.
-#[deprecated(note = "Use `Context::keyboard_context.active_mods` instead")]
+#[deprecated(note = "Use `Context::keyboard.active_mods` instead")]
 pub fn active_mods(ctx: &Context) -> KeyMods {
     ctx.keyboard.active_mods()
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,3 +2,27 @@
 pub mod gamepad;
 pub mod keyboard;
 pub mod mouse;
+use self::{gamepad::GamepadContext, keyboard::KeyboardContext, mouse::MouseContext};
+use crate::GameResult;
+
+/// Contains contexts related to user input, i.e. keyboard, mouse and gamepads connected.
+#[derive(Debug)]
+pub struct InputContext {
+    /// The mouse input context.
+    pub mouse: MouseContext,
+    /// The keyboard input context.
+    pub keyboard: KeyboardContext,
+    #[cfg(feature = "gamepad")]
+    /// The gamepad input context.
+    pub gamepad: GamepadContext,
+}
+
+impl InputContext {
+    pub(crate) fn new() -> GameResult<Self> {
+        Ok(Self {
+            mouse: MouseContext::new(),
+            keyboard: KeyboardContext::new(),
+            gamepad: GamepadContext::new()?,
+        })
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,27 +2,3 @@
 pub mod gamepad;
 pub mod keyboard;
 pub mod mouse;
-use self::{gamepad::GamepadContext, keyboard::KeyboardContext, mouse::MouseContext};
-use crate::GameResult;
-
-/// Contains contexts related to user input, i.e. keyboard, mouse and gamepads connected.
-#[derive(Debug)]
-pub struct InputContext {
-    /// The mouse input context.
-    pub mouse: MouseContext,
-    /// The keyboard input context.
-    pub keyboard: KeyboardContext,
-    #[cfg(feature = "gamepad")]
-    /// The gamepad input context.
-    pub gamepad: GamepadContext,
-}
-
-impl InputContext {
-    pub(crate) fn new() -> GameResult<Self> {
-        Ok(Self {
-            mouse: MouseContext::new(),
-            keyboard: KeyboardContext::new(),
-            gamepad: GamepadContext::new()?,
-        })
-    }
-}

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -144,12 +144,14 @@ impl Default for MouseContext {
 }
 
 /// Returns the current mouse cursor type of the window.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.mouse.cursor_type` instead")]
 pub fn cursor_type(ctx: &Context) -> CursorIcon {
     ctx.input.mouse.cursor_type()
 }
 
 /// Set whether or not the mouse is hidden (invisible)
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.mouse.cursor_hidden` instead")]
 pub fn cursor_hidden(ctx: &Context) -> bool {
     ctx.input.mouse.cursor_hidden()
@@ -158,30 +160,35 @@ pub fn cursor_hidden(ctx: &Context) -> bool {
 /// Get the current position of the mouse cursor, in pixels.
 /// Complement to [`set_position()`](fn.set_position.html).
 /// Uses strictly window-only coordinates.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.mouse.position` instead")]
 pub fn position(ctx: &Context) -> mint::Point2<f32> {
     ctx.input.mouse.position()
 }
 
 /// Get the distance the cursor was moved during the current frame, in pixels.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.mouse.delta` instead")]
 pub fn delta(ctx: &Context) -> mint::Point2<f32> {
     ctx.input.mouse.delta()
 }
 
 /// Returns whether or not the given mouse button is pressed.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.mouse.button_pressed` instead")]
 pub fn button_pressed(ctx: &Context, button: MouseButton) -> bool {
     ctx.input.mouse.button_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been pressed this frame.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.mouse.button_just_pressed` instead")]
 pub fn button_just_pressed(ctx: &Context, button: MouseButton) -> bool {
     ctx.input.mouse.button_just_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been released this frame.
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.mouse.button_just_released` instead")]
 pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
     ctx.input.mouse.button_just_released(button)
@@ -199,6 +206,7 @@ pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
 /// (Note that the default implementation of
 /// [`touch_event`](../../event/trait.EventHandler.html#method.touch_event) DOES trigger one, but
 /// it does so by invoking it on the `EventHandler` manually.)
+// TODO: Add deprecation version
 #[deprecated(note = "Use `Context::input.mouse.handle_move` instead")]
 pub fn handle_move(ctx: &mut Context, new_x: f32, new_y: f32) {
     ctx.input.mouse.handle_move(new_x, new_y)

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -10,7 +10,8 @@ use winit::dpi;
 pub use winit::event::MouseButton;
 pub use winit::window::CursorIcon;
 
-/// Stores state information for the mouse.
+/// Stores state information for the mouse input.
+// TODO: Add "differences with window cursor" notice
 #[derive(Clone, Debug)]
 pub struct MouseContext {
     last_position: Point2,
@@ -145,53 +146,53 @@ impl Default for MouseContext {
 
 /// Returns the current mouse cursor type of the window.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.mouse.cursor_type` instead")]
+#[deprecated(note = "Use `ctx.mouse.cursor_type` instead")]
 pub fn cursor_type(ctx: &Context) -> CursorIcon {
-    ctx.input.mouse.cursor_type()
+    ctx.mouse.cursor_type()
 }
 
 /// Set whether or not the mouse is hidden (invisible)
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.mouse.cursor_hidden` instead")]
+#[deprecated(note = "Use `ctx.mouse.cursor_hidden` instead")]
 pub fn cursor_hidden(ctx: &Context) -> bool {
-    ctx.input.mouse.cursor_hidden()
+    ctx.mouse.cursor_hidden()
 }
 
 /// Get the current position of the mouse cursor, in pixels.
 /// Complement to [`set_position()`](fn.set_position.html).
 /// Uses strictly window-only coordinates.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.mouse.position` instead")]
+#[deprecated(note = "Use `ctx.mouse.position` instead")]
 pub fn position(ctx: &Context) -> mint::Point2<f32> {
-    ctx.input.mouse.position()
+    ctx.mouse.position()
 }
 
 /// Get the distance the cursor was moved during the current frame, in pixels.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.mouse.delta` instead")]
+#[deprecated(note = "Use `ctx.mouse.delta` instead")]
 pub fn delta(ctx: &Context) -> mint::Point2<f32> {
-    ctx.input.mouse.delta()
+    ctx.mouse.delta()
 }
 
 /// Returns whether or not the given mouse button is pressed.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.mouse.button_pressed` instead")]
+#[deprecated(note = "Use `ctx.mouse.button_pressed` instead")]
 pub fn button_pressed(ctx: &Context, button: MouseButton) -> bool {
-    ctx.input.mouse.button_pressed(button)
+    ctx.mouse.button_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been pressed this frame.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.mouse.button_just_pressed` instead")]
+#[deprecated(note = "Use `ctx.mouse.button_just_pressed` instead")]
 pub fn button_just_pressed(ctx: &Context, button: MouseButton) -> bool {
-    ctx.input.mouse.button_just_pressed(button)
+    ctx.mouse.button_just_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been released this frame.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.mouse.button_just_released` instead")]
+#[deprecated(note = "Use `ctx.mouse.button_just_released` instead")]
 pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
-    ctx.input.mouse.button_just_released(button)
+    ctx.mouse.button_just_released(button)
 }
 
 /// Updates delta and position values.
@@ -207,35 +208,35 @@ pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
 /// [`touch_event`](../../event/trait.EventHandler.html#method.touch_event) DOES trigger one, but
 /// it does so by invoking it on the `EventHandler` manually.)
 // TODO: Add deprecation version
-#[deprecated(note = "Use `ctx.input.mouse.handle_move` instead")]
+#[deprecated(note = "Use `ctx.mouse.handle_move` instead")]
 pub fn handle_move(ctx: &mut Context, new_x: f32, new_y: f32) {
-    ctx.input.mouse.handle_move(new_x, new_y)
+    ctx.mouse.handle_move(new_x, new_y)
 }
 
 /// Set whether or not the mouse is hidden (invisible).
 // TODO: Move to graphics context (This isn't input)
 pub fn set_cursor_hidden(ctx: &mut Context, hidden: bool) {
-    ctx.input.mouse.cursor_hidden = hidden;
+    ctx.mouse.cursor_hidden = hidden;
     graphics::window(ctx).set_cursor_visible(!hidden)
 }
 
 /// Modifies the mouse cursor type of the window.
 // TODO: Move to graphics context (This isn't input)
 pub fn set_cursor_type(ctx: &mut Context, cursor_type: CursorIcon) {
-    ctx.input.mouse.cursor_type = cursor_type;
+    ctx.mouse.cursor_type = cursor_type;
     graphics::window(ctx).set_cursor_icon(cursor_type);
 }
 
 /// Get whether or not the mouse is grabbed (confined to the window)
 // TODO: Move to graphics context (This isn't input)
 pub fn cursor_grabbed(ctx: &Context) -> bool {
-    ctx.input.mouse.cursor_grabbed
+    ctx.mouse.cursor_grabbed
 }
 
 /// Set whether or not the mouse is grabbed (confined to the window)
 // TODO: Move to graphics context (This isn't input)
 pub fn set_cursor_grabbed(ctx: &mut Context, grabbed: bool) -> GameResult<()> {
-    ctx.input.mouse.cursor_grabbed = grabbed;
+    ctx.mouse.cursor_grabbed = grabbed;
     graphics::window(ctx)
         .set_cursor_grab(grabbed)
         .map_err(|e| GameError::WindowError(e.to_string()))
@@ -249,7 +250,7 @@ where
     P: Into<mint::Point2<f32>>,
 {
     let mintpoint = point.into();
-    ctx.input.mouse.last_position = Point2::from(mintpoint);
+    ctx.mouse.last_position = Point2::from(mintpoint);
     graphics::window(ctx)
         .set_cursor_position(dpi::LogicalPosition {
             x: f64::from(mintpoint.x),
@@ -260,5 +261,5 @@ where
 
 /// Get the distance the cursor was moved between the latest two mouse_motion_events.
 pub(crate) fn last_delta(ctx: &Context) -> mint::Point2<f32> {
-    ctx.input.mouse.last_delta.into()
+    ctx.mouse.last_delta.into()
 }

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -144,13 +144,13 @@ impl Default for MouseContext {
 }
 
 /// Returns the current mouse cursor type of the window.
-#[deprecated(note = "Use Context::input.mouse.cursor_type instead")]
+#[deprecated(note = "Use `Context::input.mouse.cursor_type` instead")]
 pub fn cursor_type(ctx: &Context) -> CursorIcon {
     ctx.input.mouse.cursor_type()
 }
 
 /// Set whether or not the mouse is hidden (invisible)
-#[deprecated(note = "Use Context::input.mouse.cursor_hidden instead")]
+#[deprecated(note = "Use `Context::input.mouse.cursor_hidden` instead")]
 pub fn cursor_hidden(ctx: &Context) -> bool {
     ctx.input.mouse.cursor_hidden()
 }
@@ -158,31 +158,31 @@ pub fn cursor_hidden(ctx: &Context) -> bool {
 /// Get the current position of the mouse cursor, in pixels.
 /// Complement to [`set_position()`](fn.set_position.html).
 /// Uses strictly window-only coordinates.
-#[deprecated(note = "Use Context::input.mouse.position instead")]
+#[deprecated(note = "Use `Context::input.mouse.position` instead")]
 pub fn position(ctx: &Context) -> mint::Point2<f32> {
     ctx.input.mouse.position()
 }
 
 /// Get the distance the cursor was moved during the current frame, in pixels.
-#[deprecated(note = "Use Context::input.mouse.delta instead")]
+#[deprecated(note = "Use `Context::input.mouse.delta` instead")]
 pub fn delta(ctx: &Context) -> mint::Point2<f32> {
     ctx.input.mouse.delta()
 }
 
 /// Returns whether or not the given mouse button is pressed.
-#[deprecated(note = "Use Context::input.mouse.button_pressed instead")]
+#[deprecated(note = "Use `Context::input.mouse.button_pressed` instead")]
 pub fn button_pressed(ctx: &Context, button: MouseButton) -> bool {
     ctx.input.mouse.button_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been pressed this frame.
-#[deprecated(note = "Use Context::input.mouse.button_just_pressed instead")]
+#[deprecated(note = "Use `Context::input.mouse.button_just_pressed` instead")]
 pub fn button_just_pressed(ctx: &Context, button: MouseButton) -> bool {
     ctx.input.mouse.button_just_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been released this frame.
-#[deprecated(note = "Use Context::input.mouse.button_just_released instead")]
+#[deprecated(note = "Use `Context::input.mouse.button_just_released` instead")]
 pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
     ctx.input.mouse.button_just_released(button)
 }

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -92,23 +92,23 @@ impl Default for MouseContext {
 
 /// Returns the current mouse cursor type of the window.
 pub fn cursor_type(ctx: &Context) -> CursorIcon {
-    ctx.mouse_context.cursor_type
+    ctx.mouse.cursor_type
 }
 
 /// Modifies the mouse cursor type of the window.
 pub fn set_cursor_type(ctx: &mut Context, cursor_type: CursorIcon) {
-    ctx.mouse_context.cursor_type = cursor_type;
+    ctx.mouse.cursor_type = cursor_type;
     graphics::window(ctx).set_cursor_icon(cursor_type);
 }
 
 /// Get whether or not the mouse is grabbed (confined to the window)
 pub fn cursor_grabbed(ctx: &Context) -> bool {
-    ctx.mouse_context.cursor_grabbed
+    ctx.mouse.cursor_grabbed
 }
 
 /// Set whether or not the mouse is grabbed (confined to the window)
 pub fn set_cursor_grabbed(ctx: &mut Context, grabbed: bool) -> GameResult<()> {
-    ctx.mouse_context.cursor_grabbed = grabbed;
+    ctx.mouse.cursor_grabbed = grabbed;
     graphics::window(ctx)
         .set_cursor_grab(grabbed)
         .map_err(|e| GameError::WindowError(e.to_string()))
@@ -116,12 +116,12 @@ pub fn set_cursor_grabbed(ctx: &mut Context, grabbed: bool) -> GameResult<()> {
 
 /// Set whether or not the mouse is hidden (invisible)
 pub fn cursor_hidden(ctx: &Context) -> bool {
-    ctx.mouse_context.cursor_hidden
+    ctx.mouse.cursor_hidden
 }
 
 /// Set whether or not the mouse is hidden (invisible).
 pub fn set_cursor_hidden(ctx: &mut Context, hidden: bool) {
-    ctx.mouse_context.cursor_hidden = hidden;
+    ctx.mouse.cursor_hidden = hidden;
     graphics::window(ctx).set_cursor_visible(!hidden)
 }
 
@@ -129,7 +129,7 @@ pub fn set_cursor_hidden(ctx: &mut Context, hidden: bool) {
 /// Complement to [`set_position()`](fn.set_position.html).
 /// Uses strictly window-only coordinates.
 pub fn position(ctx: &Context) -> mint::Point2<f32> {
-    ctx.mouse_context.last_position.into()
+    ctx.mouse.last_position.into()
 }
 
 /// Set the current position of the mouse cursor, in pixels.
@@ -139,7 +139,7 @@ where
     P: Into<mint::Point2<f32>>,
 {
     let mintpoint = point.into();
-    ctx.mouse_context.last_position = Point2::from(mintpoint);
+    ctx.mouse.last_position = Point2::from(mintpoint);
     graphics::window(ctx)
         .set_cursor_position(dpi::LogicalPosition {
             x: f64::from(mintpoint.x),
@@ -150,27 +150,27 @@ where
 
 /// Get the distance the cursor was moved during the current frame, in pixels.
 pub fn delta(ctx: &Context) -> mint::Point2<f32> {
-    ctx.mouse_context.delta.into()
+    ctx.mouse.delta.into()
 }
 
 /// Get the distance the cursor was moved between the latest two mouse_motion_events.
 pub(crate) fn last_delta(ctx: &Context) -> mint::Point2<f32> {
-    ctx.mouse_context.last_delta.into()
+    ctx.mouse.last_delta.into()
 }
 
 /// Returns whether or not the given mouse button is pressed.
 pub fn button_pressed(ctx: &Context, button: MouseButton) -> bool {
-    ctx.mouse_context.button_pressed(button)
+    ctx.mouse.button_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been pressed this frame.
 pub fn button_just_pressed(ctx: &Context, button: MouseButton) -> bool {
-    ctx.mouse_context.button_just_pressed(button)
+    ctx.mouse.button_just_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been released this frame.
 pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
-    ctx.mouse_context.button_just_released(button)
+    ctx.mouse.button_just_released(button)
 }
 
 /// Updates delta and position values.
@@ -190,13 +190,13 @@ pub fn handle_move(ctx: &mut Context, new_x: f32, new_y: f32) {
     let current_pos = crate::input::mouse::position(ctx);
     let diff = crate::graphics::Point2::new(new_x - current_pos.x, new_y - current_pos.y);
     // Sum up the cumulative mouse change for this frame in `delta`:
-    ctx.mouse_context.set_delta(crate::graphics::Point2::new(
+    ctx.mouse.set_delta(crate::graphics::Point2::new(
         current_delta.x + diff.x,
         current_delta.y + diff.y,
     ));
     // `last_delta` is not cumulative.
     // It represents only the change between the last mouse event and the current one.
-    ctx.mouse_context.set_last_delta(diff);
-    ctx.mouse_context
+    ctx.mouse.set_last_delta(diff);
+    ctx.mouse
         .set_last_position(crate::graphics::Point2::new(new_x as f32, new_y as f32));
 }

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -145,14 +145,14 @@ impl Default for MouseContext {
 
 /// Returns the current mouse cursor type of the window.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.mouse.cursor_type` instead")]
+#[deprecated(note = "Use `ctx.input.mouse.cursor_type` instead")]
 pub fn cursor_type(ctx: &Context) -> CursorIcon {
     ctx.input.mouse.cursor_type()
 }
 
 /// Set whether or not the mouse is hidden (invisible)
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.mouse.cursor_hidden` instead")]
+#[deprecated(note = "Use `ctx.input.mouse.cursor_hidden` instead")]
 pub fn cursor_hidden(ctx: &Context) -> bool {
     ctx.input.mouse.cursor_hidden()
 }
@@ -161,35 +161,35 @@ pub fn cursor_hidden(ctx: &Context) -> bool {
 /// Complement to [`set_position()`](fn.set_position.html).
 /// Uses strictly window-only coordinates.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.mouse.position` instead")]
+#[deprecated(note = "Use `ctx.input.mouse.position` instead")]
 pub fn position(ctx: &Context) -> mint::Point2<f32> {
     ctx.input.mouse.position()
 }
 
 /// Get the distance the cursor was moved during the current frame, in pixels.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.mouse.delta` instead")]
+#[deprecated(note = "Use `ctx.input.mouse.delta` instead")]
 pub fn delta(ctx: &Context) -> mint::Point2<f32> {
     ctx.input.mouse.delta()
 }
 
 /// Returns whether or not the given mouse button is pressed.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.mouse.button_pressed` instead")]
+#[deprecated(note = "Use `ctx.input.mouse.button_pressed` instead")]
 pub fn button_pressed(ctx: &Context, button: MouseButton) -> bool {
     ctx.input.mouse.button_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been pressed this frame.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.mouse.button_just_pressed` instead")]
+#[deprecated(note = "Use `ctx.input.mouse.button_just_pressed` instead")]
 pub fn button_just_pressed(ctx: &Context, button: MouseButton) -> bool {
     ctx.input.mouse.button_just_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been released this frame.
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.mouse.button_just_released` instead")]
+#[deprecated(note = "Use `ctx.input.mouse.button_just_released` instead")]
 pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
     ctx.input.mouse.button_just_released(button)
 }
@@ -207,7 +207,7 @@ pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
 /// [`touch_event`](../../event/trait.EventHandler.html#method.touch_event) DOES trigger one, but
 /// it does so by invoking it on the `EventHandler` manually.)
 // TODO: Add deprecation version
-#[deprecated(note = "Use `Context::input.mouse.handle_move` instead")]
+#[deprecated(note = "Use `ctx.input.mouse.handle_move` instead")]
 pub fn handle_move(ctx: &mut Context, new_x: f32, new_y: f32) {
     ctx.input.mouse.handle_move(new_x, new_y)
 }

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -37,12 +37,69 @@ impl MouseContext {
         }
     }
 
-    pub(crate) fn set_last_position(&mut self, p: Point2) {
-        self.last_position = p;
+    /// Returns the current mouse cursor type of the window.
+    pub fn cursor_type(&self) -> CursorIcon {
+        self.cursor_type
     }
 
-    pub(crate) fn set_last_delta(&mut self, p: Point2) {
-        self.last_delta = p;
+    /// Set whether or not the mouse is hidden (invisible)
+    pub fn cursor_hidden(&self) -> bool {
+        self.cursor_hidden
+    }
+
+    /// Get the current position of the mouse cursor, in pixels.
+    /// Complement to [`set_position()`](fn.set_position.html).
+    /// Uses strictly window-only coordinates.
+    pub fn position(&self) -> mint::Point2<f32> {
+        self.last_position.into()
+    }
+
+    /// Get the distance the cursor was moved during the current frame, in pixels.
+    pub fn delta(&self) -> mint::Point2<f32> {
+        self.delta.into()
+    }
+
+    /// Returns whether or not the given mouse button is pressed.
+
+    pub fn button_pressed(&self, button: MouseButton) -> bool {
+        self.buttons_pressed.contains(&button)
+    }
+
+    /// Returns whether or not the given mouse button has been pressed this frame.
+    pub fn button_just_pressed(&self, button: MouseButton) -> bool {
+        self.buttons_pressed.contains(&button) && !self.previous_buttons_pressed.contains(&button)
+    }
+
+    /// Returns whether or not the given mouse button has been released this frame.
+    pub fn button_just_released(&self, button: MouseButton) -> bool {
+        !self.buttons_pressed.contains(&button) && self.previous_buttons_pressed.contains(&button)
+    }
+
+    /// Updates delta and position values.
+    /// The inputs are interpreted as pixel coordinates inside the window.
+    ///
+    /// This function is called internally whenever the mouse moves to a new location.
+    /// It can also be used to simulate mouse input.
+    /// (It gets called inside the default implementation of the
+    /// [`touch_event`](../../event/trait.EventHandler.html#method.touch_event), for example.)
+    /// Calling this function alone won't trigger a
+    /// [`mouse_motion_event`](../../event/trait.EventHandler.html#method.mouse_motion_event) though.
+    /// (Note that the default implementation of
+    /// [`touch_event`](../../event/trait.EventHandler.html#method.touch_event) DOES trigger one, but
+    /// it does so by invoking it on the `EventHandler` manually.)
+    pub fn handle_move(&mut self, new_x: f32, new_y: f32) {
+        let current_delta = self.delta();
+        let current_pos = self.position();
+        let diff = crate::graphics::Point2::new(new_x - current_pos.x, new_y - current_pos.y);
+        // Sum up the cumulative mouse change for this frame in `delta`:
+        self.set_delta(crate::graphics::Point2::new(
+            current_delta.x + diff.x,
+            current_delta.y + diff.y,
+        ));
+        // `last_delta` is not cumulative.
+        // It represents only the change between the last mouse event and the current one.
+        self.set_last_delta(diff);
+        self.set_last_position(crate::graphics::Point2::new(new_x as f32, new_y as f32));
     }
 
     /// Resets the value returned by [`mouse::delta`](fn.delta.html) to zero.
@@ -50,6 +107,21 @@ impl MouseContext {
     /// In this case call it right at the end, after `draw` and `update` have finished.
     pub fn reset_delta(&mut self) {
         self.delta = Point2::ZERO;
+    }
+
+    /// Copies the current state of the mouse buttons into the context. If you are writing your own event loop
+    /// you need to call this at the end of every update in order to use the functions `is_button_just_pressed`
+    /// and `is_button_just_released`. Otherwise this is handled for you.
+    pub fn save_mouse_state(&mut self) {
+        self.previous_buttons_pressed = self.buttons_pressed.clone();
+    }
+
+    pub(crate) fn set_last_position(&mut self, p: Point2) {
+        self.last_position = p;
+    }
+
+    pub(crate) fn set_last_delta(&mut self, p: Point2) {
+        self.last_delta = p;
     }
 
     pub(crate) fn set_delta(&mut self, p: Point2) {
@@ -63,25 +135,6 @@ impl MouseContext {
             let _ = self.buttons_pressed.remove(&button);
         }
     }
-
-    fn button_pressed(&self, button: MouseButton) -> bool {
-        self.buttons_pressed.contains(&button)
-    }
-
-    pub(crate) fn button_just_pressed(&self, button: MouseButton) -> bool {
-        self.buttons_pressed.contains(&button) && !self.previous_buttons_pressed.contains(&button)
-    }
-
-    pub(crate) fn button_just_released(&self, button: MouseButton) -> bool {
-        !self.buttons_pressed.contains(&button) && self.previous_buttons_pressed.contains(&button)
-    }
-
-    /// Copies the current state of the mouse buttons into the context. If you are writing your own event loop
-    /// you need to call this at the end of every update in order to use the functions `is_button_just_pressed`
-    /// and `is_button_just_released`. Otherwise this is handled for you.
-    pub fn save_mouse_state(&mut self) {
-        self.previous_buttons_pressed = self.buttons_pressed.clone();
-    }
 }
 
 impl Default for MouseContext {
@@ -91,86 +144,47 @@ impl Default for MouseContext {
 }
 
 /// Returns the current mouse cursor type of the window.
+#[deprecated(note = "Use Context::input.mouse.cursor_type instead")]
 pub fn cursor_type(ctx: &Context) -> CursorIcon {
-    ctx.mouse.cursor_type
-}
-
-/// Modifies the mouse cursor type of the window.
-pub fn set_cursor_type(ctx: &mut Context, cursor_type: CursorIcon) {
-    ctx.mouse.cursor_type = cursor_type;
-    graphics::window(ctx).set_cursor_icon(cursor_type);
-}
-
-/// Get whether or not the mouse is grabbed (confined to the window)
-pub fn cursor_grabbed(ctx: &Context) -> bool {
-    ctx.mouse.cursor_grabbed
-}
-
-/// Set whether or not the mouse is grabbed (confined to the window)
-pub fn set_cursor_grabbed(ctx: &mut Context, grabbed: bool) -> GameResult<()> {
-    ctx.mouse.cursor_grabbed = grabbed;
-    graphics::window(ctx)
-        .set_cursor_grab(grabbed)
-        .map_err(|e| GameError::WindowError(e.to_string()))
+    ctx.input.mouse.cursor_type()
 }
 
 /// Set whether or not the mouse is hidden (invisible)
+#[deprecated(note = "Use Context::input.mouse.cursor_hidden instead")]
 pub fn cursor_hidden(ctx: &Context) -> bool {
-    ctx.mouse.cursor_hidden
-}
-
-/// Set whether or not the mouse is hidden (invisible).
-pub fn set_cursor_hidden(ctx: &mut Context, hidden: bool) {
-    ctx.mouse.cursor_hidden = hidden;
-    graphics::window(ctx).set_cursor_visible(!hidden)
+    ctx.input.mouse.cursor_hidden()
 }
 
 /// Get the current position of the mouse cursor, in pixels.
 /// Complement to [`set_position()`](fn.set_position.html).
 /// Uses strictly window-only coordinates.
+#[deprecated(note = "Use Context::input.mouse.position instead")]
 pub fn position(ctx: &Context) -> mint::Point2<f32> {
-    ctx.mouse.last_position.into()
-}
-
-/// Set the current position of the mouse cursor, in pixels.
-/// Uses strictly window-only coordinates.
-pub fn set_position<P>(ctx: &mut Context, point: P) -> GameResult<()>
-where
-    P: Into<mint::Point2<f32>>,
-{
-    let mintpoint = point.into();
-    ctx.mouse.last_position = Point2::from(mintpoint);
-    graphics::window(ctx)
-        .set_cursor_position(dpi::LogicalPosition {
-            x: f64::from(mintpoint.x),
-            y: f64::from(mintpoint.y),
-        })
-        .map_err(|_| GameError::WindowError("Couldn't set mouse cursor position!".to_owned()))
+    ctx.input.mouse.position()
 }
 
 /// Get the distance the cursor was moved during the current frame, in pixels.
+#[deprecated(note = "Use Context::input.mouse.delta instead")]
 pub fn delta(ctx: &Context) -> mint::Point2<f32> {
-    ctx.mouse.delta.into()
-}
-
-/// Get the distance the cursor was moved between the latest two mouse_motion_events.
-pub(crate) fn last_delta(ctx: &Context) -> mint::Point2<f32> {
-    ctx.mouse.last_delta.into()
+    ctx.input.mouse.delta()
 }
 
 /// Returns whether or not the given mouse button is pressed.
+#[deprecated(note = "Use Context::input.mouse.button_pressed instead")]
 pub fn button_pressed(ctx: &Context, button: MouseButton) -> bool {
-    ctx.mouse.button_pressed(button)
+    ctx.input.mouse.button_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been pressed this frame.
+#[deprecated(note = "Use Context::input.mouse.button_just_pressed instead")]
 pub fn button_just_pressed(ctx: &Context, button: MouseButton) -> bool {
-    ctx.mouse.button_just_pressed(button)
+    ctx.input.mouse.button_just_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been released this frame.
+#[deprecated(note = "Use Context::input.mouse.button_just_released instead")]
 pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
-    ctx.mouse.button_just_released(button)
+    ctx.input.mouse.button_just_released(button)
 }
 
 /// Updates delta and position values.
@@ -185,18 +199,58 @@ pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
 /// (Note that the default implementation of
 /// [`touch_event`](../../event/trait.EventHandler.html#method.touch_event) DOES trigger one, but
 /// it does so by invoking it on the `EventHandler` manually.)
+#[deprecated(note = "Use `Context::input.mouse.handle_move` instead")]
 pub fn handle_move(ctx: &mut Context, new_x: f32, new_y: f32) {
-    let current_delta = crate::input::mouse::delta(ctx);
-    let current_pos = crate::input::mouse::position(ctx);
-    let diff = crate::graphics::Point2::new(new_x - current_pos.x, new_y - current_pos.y);
-    // Sum up the cumulative mouse change for this frame in `delta`:
-    ctx.mouse.set_delta(crate::graphics::Point2::new(
-        current_delta.x + diff.x,
-        current_delta.y + diff.y,
-    ));
-    // `last_delta` is not cumulative.
-    // It represents only the change between the last mouse event and the current one.
-    ctx.mouse.set_last_delta(diff);
-    ctx.mouse
-        .set_last_position(crate::graphics::Point2::new(new_x as f32, new_y as f32));
+    ctx.input.mouse.handle_move(new_x, new_y)
+}
+
+/// Set whether or not the mouse is hidden (invisible).
+// TODO: Move to graphics context (This isn't input)
+pub fn set_cursor_hidden(ctx: &mut Context, hidden: bool) {
+    ctx.input.mouse.cursor_hidden = hidden;
+    graphics::window(ctx).set_cursor_visible(!hidden)
+}
+
+/// Modifies the mouse cursor type of the window.
+// TODO: Move to graphics context (This isn't input)
+pub fn set_cursor_type(ctx: &mut Context, cursor_type: CursorIcon) {
+    ctx.input.mouse.cursor_type = cursor_type;
+    graphics::window(ctx).set_cursor_icon(cursor_type);
+}
+
+/// Get whether or not the mouse is grabbed (confined to the window)
+// TODO: Move to graphics context (This isn't input)
+pub fn cursor_grabbed(ctx: &Context) -> bool {
+    ctx.input.mouse.cursor_grabbed
+}
+
+/// Set whether or not the mouse is grabbed (confined to the window)
+// TODO: Move to graphics context (This isn't input)
+pub fn set_cursor_grabbed(ctx: &mut Context, grabbed: bool) -> GameResult<()> {
+    ctx.input.mouse.cursor_grabbed = grabbed;
+    graphics::window(ctx)
+        .set_cursor_grab(grabbed)
+        .map_err(|e| GameError::WindowError(e.to_string()))
+}
+
+/// Set the current position of the mouse cursor, in pixels.
+/// Uses strictly window-only coordinates.
+// TODO: Move to graphics context (This isn't input)
+pub fn set_position<P>(ctx: &mut Context, point: P) -> GameResult<()>
+where
+    P: Into<mint::Point2<f32>>,
+{
+    let mintpoint = point.into();
+    ctx.input.mouse.last_position = Point2::from(mintpoint);
+    graphics::window(ctx)
+        .set_cursor_position(dpi::LogicalPosition {
+            x: f64::from(mintpoint.x),
+            y: f64::from(mintpoint.y),
+        })
+        .map_err(|_| GameError::WindowError("Couldn't set mouse cursor position!".to_owned()))
+}
+
+/// Get the distance the cursor was moved between the latest two mouse_motion_events.
+pub(crate) fn last_delta(ctx: &Context) -> mint::Point2<f32> {
+    ctx.input.mouse.last_delta.into()
 }

--- a/src/tests/conf.rs
+++ b/src/tests/conf.rs
@@ -15,7 +15,6 @@ pub fn context_build_tests() {
         ),
         conf::Conf::default()
             .window_mode(conf::WindowMode::default().fullscreen_type(conf::FullscreenType::True)),
-        conf::Conf::default().modules(conf::ModuleConf::default().audio(false)),
     ];
     for conf in confs.into_iter() {
         let mut cb = ContextBuilder::new("ggez_unit_tests", "ggez").default_conf(conf);

--- a/src/tests/filesystem.rs
+++ b/src/tests/filesystem.rs
@@ -1,5 +1,4 @@
 use crate::tests;
-use crate::*;
 
 use std::io::Write;
 
@@ -8,10 +7,10 @@ fn filesystem_create_correct_paths() {
     let (c, _e) = &mut tests::make_context();
 
     {
-        let mut f = filesystem::create(c, "/filesystem_create_path").unwrap();
+        let mut f = c.fs.create("/filesystem_create_path").unwrap();
         let _ = f.write(b"foo").unwrap();
     }
-    let userdata_path = filesystem::user_config_dir(c);
+    let userdata_path = c.fs.user_config_dir();
     let userdata_path = &mut userdata_path.to_owned();
     userdata_path.push("filesystem_create_path");
     println!("Userdata path: {:?}", userdata_path);

--- a/src/tests/graphics.rs
+++ b/src/tests/graphics.rs
@@ -65,7 +65,7 @@ fn save_screenshot_test(c: &mut Context) {
 
     // Don't do graphics::present(c) since calling it once (!) would mean that the result of our draw operation
     // went to the front buffer and the active screen texture is actually empty.
-    c.gfx_context.encoder.flush(&mut *c.gfx_context.device);
+    c.gfx.encoder.flush(&mut *c.gfx.device);
 
     let screenshot = graphics::screenshot(c).unwrap();
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -223,14 +223,14 @@ impl Default for TimeContext {
 
 /// Get the time between the start of the last frame and the current one;
 /// in other words, the length of the last frame.
-#[deprecated(note = "Use `Context::time.delta` instead")]
+#[deprecated(note = "Use `ctx.time.delta` instead")]
 pub fn delta(ctx: &Context) -> time::Duration {
     ctx.time.delta()
 }
 
 /// Gets the average time of a frame, averaged
 /// over the last 200 frames.
-#[deprecated(note = "Use `Context::time.average_delta` instead")]
+#[deprecated(note = "Use `ctx.time.average_delta` instead")]
 pub fn average_delta(ctx: &Context) -> time::Duration {
     ctx.time.average_delta()
 }
@@ -246,14 +246,14 @@ fn fps_as_duration(fps: u32) -> time::Duration {
 
 /// Gets the FPS of the game, averaged over the last
 /// 200 frames.
-#[deprecated(note = "Use `Context::time.fps` instead")]
+#[deprecated(note = "Use `ctx.time.fps` instead")]
 pub fn fps(ctx: &Context) -> f64 {
     ctx.time.fps()
 }
 
 /// Returns the time since the game was initialized,
 /// as reported by the system clock.
-#[deprecated(note = "Use `Context::time.time_since_start` instead")]
+#[deprecated(note = "Use `ctx.time.time_since_start` instead")]
 pub fn time_since_start(ctx: &Context) -> time::Duration {
     let tc = &ctx.time;
     time::Instant::now() - tc.init_instant
@@ -275,7 +275,7 @@ pub fn time_since_start(ctx: &Context) -> time::Duration {
 /// of your code. If you want to limit the frame rate in both game logic and drawing consider writing
 /// your own event loop, or using a dirty bit for when to redraw graphics, which is set whenever the game
 /// logic runs.
-#[deprecated(note = "Use `Context::time.check_update_time` instead")]
+#[deprecated(note = "Use `ctx.time.check_update_time` instead")]
 pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
     let timedata = &mut ctx.time;
 
@@ -301,7 +301,7 @@ pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
 /// [`draw()`](../event/trait.EventHandler.html#tymethod.draw) callback
 /// to interpolate physics states for smooth rendering.
 /// (see <http://gafferongames.com/game-physics/fix-your-timestep/>)
-#[deprecated(note = "Use `Context::time.remaining_update_time` instead")]
+#[deprecated(note = "Use `ctx.time.remaining_update_time` instead")]
 pub fn remaining_update_time(ctx: &Context) -> time::Duration {
     ctx.time.residual_update_dt
 }
@@ -325,7 +325,7 @@ pub fn yield_now() {
 ///
 /// Specifically, the number of times that [`TimeContext::tick()`](struct.TimeContext.html#method.tick)
 /// has been called by it.
-#[deprecated(note = "Use `Context::time.ticks` instead")]
+#[deprecated(note = "Use `ctx.time.ticks` instead")]
 pub fn ticks(ctx: &Context) -> usize {
     ctx.time.frame_count
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -225,14 +225,14 @@ impl Default for TimeContext {
 /// in other words, the length of the last frame.
 #[deprecated(note = "Use `Context::timer_context.delta` instead")]
 pub fn delta(ctx: &Context) -> time::Duration {
-    ctx.timer_context.delta()
+    ctx.timer.delta()
 }
 
 /// Gets the average time of a frame, averaged
 /// over the last 200 frames.
 #[deprecated(note = "Use `Context::timer_context.average_delta` instead")]
 pub fn average_delta(ctx: &Context) -> time::Duration {
-    ctx.timer_context.average_delta()
+    ctx.timer.average_delta()
 }
 
 /// Returns a `Duration` representing how long each
@@ -248,14 +248,14 @@ fn fps_as_duration(fps: u32) -> time::Duration {
 /// 200 frames.
 #[deprecated(note = "Use `Context::timer_context.fps` instead")]
 pub fn fps(ctx: &Context) -> f64 {
-    ctx.timer_context.fps()
+    ctx.timer.fps()
 }
 
 /// Returns the time since the game was initialized,
 /// as reported by the system clock.
 #[deprecated(note = "Use `Context::timer_context.time_since_start` instead")]
 pub fn time_since_start(ctx: &Context) -> time::Duration {
-    let tc = &ctx.timer_context;
+    let tc = &ctx.timer;
     time::Instant::now() - tc.init_instant
 }
 
@@ -277,7 +277,7 @@ pub fn time_since_start(ctx: &Context) -> time::Duration {
 /// logic runs.
 #[deprecated(note = "Use `Context::timer_context.check_update_time` instead")]
 pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
-    let timedata = &mut ctx.timer_context;
+    let timedata = &mut ctx.timer;
 
     let target_dt = fps_as_duration(target_fps);
     if timedata.residual_update_dt > target_dt {
@@ -303,7 +303,7 @@ pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
 /// (see <http://gafferongames.com/game-physics/fix-your-timestep/>)
 #[deprecated(note = "Use `Context::timer_context.remaining_update_time` instead")]
 pub fn remaining_update_time(ctx: &Context) -> time::Duration {
-    ctx.timer_context.residual_update_dt
+    ctx.timer.residual_update_dt
 }
 
 /// Pauses the current thread for the target duration.
@@ -327,5 +327,5 @@ pub fn yield_now() {
 /// has been called by it.
 #[deprecated(note = "Use `Context::timer_context.ticks` instead")]
 pub fn ticks(ctx: &Context) -> usize {
-    ctx.timer_context.frame_count
+    ctx.timer.frame_count
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -223,14 +223,14 @@ impl Default for TimeContext {
 
 /// Get the time between the start of the last frame and the current one;
 /// in other words, the length of the last frame.
-#[deprecated(note = "Use `Context::timer_context.delta` instead")]
+#[deprecated(note = "Use `Context::time.delta` instead")]
 pub fn delta(ctx: &Context) -> time::Duration {
     ctx.time.delta()
 }
 
 /// Gets the average time of a frame, averaged
 /// over the last 200 frames.
-#[deprecated(note = "Use `Context::timer_context.average_delta` instead")]
+#[deprecated(note = "Use `Context::time.average_delta` instead")]
 pub fn average_delta(ctx: &Context) -> time::Duration {
     ctx.time.average_delta()
 }
@@ -246,14 +246,14 @@ fn fps_as_duration(fps: u32) -> time::Duration {
 
 /// Gets the FPS of the game, averaged over the last
 /// 200 frames.
-#[deprecated(note = "Use `Context::timer_context.fps` instead")]
+#[deprecated(note = "Use `Context::time.fps` instead")]
 pub fn fps(ctx: &Context) -> f64 {
     ctx.time.fps()
 }
 
 /// Returns the time since the game was initialized,
 /// as reported by the system clock.
-#[deprecated(note = "Use `Context::timer_context.time_since_start` instead")]
+#[deprecated(note = "Use `Context::time.time_since_start` instead")]
 pub fn time_since_start(ctx: &Context) -> time::Duration {
     let tc = &ctx.time;
     time::Instant::now() - tc.init_instant
@@ -275,7 +275,7 @@ pub fn time_since_start(ctx: &Context) -> time::Duration {
 /// of your code. If you want to limit the frame rate in both game logic and drawing consider writing
 /// your own event loop, or using a dirty bit for when to redraw graphics, which is set whenever the game
 /// logic runs.
-#[deprecated(note = "Use `Context::timer_context.check_update_time` instead")]
+#[deprecated(note = "Use `Context::time.check_update_time` instead")]
 pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
     let timedata = &mut ctx.time;
 
@@ -301,7 +301,7 @@ pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
 /// [`draw()`](../event/trait.EventHandler.html#tymethod.draw) callback
 /// to interpolate physics states for smooth rendering.
 /// (see <http://gafferongames.com/game-physics/fix-your-timestep/>)
-#[deprecated(note = "Use `Context::timer_context.remaining_update_time` instead")]
+#[deprecated(note = "Use `Context::time.remaining_update_time` instead")]
 pub fn remaining_update_time(ctx: &Context) -> time::Duration {
     ctx.time.residual_update_dt
 }
@@ -325,7 +325,7 @@ pub fn yield_now() {
 ///
 /// Specifically, the number of times that [`TimeContext::tick()`](struct.TimeContext.html#method.tick)
 /// has been called by it.
-#[deprecated(note = "Use `Context::timer_context.ticks` instead")]
+#[deprecated(note = "Use `Context::time.ticks` instead")]
 pub fn ticks(ctx: &Context) -> usize {
     ctx.time.frame_count
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -225,14 +225,14 @@ impl Default for TimeContext {
 /// in other words, the length of the last frame.
 #[deprecated(note = "Use `Context::timer_context.delta` instead")]
 pub fn delta(ctx: &Context) -> time::Duration {
-    ctx.timer.delta()
+    ctx.time.delta()
 }
 
 /// Gets the average time of a frame, averaged
 /// over the last 200 frames.
 #[deprecated(note = "Use `Context::timer_context.average_delta` instead")]
 pub fn average_delta(ctx: &Context) -> time::Duration {
-    ctx.timer.average_delta()
+    ctx.time.average_delta()
 }
 
 /// Returns a `Duration` representing how long each
@@ -248,14 +248,14 @@ fn fps_as_duration(fps: u32) -> time::Duration {
 /// 200 frames.
 #[deprecated(note = "Use `Context::timer_context.fps` instead")]
 pub fn fps(ctx: &Context) -> f64 {
-    ctx.timer.fps()
+    ctx.time.fps()
 }
 
 /// Returns the time since the game was initialized,
 /// as reported by the system clock.
 #[deprecated(note = "Use `Context::timer_context.time_since_start` instead")]
 pub fn time_since_start(ctx: &Context) -> time::Duration {
-    let tc = &ctx.timer;
+    let tc = &ctx.time;
     time::Instant::now() - tc.init_instant
 }
 
@@ -277,7 +277,7 @@ pub fn time_since_start(ctx: &Context) -> time::Duration {
 /// logic runs.
 #[deprecated(note = "Use `Context::timer_context.check_update_time` instead")]
 pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
-    let timedata = &mut ctx.timer;
+    let timedata = &mut ctx.time;
 
     let target_dt = fps_as_duration(target_fps);
     if timedata.residual_update_dt > target_dt {
@@ -303,7 +303,7 @@ pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
 /// (see <http://gafferongames.com/game-physics/fix-your-timestep/>)
 #[deprecated(note = "Use `Context::timer_context.remaining_update_time` instead")]
 pub fn remaining_update_time(ctx: &Context) -> time::Duration {
-    ctx.timer.residual_update_dt
+    ctx.time.residual_update_dt
 }
 
 /// Pauses the current thread for the target duration.
@@ -327,5 +327,5 @@ pub fn yield_now() {
 /// has been called by it.
 #[deprecated(note = "Use `Context::timer_context.ticks` instead")]
 pub fn ticks(ctx: &Context) -> usize {
-    ctx.timer.frame_count
+    ctx.time.frame_count
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -113,6 +113,90 @@ impl TimeContext {
         }
     }
 
+    /// Get the time between the start of the last frame and the current one;
+    /// in other words, the length of the last frame.
+    pub fn delta(&self) -> time::Duration {
+        self.frame_durations.latest()
+    }
+
+    /// Gets the average time of a frame, averaged
+    /// over the last 200 frames.
+    pub fn average_delta(&self) -> time::Duration {
+        let sum: time::Duration = self.frame_durations.contents().iter().sum();
+        // If our buffer is actually full, divide by its size.
+        // Otherwise divide by the number of samples we've added
+        if self.frame_durations.samples > self.frame_durations.size {
+            sum / u32::try_from(self.frame_durations.size).unwrap()
+        } else {
+            sum / u32::try_from(self.frame_durations.samples).unwrap()
+        }
+    }
+
+    /// Gets the FPS of the game, averaged over the last
+    /// 200 frames.
+    pub fn fps(&self) -> f64 {
+        let duration_per_frame = self.average_delta();
+        let seconds_per_frame = duration_per_frame.as_secs_f64();
+        1.0 / seconds_per_frame
+    }
+
+    /// Gets the number of times the game has gone through its event loop.
+    ///
+    /// Specifically, the number of times that [`TimeContext::tick()`](struct.TimeContext.html#method.tick)
+    /// has been called by it.
+    pub fn ticks(&self) -> usize {
+        self.frame_count
+    }
+
+    /// Returns the time since the game was initialized,
+    /// as reported by the system clock.
+    pub fn time_since_start(&self) -> time::Duration {
+        time::Instant::now() - self.init_instant
+    }
+
+    /// Check whether or not the desired amount of time has elapsed
+    /// since the last frame.
+    ///
+    /// The intention is to use this in your `update` call to control
+    /// how often game logic is updated per frame (see [the astroblasto example](https://github.com/ggez/ggez/blob/30ea4a4ead67557d2ebb39550e17339323fc9c58/examples/05_astroblasto.rs#L438-L442)).
+    ///
+    /// Calling this decreases a timer inside the context if the function returns true.
+    /// If called in a loop it may therefore return true once, twice or not at all, depending on
+    /// how much time elapsed since the last frame.
+    ///
+    /// For more info on the idea behind this see <http://gafferongames.com/game-physics/fix-your-timestep/>.
+    ///
+    /// Due to the global nature of this timer it's desirable to only use this function at one point
+    /// of your code. If you want to limit the frame rate in both game logic and drawing consider writing
+    /// your own event loop, or using a dirty bit for when to redraw graphics, which is set whenever the game
+    /// logic runs.
+    pub fn check_update_time(&mut self, target_fps: u32) -> bool {
+        let target_dt = fps_as_duration(target_fps);
+        if self.residual_update_dt > target_dt {
+            self.residual_update_dt -= target_dt;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the fractional amount of a frame not consumed
+    /// by  [`check_update_time()`](fn.check_update_time.html).
+    /// For example, if the desired
+    /// update frame time is 40 ms (25 fps), and 45 ms have
+    /// passed since the last frame, [`check_update_time()`](fn.check_update_time.html)
+    /// will return `true` and `remaining_update_time()` will
+    /// return 5 ms -- the amount of time "overflowing" from one
+    /// frame to the next.
+    ///
+    /// The intention is for it to be called in your
+    /// [`draw()`](../event/trait.EventHandler.html#tymethod.draw) callback
+    /// to interpolate physics states for smooth rendering.
+    /// (see <http://gafferongames.com/game-physics/fix-your-timestep/>)
+    pub fn remaining_update_time(&self) -> time::Duration {
+        self.residual_update_dt
+    }
+
     /// Update the state of the `TimeContext` to record that
     /// another frame has taken place.  Necessary for the FPS
     /// tracking and [`check_update_time()`](fn.check_update_time.html)
@@ -139,23 +223,16 @@ impl Default for TimeContext {
 
 /// Get the time between the start of the last frame and the current one;
 /// in other words, the length of the last frame.
+#[deprecated(note = "Use `Context::timer_context.delta` instead")]
 pub fn delta(ctx: &Context) -> time::Duration {
-    let tc = &ctx.timer_context;
-    tc.frame_durations.latest()
+    ctx.timer_context.delta()
 }
 
 /// Gets the average time of a frame, averaged
 /// over the last 200 frames.
+#[deprecated(note = "Use `Context::timer_context.average_delta` instead")]
 pub fn average_delta(ctx: &Context) -> time::Duration {
-    let tc = &ctx.timer_context;
-    let sum: time::Duration = tc.frame_durations.contents().iter().sum();
-    // If our buffer is actually full, divide by its size.
-    // Otherwise divide by the number of samples we've added
-    if tc.frame_durations.samples > tc.frame_durations.size {
-        sum / u32::try_from(tc.frame_durations.size).unwrap()
-    } else {
-        sum / u32::try_from(tc.frame_durations.samples).unwrap()
-    }
+    ctx.timer_context.average_delta()
 }
 
 /// Returns a `Duration` representing how long each
@@ -169,14 +246,14 @@ fn fps_as_duration(fps: u32) -> time::Duration {
 
 /// Gets the FPS of the game, averaged over the last
 /// 200 frames.
+#[deprecated(note = "Use `Context::timer_context.fps` instead")]
 pub fn fps(ctx: &Context) -> f64 {
-    let duration_per_frame = average_delta(ctx);
-    let seconds_per_frame = duration_per_frame.as_secs_f64();
-    1.0 / seconds_per_frame
+    ctx.timer_context.fps()
 }
 
 /// Returns the time since the game was initialized,
 /// as reported by the system clock.
+#[deprecated(note = "Use `Context::timer_context.time_since_start` instead")]
 pub fn time_since_start(ctx: &Context) -> time::Duration {
     let tc = &ctx.timer_context;
     time::Instant::now() - tc.init_instant
@@ -198,6 +275,7 @@ pub fn time_since_start(ctx: &Context) -> time::Duration {
 /// of your code. If you want to limit the frame rate in both game logic and drawing consider writing
 /// your own event loop, or using a dirty bit for when to redraw graphics, which is set whenever the game
 /// logic runs.
+#[deprecated(note = "Use `Context::timer_context.check_update_time` instead")]
 pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
     let timedata = &mut ctx.timer_context;
 
@@ -223,6 +301,7 @@ pub fn check_update_time(ctx: &mut Context, target_fps: u32) -> bool {
 /// [`draw()`](../event/trait.EventHandler.html#tymethod.draw) callback
 /// to interpolate physics states for smooth rendering.
 /// (see <http://gafferongames.com/game-physics/fix-your-timestep/>)
+#[deprecated(note = "Use `Context::timer_context.remaining_update_time` instead")]
 pub fn remaining_update_time(ctx: &Context) -> time::Duration {
     ctx.timer_context.residual_update_dt
 }
@@ -246,6 +325,7 @@ pub fn yield_now() {
 ///
 /// Specifically, the number of times that [`TimeContext::tick()`](struct.TimeContext.html#method.tick)
 /// has been called by it.
+#[deprecated(note = "Use `Context::timer_context.ticks` instead")]
 pub fn ticks(ctx: &Context) -> usize {
     ctx.timer_context.frame_count
 }


### PR DESCRIPTION
Deprecates the old free functions and uses the subcontexts directly, as mentioned in #1012 and discussed in the Matrix room. WIP.

Note: The graphical context hasn't been refactored since the changes would be overwritten by the WGPU PR anyways.