### PR TITLE
Provide access to keyboard scancodes

### DIFF
--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -19,7 +19,7 @@ use oorandom::Rand32;
 
 // Next we need to actually `use` the pieces of ggez that we are going
 // to need frequently.
-use ggez::event::{KeyCode, KeyMods};
+use ggez::event::{KeyCode, KeyMods, ScanCode};
 use ggez::{event, graphics, Context, GameResult};
 
 // We'll bring in some things from `std` to help us in the future.
@@ -433,13 +433,14 @@ impl event::EventHandler<ggez::GameError> for GameState {
     fn key_down_event(
         &mut self,
         _ctx: &mut Context,
-        keycode: KeyCode,
+        _scancode: ScanCode,
+        keycode: Option<KeyCode>,
         _keymod: KeyMods,
         _repeat: bool,
     ) -> GameResult {
         // Here we attempt to convert the Keycode into a Direction using the helper
         // we defined earlier.
-        if let Some(dir) = Direction::from_keycode(keycode) {
+        if let Some(dir) = keycode.and_then(Direction::from_keycode) {
             // If it succeeds, we check if a new direction has already been set
             // and make sure the new direction is different then `snake.dir`
             if self.snake.dir != self.snake.last_update_dir && dir.inverse() != self.snake.dir {

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -5,7 +5,7 @@
 use ggez::audio;
 use ggez::audio::SoundSource;
 use ggez::conf;
-use ggez::event::{self, EventHandler, KeyCode, KeyMods};
+use ggez::event::{self, EventHandler, KeyCode, KeyMods, ScanCode};
 use ggez::graphics::{self, Color};
 use ggez::timer;
 use ggez::{Context, ContextBuilder, GameResult};
@@ -543,29 +543,30 @@ impl EventHandler for MainState {
     fn key_down_event(
         &mut self,
         ctx: &mut Context,
-        keycode: KeyCode,
+        _scancode: ScanCode,
+        keycode: Option<KeyCode>,
         _keymod: KeyMods,
         _repeat: bool,
     ) -> GameResult {
         match keycode {
-            KeyCode::Up => {
+            Some(KeyCode::Up) => {
                 self.input.yaxis = 1.0;
             }
-            KeyCode::Left => {
+            Some(KeyCode::Left) => {
                 self.input.xaxis = -1.0;
             }
-            KeyCode::Right => {
+            Some(KeyCode::Right) => {
                 self.input.xaxis = 1.0;
             }
-            KeyCode::Space => {
+            Some(KeyCode::Space) => {
                 self.input.fire = true;
             }
-            KeyCode::P => {
+            Some(KeyCode::P) => {
                 let img = graphics::screenshot(ctx).expect("Could not take screenshot");
                 img.encode(ctx, graphics::ImageFormat::Png, "/screenshot.png")
                     .expect("Could not save screenshot");
             }
-            KeyCode::Escape => event::quit(ctx),
+            Some(KeyCode::Escape) => event::quit(ctx),
             _ => (), // Do nothing
         }
         Ok(())
@@ -574,17 +575,18 @@ impl EventHandler for MainState {
     fn key_up_event(
         &mut self,
         _ctx: &mut Context,
-        keycode: KeyCode,
+        _scancode: ScanCode,
+        keycode: Option<KeyCode>,
         _keymod: KeyMods,
     ) -> GameResult {
         match keycode {
-            KeyCode::Up => {
+            Some(KeyCode::Up) => {
                 self.input.yaxis = 0.0;
             }
-            KeyCode::Left | KeyCode::Right => {
+            Some(KeyCode::Left | KeyCode::Right) => {
                 self.input.xaxis = 0.0;
             }
-            KeyCode::Space => {
+            Some(KeyCode::Space) => {
                 self.input.fire = false;
             }
             _ => (), // Do nothing

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -311,34 +311,35 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn key_down_event(
         &mut self,
         _ctx: &mut Context,
-        keycode: ggez::input::keyboard::KeyCode,
+        _scancode: ggez::input::keyboard::ScanCode,
+        keycode: Option<ggez::input::keyboard::KeyCode>,
         _keymods: ggez::input::keyboard::KeyMods,
         _repeat: bool,
     ) -> GameResult {
         const DELTA: f32 = 0.2;
         match keycode {
-            KeyCode::Up | KeyCode::Down => {
+            Some(KeyCode::Up | KeyCode::Down) => {
                 // easing change
                 let new_easing_enum = new_enum_after_key(
                     &self.easing_enum,
                     &EasingEnum::EaseInOut3Point,
                     &KeyCode::Down,
                     &KeyCode::Up,
-                    &keycode,
+                    &keycode.unwrap(),
                 );
 
                 if self.easing_enum != new_easing_enum {
                     self.easing_enum = new_easing_enum;
                 }
             }
-            KeyCode::Left | KeyCode::Right => {
+            Some(KeyCode::Left | KeyCode::Right) => {
                 // animation change
                 let new_animation_type = new_enum_after_key(
                     &self.animation_type,
                     &AnimationType::Crawl,
                     &KeyCode::Left,
                     &KeyCode::Right,
-                    &keycode,
+                    &keycode.unwrap(),
                 );
 
                 if self.animation_type != new_animation_type {
@@ -346,10 +347,10 @@ impl event::EventHandler<ggez::GameError> for MainState {
                 }
             }
             // duration change
-            KeyCode::W => {
+            Some(KeyCode::W) => {
                 self.duration += DELTA;
             }
-            KeyCode::S => {
+            Some(KeyCode::S) => {
                 if self.duration - DELTA > 0.1 {
                     self.duration -= DELTA;
                 }

--- a/examples/blend_modes.rs
+++ b/examples/blend_modes.rs
@@ -178,7 +178,8 @@ impl EventHandler for MainState {
     fn key_down_event(
         &mut self,
         _ctx: &mut Context,
-        _keycode: ggez::event::KeyCode,
+        _scancode: ggez::event::ScanCode,
+        _keycode: Option<ggez::event::KeyCode>,
         _keymod: ggez::event::KeyMods,
         repeat: bool,
     ) -> GameResult {

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -144,11 +144,12 @@ impl event::EventHandler<ggez::GameError> for GameState {
     fn key_down_event(
         &mut self,
         _ctx: &mut Context,
-        keycode: event::KeyCode,
+        _scancode: event::ScanCode,
+        keycode: Option<event::KeyCode>,
         _keymods: event::KeyMods,
         _repeat: bool,
     ) -> GameResult {
-        if keycode == event::KeyCode::Space {
+        if keycode == Some(event::KeyCode::Space) {
             self.batched_drawing = !self.batched_drawing;
         }
         Ok(())

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -5,7 +5,7 @@
 use std::convert::TryFrom;
 
 use ggez::conf;
-use ggez::event::{self, KeyCode, KeyMods};
+use ggez::event::{self, KeyCode, KeyMods, ScanCode};
 use ggez::graphics::{self, Color, DrawMode, DrawParam};
 use ggez::{Context, GameResult};
 
@@ -134,15 +134,16 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn key_up_event(
         &mut self,
         ctx: &mut Context,
-        keycode: KeyCode,
+        _scancode: ScanCode,
+        keycode: Option<KeyCode>,
         _keymod: KeyMods,
     ) -> GameResult {
         match keycode {
-            KeyCode::F => {
+            Some(KeyCode::F) => {
                 self.window_settings.toggle_fullscreen = true;
                 self.window_settings.is_fullscreen = !self.window_settings.is_fullscreen;
             }
-            KeyCode::Up => {
+            Some(KeyCode::Up) => {
                 self.zoom += 0.1;
                 println!("Zoom is now {}", self.zoom);
                 let (w, h) = graphics::size(ctx);
@@ -150,7 +151,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
                     graphics::Rect::new(0.0, 0.0, w as f32 * self.zoom, h as f32 * self.zoom);
                 graphics::set_screen_coordinates(ctx, new_rect).unwrap();
             }
-            KeyCode::Down => {
+            Some(KeyCode::Down) => {
                 self.zoom -= 0.1;
                 println!("Zoom is now {}", self.zoom);
                 let (w, h) = graphics::size(ctx);
@@ -158,7 +159,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
                     graphics::Rect::new(0.0, 0.0, w as f32 * self.zoom, h as f32 * self.zoom);
                 graphics::set_screen_coordinates(ctx, new_rect).unwrap();
             }
-            KeyCode::Space => {
+            Some(KeyCode::Space) => {
                 self.window_settings.resize_projection = !self.window_settings.resize_projection;
                 println!(
                     "Resizing the projection on window resize is now: {}",

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -90,7 +90,8 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn key_down_event(
         &mut self,
         _ctx: &mut Context,
-        _keycode: ggez::event::KeyCode,
+        _scancode: ggez::event::ScanCode,
+        _keycode: Option<ggez::event::KeyCode>,
         _keymod: ggez::event::KeyMods,
         repeat: bool,
     ) -> GameResult {

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -1,6 +1,6 @@
 //! Example that just prints out all the input events.
 
-use ggez::event::{self, Axis, Button, GamepadId, KeyCode, KeyMods, MouseButton};
+use ggez::event::{self, Axis, Button, GamepadId, KeyCode, KeyMods, MouseButton, ScanCode};
 use ggez::graphics::{self, Color, DrawMode};
 use ggez::{conf, input};
 use ggez::{Context, GameResult};
@@ -119,13 +119,14 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn key_down_event(
         &mut self,
         _ctx: &mut Context,
-        keycode: KeyCode,
+        scancode: ScanCode,
+        keycode: Option<KeyCode>,
         keymod: KeyMods,
         repeat: bool,
     ) -> GameResult {
         println!(
-            "Key pressed: {:?}, modifier {:?}, repeat: {}",
-            keycode, keymod, repeat
+            "Key pressed: scancode {}, keycode {:?}, modifier {:?}, repeat: {}",
+            scancode, keycode, keymod, repeat
         );
         Ok(())
     }
@@ -133,10 +134,14 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn key_up_event(
         &mut self,
         _ctx: &mut Context,
-        keycode: KeyCode,
+        scancode: ScanCode,
+        keycode: Option<KeyCode>,
         keymod: KeyMods,
     ) -> GameResult {
-        println!("Key released: {:?}, modifier {:?}", keycode, keymod);
+        println!(
+            "Key released: scancode {}, keycode {:?}, modifier {:?}",
+            scancode, keycode, keymod
+        );
         Ok(())
     }
 

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -9,7 +9,7 @@
 use log::*;
 
 use ggez::conf::{WindowMode, WindowSetup};
-use ggez::event::{EventHandler, KeyCode, KeyMods};
+use ggez::event::{EventHandler, KeyCode, KeyMods, ScanCode};
 use ggez::filesystem::File;
 use ggez::graphics;
 use ggez::timer;
@@ -100,7 +100,8 @@ impl EventHandler for App {
     fn key_down_event(
         &mut self,
         ctx: &mut Context,
-        keycode: KeyCode,
+        _scancode: ScanCode,
+        keycode: Option<KeyCode>,
         keymod: KeyMods,
         repeat: bool,
     ) -> GameResult {
@@ -109,7 +110,7 @@ impl EventHandler for App {
             "Key down event: {:?}, modifiers: {:?}, repeat: {}",
             keycode, keymod, repeat
         );
-        if keycode == KeyCode::Escape {
+        if keycode == Some(KeyCode::Escape) {
             // Escape key closes the app.
             ggez::event::quit(ctx);
         }

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -94,18 +94,19 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn key_down_event(
         &mut self,
         ctx: &mut Context,
-        keycode: input::keyboard::KeyCode,
+        _scancode: input::keyboard::ScanCode,
+        keycode: Option<input::keyboard::KeyCode>,
         _keymod: input::keyboard::KeyMods,
         _repeat: bool,
     ) -> GameResult {
         match keycode {
-            input::keyboard::KeyCode::Key1 => self.play_detached(ctx),
-            input::keyboard::KeyCode::Key2 => self.play_later(ctx),
-            input::keyboard::KeyCode::Key3 => self.play_fadein(ctx),
-            input::keyboard::KeyCode::Key4 => self.play_highpitch(ctx),
-            input::keyboard::KeyCode::Key5 => self.play_lowpitch(ctx),
-            input::keyboard::KeyCode::Key6 => self.play_stats(ctx),
-            input::keyboard::KeyCode::Escape => event::quit(ctx),
+            Some(input::keyboard::KeyCode::Key1) => self.play_detached(ctx),
+            Some(input::keyboard::KeyCode::Key2) => self.play_later(ctx),
+            Some(input::keyboard::KeyCode::Key3) => self.play_fadein(ctx),
+            Some(input::keyboard::KeyCode::Key4) => self.play_highpitch(ctx),
+            Some(input::keyboard::KeyCode::Key5) => self.play_lowpitch(ctx),
+            Some(input::keyboard::KeyCode::Key6) => self.play_stats(ctx),
+            Some(input::keyboard::KeyCode::Escape) => event::quit(ctx),
             _ => (),
         }
         Ok(())

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -1,5 +1,5 @@
 //! Demonstrates various projection and matrix fiddling/testing.
-use ggez::event::{self, KeyCode, KeyMods};
+use ggez::event::{self, KeyCode, KeyMods, ScanCode};
 use ggez::graphics::{self, Color, DrawMode};
 use ggez::{Context, GameResult};
 use glam::*;
@@ -105,11 +105,12 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn key_down_event(
         &mut self,
         ctx: &mut Context,
-        keycode: KeyCode,
+        _scancode: ScanCode,
+        keycode: Option<KeyCode>,
         _keymod: KeyMods,
         _repeat: bool,
     ) -> GameResult {
-        if let event::KeyCode::Space = keycode {
+        if let Some(event::KeyCode::Space) = keycode {
             self.screen_bounds_idx = (self.screen_bounds_idx + 1) % self.screen_bounds.len();
             return graphics::set_screen_coordinates(
                 ctx,

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -69,6 +69,7 @@ use crate::context::Context;
 
 use std::collections::HashSet;
 use winit::event::ModifiersState;
+pub use winit::event::ScanCode;
 /// A key code.
 pub use winit::event::VirtualKeyCode as KeyCode;
 


### PR DESCRIPTION
Not sure if this is something that ggez would like, but opening this MR because it's something I've needed for my project.

Basically, this exposes the winit scancodes to the EventHandler should the developer want access to them. They can use these codes to implement support for non US QWERTY keyboards.

Have added it as a seperate event hook so that existing code and guides can use the "simple" function in case they don't need scancodes.

I'm also not a keyboard expert, so there's probably much better ways to go about doing this!

===

Extend the EventHandler trait to include key up/down events that have a
scancode. This can be used by developers to have layout-independant key
bindings.