### PR TITLE
Improve sub-context passing ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ impl EventHandler for MyGame {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::WHITE);
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::WHITE);
         // Draw code here...
-        canvas.finish(&mut ctx.gfx)
+        canvas.finish(ctx)
     }
 }
 ```

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -25,6 +25,7 @@
 * **[Miscellaneous](#misc)**
   * [How do I load my `conf.toml` file?](#misc_conf)
   * [I get a console window when I launch my executable on Windows](#misc_win_console)
+  * [What is this `Has<GraphicsContext>` parameter?](#has_parameter)
 
 ---
 
@@ -120,7 +121,7 @@ graphics::set_screen_coordinates(&mut context, Rect::new(0.0, 0.0, 1.0, 1.0)).un
 ```
 
 and scaling your `Image`s with `graphics::DrawParam`.
- 
+
 Please note that updating your coordinate system like this may also
 be necessary [when drawing onto canvases of custom sizes](https://github.com/ggez/ggez/blob/aed56921fbca8ac8192b492f0a46d92e4a0a95bb/src/graphics/canvas.rs#L44-L48).
 
@@ -196,7 +197,7 @@ When created, a window starts out with a coordinate system perfectly
 corresponding to its physical size in pixels. That's why, initially,
 translating mouse coordinates to logical coordinates is not necessary
 at all. Both systems are just the same.
- 
+
 But once physical and logical coordinates get out of sync problems
 start to arise. If you want more info on how to navigate this issue
 take a look at the [`input_test`](../examples/input_test.rs) and [`graphics_settings`](../examples/graphics_settings.rs) examples.
@@ -228,11 +229,11 @@ provides types for other math libraries to convert to and from with.
 What you are supposed to do is to add a math library of your choice to
 your game such as glam or nalgebra, usually with a "mint" feature.  For
 example. You can add
- 
+
  ```rust
  glam = { version = "0.15.2", features = ["mint"] }
  ```
- 
+
  in your Cargo.toml, then when you try to pass
 something to, say `DrawParam::new().dest(my_point)`, you will
 be able to pass a glam type like
@@ -404,3 +405,15 @@ If you wish, you can also disable it only in release mode:
 ```
 
 [`egui`]: https://github.com/emilk/egui#integrations
+
+<a name="has_parameter">
+
+## What is this `Has` parameter?
+
+You may notice a lot of methods taking a `gfx: &impl Has<GraphicsContext>` parameter or `ctxs: &impl HasTwo<GraphicsContext, Filesystem>`, what is up with that?
+
+Since version 0.8, we support split borrowing the sub-contexts. **This is not useful for most users so you may just pass `ctx` to any parameter taking `Has`**. If you want to perform a split-borrow:
+
+You may pass `&ctx.gfx` for `gfx: &impl Has<GraphicsContext>`
+
+Or you may pass it like `&(&ctx.gfx, &ctx.fs)` for `ctxs: &impl HasTwo<GraphicsContext, Filesystem>`

--- a/docs/guides/GenerativeArt.md
+++ b/docs/guides/GenerativeArt.md
@@ -74,7 +74,7 @@ Geometry, it's all coming back now.
 Here is the code for a [circle](https://docs.rs/ggez/0.7.0/ggez/graphics/struct.Mesh.html#method.new_circle):
 ```rust,skt-expression,no_run
 graphics::Mesh::new_circle(
-    &ctx.gfx,
+    ctx,
     graphics::DrawMode::fill(),
     mint::Point2{x: 200.0, y: 300.0},
     100.0,
@@ -109,19 +109,19 @@ To draw it, we first need to create our `Canvas`, filling it with black. Then we
 drawing the circle onto it. Lastly, we submit this draw call.
 ```rust,skt-draw,no_run
 fn draw(&mut self, ctx: &mut Context) -> GameResult {
-    let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, graphics::Color::BLACK);
-    
+    let mut canvas = graphics::Canvas::from_frame(ctx, graphics::Color::BLACK);
+
     let circle = graphics::Mesh::new_circle(
-        &ctx.gfx,
+        ctx,
         graphics::DrawMode::fill(),
         mint::Point2{x: 200.0, y: 300.0},
         100.0,
         0.1,
         graphics::Color::WHITE,
     )?;
-    
+
     canvas.draw(&circle, graphics::DrawParam::default());
-    canvas.finish(&mut ctx.gfx)?;
+    canvas.finish(ctx)?;
     Ok(())
 }
 ```
@@ -135,7 +135,7 @@ Rectangles are represented by 3 pieces of information: origin, width, and height
 Here is the code for a [rectangle](https://docs.rs/ggez/0.7.0/ggez/graphics/struct.Mesh.html#method.new_rectangle):
 ```rust,skt-expression,no_run
 graphics::Mesh::new_rectangle(
-    &ctx.gfx,
+    ctx,
     graphics::DrawMode::fill(),
     graphics::Rect::new(500.0, 250.0, 200.0, 100.0),
     graphics::Color::WHITE,
@@ -156,17 +156,17 @@ And that's how a rectangle is created!
 Let's try it out with some quick code:
 ```rust,skt-draw,no_run
 fn draw(&mut self, ctx: &mut Context) -> GameResult {
-    let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, graphics::Color::BLACK);
-    
+    let mut canvas = graphics::Canvas::from_frame(ctx, graphics::Color::BLACK);
+
     let rect = graphics::Mesh::new_rectangle(
-        &ctx.gfx,
+        ctx,
         graphics::DrawMode::fill(),
         graphics::Rect::new(500.0, 250.0, 200.0, 100.0),
         graphics::Color::WHITE,
     )?;
-    
+
     canvas.draw(&rect, graphics::DrawParam::default());
-    canvas.finish(&mut ctx.gfx)?;
+    canvas.finish(ctx)?;
     Ok(())
 }
 ```
@@ -234,13 +234,13 @@ But we still don't see anything...
 You need to modify `draw` to illustrate your new `State`.
 ```rust,skt-draw,no_run
 fn draw(&mut self, ctx: &mut Context) -> GameResult {
-    let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, graphics::Color::BLACK);
+    let mut canvas = graphics::Canvas::from_frame(ctx, graphics::Color::BLACK);
     for shape in &self.shapes {
         // Make the shape...
         let mesh = match shape {
             &Shape::Rectangle(rect) => {
                 graphics::Mesh::new_rectangle(
-                    &ctx.gfx,
+                    ctx,
                     graphics::DrawMode::fill(),
                     rect,
                     graphics::Color::WHITE
@@ -248,7 +248,7 @@ fn draw(&mut self, ctx: &mut Context) -> GameResult {
             }
             &Shape::Circle(origin, radius) => {
                 graphics::Mesh::new_circle(
-                    &ctx.gfx,
+                    ctx,
                     graphics::DrawMode::fill(),
                     origin,
                     radius,
@@ -261,7 +261,7 @@ fn draw(&mut self, ctx: &mut Context) -> GameResult {
         // ...and then draw it.
         canvas.draw(&mesh, graphics::DrawParam::default());
     }
-    canvas.finish(&mut ctx.gfx)?;
+    canvas.finish(ctx)?;
     Ok(())
 }
 ```

--- a/examples/01_super_simple.rs
+++ b/examples/01_super_simple.rs
@@ -16,7 +16,7 @@ struct MainState {
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         let circle = graphics::Mesh::new_circle(
-            &ctx.gfx,
+            ctx,
             graphics::DrawMode::fill(),
             vec2(0., 0.),
             100.0,
@@ -36,13 +36,13 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         let mut canvas = graphics::Canvas::from_frame(
-            &ctx.gfx,
+            ctx,
             graphics::CanvasLoadOp::Clear([0.1, 0.2, 0.3, 1.0].into()),
         );
 
         canvas.draw(&self.circle, Vec2::new(self.pos_x, 380.0));
 
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         Ok(())
     }

--- a/examples/02_hello_world.rs
+++ b/examples/02_hello_world.rs
@@ -12,7 +12,7 @@ impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         ctx.gfx.add_font(
             "LiberationMono",
-            graphics::FontData::from_path(&ctx.fs, "/LiberationMono-Regular.ttf")?,
+            graphics::FontData::from_path(ctx, "/LiberationMono-Regular.ttf")?,
         );
 
         let s = MainState { frames: 0 };
@@ -32,7 +32,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         let mut canvas = graphics::Canvas::from_frame(
-            &ctx.gfx,
+            ctx,
             graphics::CanvasLoadOp::Clear([0.1, 0.2, 0.3, 1.0].into()),
         );
 
@@ -46,7 +46,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             dest_point,
         );
 
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         self.frames += 1;
         if (self.frames % 100) == 0 {

--- a/examples/03_drawing.rs
+++ b/examples/03_drawing.rs
@@ -19,8 +19,8 @@ struct MainState {
 impl MainState {
     /// Load images and create meshes.
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let image1 = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/dragon1.png", true)?;
-        let image2 = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/shot.png", true)?;
+        let image1 = graphics::Image::from_path(ctx, "/dragon1.png", true)?;
+        let image2 = graphics::Image::from_path(ctx, "/shot.png", true)?;
 
         let mb = &mut graphics::MeshBuilder::new();
         mb.rectangle(
@@ -29,14 +29,14 @@ impl MainState {
             graphics::Color::new(1.0, 0.0, 0.0, 1.0),
         )?;
 
-        let rock = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/rock.png", true)?;
+        let rock = graphics::Image::from_path(ctx, "/rock.png", true)?;
 
         let meshes = vec![
             (None, build_mesh(ctx)?),
             (Some(rock), build_textured_triangle(ctx)?),
         ];
 
-        let rect = graphics::Mesh::from_data(&ctx.gfx, mb.build());
+        let rect = graphics::Mesh::from_data(ctx, mb.build());
 
         let s = MainState {
             image1,
@@ -82,7 +82,7 @@ fn build_mesh(ctx: &mut Context) -> GameResult<graphics::Mesh> {
         Color::new(1.0, 0.0, 1.0, 1.0),
     )?;
 
-    Ok(graphics::Mesh::from_data(&ctx.gfx, mb.build()))
+    Ok(graphics::Mesh::from_data(ctx, mb.build()))
 }
 
 fn build_textured_triangle(ctx: &mut Context) -> GameResult<graphics::Mesh> {
@@ -107,7 +107,7 @@ fn build_textured_triangle(ctx: &mut Context) -> GameResult<graphics::Mesh> {
     let triangle_indices = vec![0, 1, 2];
 
     Ok(graphics::Mesh::from_data(
-        &ctx.gfx,
+        ctx,
         graphics::MeshData {
             vertices: &triangle_verts,
             indices: &triangle_indices,
@@ -128,7 +128,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         let mut canvas = graphics::Canvas::from_frame(
-            &ctx.gfx,
+            ctx,
             graphics::CanvasLoadOp::Clear([0.1, 0.2, 0.3, 1.0].into()),
         );
 
@@ -186,7 +186,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
         }
 
         // Finished drawing, show it all on the screen!
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         Ok(())
     }

--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -417,7 +417,7 @@ impl event::EventHandler<ggez::GameError> for GameState {
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         // First we create a canvas that renders to the frame, and clear it to a (sort of) green color
         let mut canvas = graphics::Canvas::from_frame(
-            &ctx.gfx,
+            ctx,
             graphics::CanvasLoadOp::Clear([0.0, 1.0, 0.0, 1.0].into()),
         );
 
@@ -428,7 +428,7 @@ impl event::EventHandler<ggez::GameError> for GameState {
         // Finally, we "flush" the draw commands.
         // Since we rendered to the frame, we don't need to tell ggez to present anything else,
         // as ggez will automatically present the frame image unless told otherwise.
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         // We yield the current thread until the next update
         ggez::timer::yield_now();

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -244,12 +244,12 @@ struct Assets {
 
 impl Assets {
     fn new(ctx: &mut Context) -> GameResult<Assets> {
-        let player_image = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/player.png", true)?;
-        let shot_image = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/shot.png", true)?;
-        let rock_image = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/rock.png", true)?;
+        let player_image = graphics::Image::from_path(ctx, "/player.png", true)?;
+        let shot_image = graphics::Image::from_path(ctx, "/shot.png", true)?;
+        let rock_image = graphics::Image::from_path(ctx, "/rock.png", true)?;
 
-        let shot_sound = audio::Source::new(&ctx.fs, &ctx.audio, "/pew.ogg")?;
-        let hit_sound = audio::Source::new(&ctx.fs, &ctx.audio, "/boom.ogg")?;
+        let shot_sound = audio::Source::new(ctx, "/pew.ogg")?;
+        let hit_sound = audio::Source::new(ctx, "/boom.ogg")?;
 
         Ok(Assets {
             player_image,
@@ -335,7 +335,7 @@ impl MainState {
 
         let (width, height) = ctx.gfx.drawable_size();
         let screen =
-            graphics::ScreenImage::new(&ctx.gfx, graphics::ImageFormat::Rgba8UnormSrgb, 1., 1., 1);
+            graphics::ScreenImage::new(ctx, graphics::ImageFormat::Rgba8UnormSrgb, 1., 1., 1);
 
         let s = MainState {
             screen,
@@ -367,7 +367,7 @@ impl MainState {
 
         self.shots.push(shot);
 
-        self.assets.shot_sound.play(&ctx.audio)?;
+        self.assets.shot_sound.play(ctx)?;
 
         Ok(())
     }
@@ -390,7 +390,7 @@ impl MainState {
                     rock.life = 0.0;
                     self.score += 1;
 
-                    self.assets.hit_sound.play(&ctx.audio)?;
+                    self.assets.hit_sound.play(ctx)?;
                 }
             }
         }
@@ -501,8 +501,7 @@ impl EventHandler for MainState {
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         // Our drawing is quite simple.
         // Just clear the screen...
-        let mut canvas =
-            graphics::Canvas::from_screen_image(&ctx.gfx, &mut self.screen, Color::BLACK);
+        let mut canvas = graphics::Canvas::from_screen_image(ctx, &mut self.screen, Color::BLACK);
 
         // Loop over all objects drawing them...
         {
@@ -538,8 +537,8 @@ impl EventHandler for MainState {
             graphics::DrawParam::from(score_dest).color(Color::WHITE),
         );
 
-        canvas.finish(&mut ctx.gfx)?;
-        ctx.gfx.present(&self.screen.image(&ctx.gfx))?;
+        canvas.finish(ctx)?;
+        ctx.gfx.present(&self.screen.image(ctx))?;
 
         // And yield the timeslice
         // This tells the OS that we're done using the CPU but it should
@@ -574,7 +573,7 @@ impl EventHandler for MainState {
                 self.input.fire = true;
             }
             KeyCode::P => {
-                self.screen.image(&ctx.gfx).encode(
+                self.screen.image(ctx).encode(
                     ctx,
                     graphics::ImageEncodingFormat::Png,
                     "/screenshot.png",

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -226,7 +226,7 @@ fn player_sequence(
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         let ball = graphics::Mesh::new_circle(
-            &ctx.gfx,
+            ctx,
             graphics::DrawMode::fill(),
             Vec2::new(0.0, 0.0),
             60.0,
@@ -234,7 +234,7 @@ impl MainState {
             Color::WHITE,
         )?;
 
-        let img = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/player_sheet.png", true)?;
+        let img = graphics::Image::from_path(ctx, "/player_sheet.png", true)?;
         let s = MainState {
             ball,
             spritesheet: img,
@@ -266,7 +266,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::from([0.1, 0.2, 0.3, 1.0]));
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::from([0.1, 0.2, 0.3, 1.0]));
 
         canvas.set_sampler(graphics::Sampler::nearest_clamp()); // because pixel art
 
@@ -303,7 +303,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
                 .offset([0.5, 1.0]),
         );
 
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         Ok(())
     }

--- a/examples/blend_modes.rs
+++ b/examples/blend_modes.rs
@@ -5,6 +5,7 @@
 //! using the `Premultiplied` blend mode
 //! (for more explanations on this see https://github.com/ggez/ggez/issues/694#issuecomment-853724926)
 
+use ggez::context::HasMut;
 use ggez::event::{self, EventHandler};
 use ggez::graphics::{self, BlendMode, Color, DrawParam, GraphicsContext};
 use ggez::{Context, GameResult};
@@ -41,7 +42,7 @@ impl MainState {
 
     fn draw_venn(
         &self,
-        _gfx: &mut GraphicsContext,
+        _gfx: &mut impl HasMut<GraphicsContext>,
         canvas: &mut graphics::Canvas,
         pos: Vec2,
         name: &str,
@@ -86,7 +87,7 @@ impl MainState {
 
     fn draw_venn_diagrams(
         &mut self,
-        gfx: &mut GraphicsContext,
+        ctx: &mut Context,
         (w, h): (f32, f32),
         canvas: &mut graphics::Canvas,
     ) -> GameResult<()> {
@@ -96,35 +97,35 @@ impl MainState {
 
         // draw with Alpha
         canvas.set_blend_mode(BlendMode::ALPHA);
-        self.draw_venn(gfx, canvas, [x_step, y].into(), "Alpha")?;
+        self.draw_venn(ctx, canvas, [x_step, y].into(), "Alpha")?;
 
         // draw with Add
         canvas.set_blend_mode(BlendMode::ADD);
-        self.draw_venn(gfx, canvas, [x_step * 2., y].into(), "Add")?;
+        self.draw_venn(ctx, canvas, [x_step * 2., y].into(), "Add")?;
 
         // draw with Sub
         canvas.set_blend_mode(BlendMode::SUBTRACT);
-        self.draw_venn(gfx, canvas, [x_step * 3., y].into(), "Subtract")?;
+        self.draw_venn(ctx, canvas, [x_step * 3., y].into(), "Subtract")?;
 
         // draw with Multiply
         canvas.set_blend_mode(BlendMode::MULTIPLY);
-        self.draw_venn(gfx, canvas, [x_step * 4., y].into(), "Multiply")?;
+        self.draw_venn(ctx, canvas, [x_step * 4., y].into(), "Multiply")?;
 
         // draw with Invert
         canvas.set_blend_mode(BlendMode::INVERT);
-        self.draw_venn(gfx, canvas, [x_step * 5., y].into(), "Invert")?;
+        self.draw_venn(ctx, canvas, [x_step * 5., y].into(), "Invert")?;
 
         // draw with Replace
         canvas.set_blend_mode(BlendMode::REPLACE);
-        self.draw_venn(gfx, canvas, [x_step * 6., y].into(), "Replace")?;
+        self.draw_venn(ctx, canvas, [x_step * 6., y].into(), "Replace")?;
 
         // draw with Darken
         canvas.set_blend_mode(BlendMode::DARKEN);
-        self.draw_venn(gfx, canvas, [x_step * 7., y].into(), "Darken")?;
+        self.draw_venn(ctx, canvas, [x_step * 7., y].into(), "Darken")?;
 
         // draw with Lighten
         canvas.set_blend_mode(BlendMode::LIGHTEN);
-        self.draw_venn(gfx, canvas, [x_step * 8., y].into(), "Lighten")?;
+        self.draw_venn(ctx, canvas, [x_step * 8., y].into(), "Lighten")?;
 
         Ok(())
     }

--- a/examples/blend_modes.rs
+++ b/examples/blend_modes.rs
@@ -20,10 +20,10 @@ struct MainState {
 
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let layer = graphics::ScreenImage::new(&ctx.gfx, None, 1., 1., 1);
+        let layer = graphics::ScreenImage::new(ctx, None, 1., 1., 1);
 
         let circle = graphics::Mesh::new_circle(
-            &ctx.gfx,
+            ctx,
             graphics::DrawMode::fill(),
             Vec2::new(0.0, 0.0),
             45.0,
@@ -139,17 +139,17 @@ impl EventHandler for MainState {
         let (w, h) = ctx.gfx.drawable_size();
 
         // draw everything onto self.layer
-        let layer = self.layer.image(&ctx.gfx);
+        let layer = self.layer.image(ctx);
         let mut canvas =
-            graphics::Canvas::from_image(&ctx.gfx, layer.clone(), Color::new(0., 0., 0., 0.));
-        self.draw_venn_diagrams(&mut ctx.gfx, (w, h), &mut canvas)?;
-        canvas.finish(&mut ctx.gfx)?;
+            graphics::Canvas::from_image(ctx, layer.clone(), Color::new(0., 0., 0., 0.));
+        self.draw_venn_diagrams(ctx, (w, h), &mut canvas)?;
+        canvas.finish(ctx)?;
 
         // now start drawing to the screen
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::new(0.3, 0.3, 0.3, 1.0));
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::new(0.3, 0.3, 0.3, 1.0));
 
         // draw everything directly onto the screen once
-        self.draw_venn_diagrams(&mut ctx.gfx, (w, h), &mut canvas)?;
+        self.draw_venn_diagrams(ctx, (w, h), &mut canvas)?;
 
         // draw layer onto the screen
         canvas.set_blend_mode(self.layer_blend);
@@ -170,7 +170,7 @@ impl EventHandler for MainState {
             graphics::DrawParam::from([8., 4. + y]).color(Color::WHITE),
         );
 
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         Ok(())
     }

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -52,7 +52,7 @@ impl GameState {
     fn new(ctx: &mut Context) -> ggez::GameResult<GameState> {
         // We just use the same RNG seed every time.
         let mut rng = Rand32::new(12345);
-        let texture = Image::from_path(&ctx.fs, &ctx.gfx, "/wabbit_alpha.png", true)?;
+        let texture = Image::from_path(ctx, "/wabbit_alpha.png", true)?;
         let mut bunnies = Vec::with_capacity(INITIAL_BUNNIES);
         let max_x = (WIDTH - texture.width() as u16) as f32;
         let max_y = (HEIGHT - texture.height() as u16) as f32;
@@ -61,8 +61,7 @@ impl GameState {
             bunnies.push(Bunny::new(&mut rng));
         }
 
-        let bunnybatch =
-            InstanceArray::new(&ctx.gfx, texture.clone(), INITIAL_BUNNIES as u32, false);
+        let bunnybatch = InstanceArray::new(ctx, texture.clone(), INITIAL_BUNNIES as u32, false);
 
         Ok(GameState {
             rng,
@@ -114,7 +113,7 @@ impl event::EventHandler<ggez::GameError> for GameState {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::from((0.392, 0.584, 0.929)));
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::from((0.392, 0.584, 0.929)));
 
         if self.batched_drawing {
             self.bunnybatch.set(
@@ -140,7 +139,7 @@ impl event::EventHandler<ggez::GameError> for GameState {
             self.batched_drawing
         ));
 
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         Ok(())
     }

--- a/examples/canvas_subframe.rs
+++ b/examples/canvas_subframe.rs
@@ -21,9 +21,9 @@ struct MainState {
 
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let image = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/tile.png", true).unwrap();
-        let instances = graphics::InstanceArray::new(&ctx.gfx, image, 150 * 150, false);
-        let canvas_image = graphics::ScreenImage::new(&ctx.gfx, None, 1., 1., 1);
+        let image = graphics::Image::from_path(ctx, "/tile.png", true).unwrap();
+        let instances = graphics::InstanceArray::new(ctx, image, 150 * 150, false);
+        let canvas_image = graphics::ScreenImage::new(ctx, None, 1., 1., 1);
         let draw_pt = Point2::new(0.0, 0.0);
         let draw_vec = Vector2::new(1.0, 1.0);
         let s = MainState {
@@ -58,7 +58,7 @@ impl MainState {
         }));
 
         let mut canvas =
-            graphics::Canvas::from_screen_image(&ctx.gfx, &mut self.canvas_image, Color::WHITE);
+            graphics::Canvas::from_screen_image(ctx, &mut self.canvas_image, Color::WHITE);
 
         let param = graphics::DrawParam::new()
             .dest(Point2::new(
@@ -73,7 +73,7 @@ impl MainState {
             .offset(Point2::new(750., 750.));
 
         canvas.draw(&self.instances, param);
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         Ok(())
     }
@@ -101,8 +101,8 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         self.draw_spritebatch(ctx)?;
 
-        let canvas_image = self.canvas_image.image(&ctx.gfx);
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::from([0.1, 0.2, 0.3, 1.0]));
+        let canvas_image = self.canvas_image.image(ctx);
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::from([0.1, 0.2, 0.3, 1.0]));
 
         let src_x = self.draw_pt.x / canvas_image.width() as f32;
         let src_y = self.draw_pt.y / canvas_image.height() as f32;
@@ -115,7 +115,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
                 .scale([0.5, 0.5]),
         );
 
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         Ok(())
     }

--- a/examples/colorspace.rs
+++ b/examples/colorspace.rs
@@ -86,7 +86,7 @@ struct MainState {
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         let demo_mesh = graphics::Mesh::new_circle(
-            &ctx.gfx,
+            ctx,
             graphics::DrawMode::fill(),
             Vec2::new(0.0, 0.0),
             100.0,
@@ -94,15 +94,14 @@ impl MainState {
             AQUA,
         )?;
         let square_mesh = graphics::Mesh::new_rectangle(
-            &ctx.gfx,
+            ctx,
             graphics::DrawMode::fill(),
             graphics::Rect::new(0.0, 0.0, 400.0, 400.0),
             Color::WHITE,
         )?;
-        let demo_image = graphics::Image::from_solid(&ctx.gfx, 200, AQUA);
+        let demo_image = graphics::Image::from_solid(ctx, 200, AQUA);
 
-        let mut demo_instances =
-            graphics::InstanceArray::new(&ctx.gfx, demo_image.clone(), 2, false);
+        let mut demo_instances = graphics::InstanceArray::new(ctx, demo_image.clone(), 2, false);
         demo_instances.push(
             DrawParam::default()
                 .dest(Vec2::new(250.0, 350.0))
@@ -130,7 +129,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, AQUA);
+        let mut canvas = graphics::Canvas::from_frame(ctx, AQUA);
 
         // Draw a white square so we can see things
         canvas.draw(
@@ -166,7 +165,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             DrawParam::default().dest(Vec2::new(0.0, 0.0)),
         );
 
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         Ok(())
     }

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -208,7 +208,7 @@ impl MainState {
 
         // Create 1-pixel blue texture.
         let image =
-            graphics::Image::from_solid(&ctx.gfx, 1, graphics::Color::from_rgb(0x20, 0xA0, 0xC0));
+            graphics::Image::from_solid(ctx, 1, graphics::Color::from_rgb(0x20, 0xA0, 0xC0));
 
         let sampler = ctx
             .gfx
@@ -254,8 +254,7 @@ impl MainState {
                 ],
             });
 
-        let depth =
-            graphics::ScreenImage::new(&ctx.gfx, graphics::ImageFormat::Depth32Float, 1., 1., 1);
+        let depth = graphics::ScreenImage::new(ctx, graphics::ImageFormat::Depth32Float, 1., 1., 1);
 
         // FOV, spect ratio, znear, zfar
         let proj = Mat4::perspective_rh(f32::consts::PI / 4.0, 4.0 / 3.0, 1.0, 10.0);
@@ -293,7 +292,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
                 .queue
                 .write_buffer(&self.locals, 0, locals.as_std140().as_bytes());
 
-            let depth = self.depth.image(&ctx.gfx);
+            let depth = self.depth.image(ctx);
 
             let frame = ctx.gfx.frame().clone();
             let cmd = ctx.gfx.commands().unwrap();
@@ -327,7 +326,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             pass.draw_indexed(0..36, 0, 0..1);
         }
 
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, None);
+        let mut canvas = graphics::Canvas::from_frame(ctx, None);
 
         // Do ggez drawing
         let dest_point1 = Vec2::new(10.0, 210.0);
@@ -341,7 +340,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             dest_point2,
         );
 
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         self.frames += 1;
         if (self.frames % 10) == 0 {

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -67,13 +67,11 @@ pub fn main() -> GameResult {
                 // Draw
                 ctx.gfx.begin_frame().unwrap();
 
-                let mut canvas = graphics::Canvas::from_frame(
-                    &ctx.gfx,
-                    graphics::Color::from([0.1, 0.2, 0.3, 1.0]),
-                );
+                let mut canvas =
+                    graphics::Canvas::from_frame(ctx, graphics::Color::from([0.1, 0.2, 0.3, 1.0]));
 
                 let circle = graphics::Mesh::new_circle(
-                    &ctx.gfx,
+                    ctx,
                     DrawMode::fill(),
                     glam::Vec2::new(0.0, 0.0),
                     100.0,
@@ -83,7 +81,7 @@ pub fn main() -> GameResult {
                 .unwrap();
                 canvas.draw(&circle, glam::Vec2::new(position, 380.0));
 
-                canvas.finish(&mut ctx.gfx).unwrap();
+                canvas.finish(ctx).unwrap();
                 ctx.gfx.end_frame().unwrap();
 
                 // reset the mouse delta for the next frame

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -35,7 +35,7 @@ impl MainState {
         let s = MainState {
             angle: 0.0,
             zoom: 1.0,
-            image: graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/tile.png", true)?,
+            image: graphics::Image::from_path(ctx, "/tile.png", true)?,
             window_settings: WindowSettings {
                 toggle_fullscreen: false,
                 is_fullscreen: false,
@@ -72,7 +72,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::BLACK);
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::BLACK);
         canvas.set_screen_coordinates(self.screen_coords);
 
         canvas.draw(
@@ -84,7 +84,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
         let rotation = ctx.time.ticks() % 1000;
         let circle = graphics::Mesh::new_circle(
-            &ctx.gfx,
+            ctx,
             DrawMode::stroke(3.0),
             Point2::new(0.0, 0.0),
             100.0,
@@ -125,10 +125,10 @@ impl event::EventHandler<ggez::GameError> for MainState {
                 )?;
             }
         }
-        let mesh = graphics::Mesh::from_data(&ctx.gfx, mb.build());
+        let mesh = graphics::Mesh::from_data(ctx, mb.build());
         canvas.draw(&mesh, ggez::mint::Point2 { x: 0.0, y: 0.0 });
 
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         Ok(())
     }

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -20,9 +20,9 @@ impl MainState {
         // will mount that directory so we can omit it in the path here.
         ctx.gfx.add_font(
             "LiberationMono",
-            graphics::FontData::from_path(&ctx.fs, "/LiberationMono-Regular.ttf")?,
+            graphics::FontData::from_path(ctx, "/LiberationMono-Regular.ttf")?,
         );
-        let canvas_image = graphics::ScreenImage::new(&ctx.gfx, None, 1., 1., 1);
+        let canvas_image = graphics::ScreenImage::new(ctx, None, 1., 1., 1);
 
         let s = MainState {
             canvas_image,
@@ -48,9 +48,9 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
         if self.draw_with_canvas {
             println!("Drawing with canvas");
-            let canvas_image = self.canvas_image.image(&ctx.gfx);
+            let canvas_image = self.canvas_image.image(ctx);
             let mut canvas = graphics::Canvas::from_image(
-                &ctx.gfx,
+                ctx,
                 canvas_image.clone(),
                 graphics::Color::from((255, 255, 255, 128)),
             );
@@ -60,25 +60,24 @@ impl event::EventHandler<ggez::GameError> for MainState {
                 graphics::DrawParam::from(dest_point + vec2(15., 15.))
                     .color(Color::from((0, 0, 0, 255))),
             );
-            canvas.finish(&mut ctx.gfx)?;
+            canvas.finish(ctx)?;
 
-            let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::from((64, 0, 0, 0)));
+            let mut canvas = graphics::Canvas::from_frame(ctx, Color::from((64, 0, 0, 0)));
             canvas.draw(
                 &canvas_image,
                 graphics::DrawParam::new().color(Color::from((255, 255, 255, 128))),
             );
-            canvas.finish(&mut ctx.gfx)?;
+            canvas.finish(ctx)?;
         } else {
             println!("Drawing without canvas");
-            let mut canvas =
-                graphics::Canvas::from_frame(&ctx.gfx, Color::from([0.25, 0.0, 0.0, 1.0]));
+            let mut canvas = graphics::Canvas::from_frame(ctx, Color::from([0.25, 0.0, 0.0, 1.0]));
 
             canvas.draw(
                 &text,
                 graphics::DrawParam::from(dest_point).color(Color::from((192, 128, 64, 255))),
             );
 
-            canvas.finish(&mut ctx.gfx)?;
+            canvas.finish(ctx)?;
         }
 
         self.frames += 1;

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -34,7 +34,7 @@ impl MainState {
             mb.line(&[last_point, point], 3.0, color)?;
             last_point = point;
         }
-        let mesh = graphics::Mesh::from_data(&ctx.gfx, mb.build());
+        let mesh = graphics::Mesh::from_data(ctx, mb.build());
         canvas.draw(&mesh, glam::Vec2::new(0.0, 0.0));
 
         Ok(())
@@ -43,12 +43,12 @@ impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         ctx.fs.print_all();
 
-        let image = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/dragon1.png", true)?;
+        let image = graphics::Image::from_path(ctx, "/dragon1.png", true)?;
 
-        let mut sound = audio::Source::new(&ctx.fs, &ctx.audio, "/sound.ogg")?;
+        let mut sound = audio::Source::new(ctx, "/sound.ogg")?;
 
         // "detached" sounds keep playing even after they are dropped
-        let _ = sound.play_detached(&ctx.audio);
+        let _ = sound.play_detached(ctx);
 
         let rng = oorandom::Rand32::new(271828);
 
@@ -80,7 +80,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         let c = self.a as u8;
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::from([0.1, 0.2, 0.3, 1.0]));
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::from([0.1, 0.2, 0.3, 1.0]));
 
         let color = Color::from((c, c, c, 255));
         let dest_point = glam::Vec2::new(0.0, 0.0);
@@ -92,7 +92,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
         let dest_point2 = glam::Vec2::new(0.0, 256.0);
         let rectangle = graphics::Mesh::new_rectangle(
-            &ctx.gfx,
+            ctx,
             graphics::DrawMode::fill(),
             graphics::Rect::new(0.0, 256.0, 500.0, 32.0),
             Color::from((0, 0, 0, 255)),
@@ -104,7 +104,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
         );
 
         self.draw_crazy_lines(ctx, &mut canvas)?;
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
 
         timer::yield_now();
         Ok(())

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -41,9 +41,9 @@ impl event::EventHandler<ggez::GameError> for MainState {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::from([0.1, 0.2, 0.3, 1.0]));
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::from([0.1, 0.2, 0.3, 1.0]));
         let rectangle = graphics::Mesh::new_rectangle(
-            &ctx.gfx,
+            ctx,
             DrawMode::fill(),
             graphics::Rect {
                 x: self.pos_x,
@@ -54,7 +54,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             Color::WHITE,
         )?;
         canvas.draw(&rectangle, glam::Vec2::new(0.0, 0.0));
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
         Ok(())
     }
 

--- a/examples/instance_array.rs
+++ b/examples/instance_array.rs
@@ -17,8 +17,8 @@ struct MainState {
 
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let image = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/tile.png", true)?;
-        let instances = graphics::InstanceArray::new(&ctx.gfx, image, 150 * 150, false);
+        let image = graphics::Image::from_path(ctx, "/tile.png", true)?;
+        let instances = graphics::InstanceArray::new(ctx, image, 150 * 150, false);
         Ok(MainState { instances })
     }
 }
@@ -33,7 +33,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::BLACK);
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::BLACK);
 
         let time = (ctx.time.time_since_start().as_secs_f64() * 1000.0) as u32;
         let cycle = 10_000;
@@ -66,7 +66,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             .src(graphics::Rect::new(0.005, 0.005, 0.005, 0.005));
         canvas.draw(&self.instances, param);
 
-        canvas.finish(&mut ctx.gfx)
+        canvas.finish(ctx)
     }
 }
 

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -89,8 +89,8 @@ impl EventHandler for App {
 
     /// Draws the screen. We don't really have anything to draw.
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        graphics::Canvas::from_frame(&ctx.gfx, graphics::Color::from([0.1, 0.2, 0.3, 1.0]))
-            .finish(&mut ctx.gfx)?;
+        graphics::Canvas::from_frame(ctx, graphics::Color::from([0.1, 0.2, 0.3, 1.0]))
+            .finish(ctx)?;
         timer::yield_now();
         Ok(())
     }

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -21,8 +21,8 @@ impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         let dim = Dim { rate: 0.5 };
         let shader =
-            graphics::Shader::from_wgsl(&ctx.gfx, include_str!("../resources/dimmer.wgsl"), "main");
-        let params = graphics::ShaderParams::new(&mut ctx.gfx, &dim, &[], &[]);
+            graphics::Shader::from_wgsl(ctx, include_str!("../resources/dimmer.wgsl"), "main");
+        let params = graphics::ShaderParams::new(ctx, &dim, &[], &[]);
         Ok(MainState {
             dim,
             shader,
@@ -38,10 +38,10 @@ impl event::EventHandler<ggez::GameError> for MainState {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::from([0.1, 0.2, 0.3, 1.0]));
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::from([0.1, 0.2, 0.3, 1.0]));
 
         let circle = graphics::Mesh::new_circle(
-            &ctx.gfx,
+            ctx,
             DrawMode::fill(),
             glam::Vec2::new(100.0, 300.0),
             100.0,
@@ -50,11 +50,11 @@ impl event::EventHandler<ggez::GameError> for MainState {
         )?;
         canvas.draw(&circle, glam::Vec2::new(0.0, 0.0));
 
-        self.params.set_uniforms(&ctx.gfx, &self.dim);
+        self.params.set_uniforms(ctx, &self.dim);
         canvas.set_shader(self.shader.clone());
         canvas.set_shader_params(self.params.clone());
         let circle = graphics::Mesh::new_circle(
-            &ctx.gfx,
+            ctx,
             DrawMode::fill(),
             glam::Vec2::new(400.0, 300.0),
             100.0,
@@ -65,7 +65,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
         canvas.set_default_shader();
         let circle = graphics::Mesh::new_circle(
-            &ctx.gfx,
+            ctx,
             DrawMode::fill(),
             glam::Vec2::new(700.0, 300.0),
             100.0,
@@ -74,7 +74,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
         )?;
         canvas.draw(&circle, glam::Vec2::new(0.0, 0.0));
 
-        canvas.finish(&mut ctx.gfx)
+        canvas.finish(ctx)
     }
 }
 

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -17,7 +17,7 @@ struct MainState {
 
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let sound = audio::Source::new(&ctx.fs, &ctx.audio, "/sound.ogg")?;
+        let sound = audio::Source::new(ctx, "/sound.ogg")?;
         let s = MainState { sound };
         Ok(s)
     }
@@ -30,7 +30,7 @@ impl MainState {
     /// Plays the sound multiple times
     fn play_detached(&mut self, ctx: &mut Context) {
         // "detached" sounds keep playing even after they are dropped
-        let _ = self.sound.play_detached(&ctx.audio);
+        let _ = self.sound.play_detached(ctx);
     }
 
     /// Waits until the sound is done playing before playing again.
@@ -41,25 +41,25 @@ impl MainState {
     /// Fades the sound in over a second
     /// Which isn't really ideal 'cause the sound is barely a second long, but still.
     fn play_fadein(&mut self, ctx: &mut Context) {
-        let mut sound = audio::Source::new(&ctx.fs, &ctx.audio, "/sound.ogg").unwrap();
+        let mut sound = audio::Source::new(ctx, "/sound.ogg").unwrap();
         sound.set_fade_in(Duration::from_millis(1000));
-        sound.play_detached(&ctx.audio).unwrap();
+        sound.play_detached(ctx).unwrap();
     }
 
     fn play_highpitch(&mut self, ctx: &mut Context) {
-        let mut sound = audio::Source::new(&ctx.fs, &ctx.audio, "/sound.ogg").unwrap();
+        let mut sound = audio::Source::new(ctx, "/sound.ogg").unwrap();
         sound.set_pitch(2.0);
-        sound.play_detached(&ctx.audio).unwrap();
+        sound.play_detached(ctx).unwrap();
     }
     fn play_lowpitch(&mut self, ctx: &mut Context) {
-        let mut sound = audio::Source::new(&ctx.fs, &ctx.audio, "/sound.ogg").unwrap();
+        let mut sound = audio::Source::new(ctx, "/sound.ogg").unwrap();
         sound.set_pitch(0.5);
-        sound.play_detached(&ctx.audio).unwrap();
+        sound.play_detached(ctx).unwrap();
     }
 
     /// Plays the sound and prints out stats until it's done.
     fn play_stats(&mut self, ctx: &mut Context) {
-        let _ = self.sound.play(&ctx.audio);
+        let _ = self.sound.play(ctx);
         while self.sound.playing() {
             println!("Elapsed time: {:?}", self.sound.elapsed())
         }
@@ -73,14 +73,14 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         let mut canvas =
-            graphics::Canvas::from_frame(&ctx.gfx, graphics::Color::from([0.1, 0.2, 0.3, 1.0]));
+            graphics::Canvas::from_frame(ctx, graphics::Color::from([0.1, 0.2, 0.3, 1.0]));
 
         canvas.draw(
             &graphics::Text::new("Press number keys 1-6 to play a sound, or escape to quit."),
             [100., 100.],
         );
 
-        canvas.finish(&mut ctx.gfx)
+        canvas.finish(ctx)
     }
 
     fn key_down_event(

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -66,7 +66,7 @@ impl App {
         // This loads a new TrueType font into the context named "Fancy font".
         ctx.gfx.add_font(
             "Fancy font",
-            graphics::FontData::from_path(&ctx.fs, "/Tangerine_Regular.ttf")?,
+            graphics::FontData::from_path(ctx, "/Tangerine_Regular.ttf")?,
         );
 
         // `Font` is really only an integer handle, and can be copied around.
@@ -142,7 +142,7 @@ impl event::EventHandler<ggez::GameError> for App {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::from([0.1, 0.2, 0.3, 1.0]));
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::from([0.1, 0.2, 0.3, 1.0]));
 
         let fps = ctx.time.fps();
         let fps_display = Text::new(format!("FPS: {}", fps));
@@ -158,7 +158,7 @@ impl event::EventHandler<ggez::GameError> for App {
             // followed with `::draw_queued()` with said params, is the intended way.
             canvas.draw(text, Vec2::new(20.0, 20.0 + height));
             //height += 20.0 + text.height(ctx) as f32;
-            height += 20.0 + text.dimensions(&mut ctx.gfx).unwrap().h as f32;
+            height += 20.0 + text.dimensions(ctx).unwrap().h as f32;
         }
 
         // Individual fragments within the `Text` can be replaced;
@@ -177,7 +177,7 @@ impl event::EventHandler<ggez::GameError> for App {
                 TextFragment::new(ch).scale(PxScale::from(10.0 + 6.0 * self.rng.rand_float())),
             );
         }
-        let wobble_rect = (&wobble).dimensions(&mut ctx.gfx).unwrap();
+        let wobble_rect = (&wobble).dimensions(ctx).unwrap();
         canvas.draw(
             &wobble,
             graphics::DrawParam::new()
@@ -191,7 +191,7 @@ impl event::EventHandler<ggez::GameError> for App {
         ));
         canvas.draw(&t, graphics::DrawParam::from([500.0, 320.0]).rotation(-0.5));
 
-        canvas.finish(&mut ctx.gfx)?;
+        canvas.finish(ctx)?;
         timer::yield_now();
         Ok(())
     }

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -21,7 +21,7 @@ impl MainState {
     const GRID_POINT_RADIUS: f32 = 5.0;
 
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let angle = graphics::Image::from_path(&ctx.fs, &ctx.gfx, "/angle.png", true)?;
+        let angle = graphics::Image::from_path(ctx, "/angle.png", true)?;
         let gridmesh_builder = &mut graphics::MeshBuilder::new();
         for x in 0..Self::GRID_SIZE {
             for y in 0..Self::GRID_SIZE {
@@ -39,7 +39,7 @@ impl MainState {
                 )?;
             }
         }
-        let gridmesh = graphics::Mesh::from_data(&ctx.gfx, gridmesh_builder.build());
+        let gridmesh = graphics::Mesh::from_data(ctx, gridmesh_builder.build());
         // An array of rects to cycle the screen coordinates through.
         let screen_bounds = vec![
             graphics::Rect::new(0.0, 0.0, 800.0, 600.0),
@@ -83,7 +83,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::from([0.1, 0.2, 0.3, 1.0]));
+        let mut canvas = graphics::Canvas::from_frame(ctx, Color::from([0.1, 0.2, 0.3, 1.0]));
         canvas.set_screen_coordinates(self.screen_coords);
 
         let origin = Vec2::ZERO;
@@ -102,7 +102,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
         canvas.draw(&self.angle, param);
 
-        canvas.finish(&mut ctx.gfx)
+        canvas.finish(ctx)
     }
 
     fn key_down_event(

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -285,11 +285,11 @@ pub struct Source {
 impl Source {
     /// Create a new `Source` from the given file.
     pub fn new<P: AsRef<path::Path>>(
-        extra: &impl HasTwo<Filesystem, AudioContext>,
+        ctxs: &impl HasTwo<Filesystem, AudioContext>,
         path: P,
     ) -> GameResult<Self> {
-        let fs = extra.get_first();
-        let audio = extra.get_second();
+        let fs = ctxs.get_first();
+        let audio = ctxs.get_second();
         let path = path.as_ref();
         let data = SoundData::new(fs, path)?;
         Source::from_data(audio, data)

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -66,7 +66,7 @@ pub struct SoundData(Arc<[u8]>);
 impl SoundData {
     /// Load the file at the given path and create a new `SoundData` from it.
     pub fn new<P: AsRef<path::Path>>(fs: &impl Has<Filesystem>, path: P) -> GameResult<Self> {
-        let fs = fs.get();
+        let fs = fs.retrieve();
         let path = path.as_ref();
         let file = &mut fs.open(path)?;
         SoundData::from_read(file)
@@ -127,7 +127,7 @@ impl AsRef<[u8]> for SoundData {
 pub trait SoundSource {
     /// Plays the audio source; restarts the sound if currently playing
     fn play(&mut self, audio: &impl Has<AudioContext>) -> GameResult {
-        let audio = audio.get();
+        let audio = audio.retrieve();
         self.stop(audio)?;
         self.play_later()
     }
@@ -288,8 +288,8 @@ impl Source {
         ctxs: &impl HasTwo<Filesystem, AudioContext>,
         path: P,
     ) -> GameResult<Self> {
-        let fs = ctxs.get_first();
-        let audio = ctxs.get_second();
+        let fs = ctxs.retrieve_first();
+        let audio = ctxs.retrieve_second();
         let path = path.as_ref();
         let data = SoundData::new(fs, path)?;
         Source::from_data(audio, data)
@@ -297,7 +297,7 @@ impl Source {
 
     /// Creates a new `Source` using the given `SoundData` object.
     pub fn from_data(audio: &impl Has<AudioContext>, data: SoundData) -> GameResult<Self> {
-        let audio = audio.get();
+        let audio = audio.retrieve();
         if !data.can_play() {
             return Err(GameError::AudioError(
                 "Could not decode the given audio data".to_string(),
@@ -350,7 +350,7 @@ impl SoundSource for Source {
     }
 
     fn play_detached(&mut self, audio: &impl Has<AudioContext>) -> GameResult {
-        let audio = audio.get();
+        let audio = audio.retrieve();
         self.stop(audio)?;
         self.play_later()?;
 
@@ -384,7 +384,7 @@ impl SoundSource for Source {
     }
 
     fn stop(&mut self, audio: &impl Has<AudioContext>) -> GameResult {
-        let audio = audio.get();
+        let audio = audio.retrieve();
         // Sinks cannot be reused after calling `.stop()`. See
         // https://github.com/tomaka/rodio/issues/171 for information.
         // To stop the current sound we have to drop the old sink and
@@ -467,7 +467,7 @@ impl SpatialSource {
 
     /// Creates a new `SpatialSource` using the given `SoundData` object.
     pub fn from_data(audio: &impl Has<AudioContext>, data: SoundData) -> GameResult<Self> {
-        let audio = audio.get();
+        let audio = audio.retrieve();
         if !data.can_play() {
             return Err(GameError::AudioError(
                 "Could not decode the given audio data".to_string(),
@@ -531,7 +531,7 @@ impl SoundSource for SpatialSource {
     }
 
     fn play_detached(&mut self, audio: &impl Has<AudioContext>) -> GameResult {
-        let audio = audio.get();
+        let audio = audio.retrieve();
         self.stop(audio)?;
         self.play_later()?;
 
@@ -577,7 +577,7 @@ impl SoundSource for SpatialSource {
     }
 
     fn stop(&mut self, audio: &impl Has<AudioContext>) -> GameResult {
-        let audio = audio.get();
+        let audio = audio.retrieve();
         // Sinks cannot be reused after calling `.stop()`. See
         // https://github.com/tomaka/rodio/issues/171 for information.
         // To stop the current sound we have to drop the old sink and

--- a/src/context.rs
+++ b/src/context.rs
@@ -67,6 +67,9 @@ pub struct Context {
 
 // This is ugly and hacky but greatly improves ergonomics.
 
+/// Used to represent types that can provide a certain context type.
+///
+/// If you don't know what this is, you most likely want to pass `ctx`.
 pub trait Has<T> {
     fn get(&self) -> &T;
 }
@@ -100,6 +103,9 @@ impl Has<audio::AudioContext> for Context {
     }
 }
 
+/// Used to represent types that can provide a certain context type in a mutable form.
+///
+/// If you don't know what this is, you most likely want to pass `ctx`.
 pub trait HasMut<T> {
     fn get_mut(&mut self) -> &mut T;
 }
@@ -118,6 +124,9 @@ impl HasMut<GraphicsContext> for Context {
     }
 }
 
+/// Used to represent types that can provide two context types. See also `Has<T>`.
+///
+/// If you don't know what this is, you most likely want to pass `ctx`.
 pub trait HasTwo<T, U> {
     fn get_first(&self) -> &T;
     fn get_second(&self) -> &U;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,5 @@
+//! The `context` module contains functions and traits related to using the `Context` type.
+
 use std::fmt;
 /// We re-export winit so it's easy for people to use the same version as we are
 /// without having to mess around figuring it out.
@@ -71,26 +73,27 @@ pub struct Context {
 ///
 /// If you don't know what this is, you most likely want to pass `ctx`.
 pub trait Has<T> {
-    fn get(&self) -> &T;
+    /// Method to retrieve the context type.
+    fn retrieve(&self) -> &T;
 }
 
 impl<T> Has<T> for T {
     #[inline]
-    fn get(&self) -> &T {
+    fn retrieve(&self) -> &T {
         self
     }
 }
 
 impl Has<Filesystem> for Context {
     #[inline]
-    fn get(&self) -> &Filesystem {
+    fn retrieve(&self) -> &Filesystem {
         &self.fs
     }
 }
 
 impl Has<GraphicsContext> for Context {
     #[inline]
-    fn get(&self) -> &GraphicsContext {
+    fn retrieve(&self) -> &GraphicsContext {
         &self.gfx
     }
 }
@@ -98,7 +101,7 @@ impl Has<GraphicsContext> for Context {
 #[cfg(feature = "audio")]
 impl Has<audio::AudioContext> for Context {
     #[inline]
-    fn get(&self) -> &audio::AudioContext {
+    fn retrieve(&self) -> &audio::AudioContext {
         &self.audio
     }
 }
@@ -107,19 +110,20 @@ impl Has<audio::AudioContext> for Context {
 ///
 /// If you don't know what this is, you most likely want to pass `ctx`.
 pub trait HasMut<T> {
-    fn get_mut(&mut self) -> &mut T;
+    /// Method to retrieve the context type as mutable.
+    fn retrieve_mut(&mut self) -> &mut T;
 }
 
 impl<T> HasMut<T> for T {
     #[inline]
-    fn get_mut(&mut self) -> &mut T {
+    fn retrieve_mut(&mut self) -> &mut T {
         self
     }
 }
 
 impl HasMut<GraphicsContext> for Context {
     #[inline]
-    fn get_mut(&mut self) -> &mut GraphicsContext {
+    fn retrieve_mut(&mut self) -> &mut GraphicsContext {
         &mut self.gfx
     }
 }
@@ -128,41 +132,43 @@ impl HasMut<GraphicsContext> for Context {
 ///
 /// If you don't know what this is, you most likely want to pass `ctx`.
 pub trait HasTwo<T, U> {
-    fn get_first(&self) -> &T;
-    fn get_second(&self) -> &U;
+    /// Method to retrieve the first context type.
+    fn retrieve_first(&self) -> &T;
+    /// Method to retrieve the second context type.
+    fn retrieve_second(&self) -> &U;
 }
 
 impl<T, U> HasTwo<T, U> for (&T, &U) {
     #[inline]
-    fn get_first(&self) -> &T {
+    fn retrieve_first(&self) -> &T {
         self.0
     }
 
     #[inline]
-    fn get_second(&self) -> &U {
+    fn retrieve_second(&self) -> &U {
         self.1
     }
 }
 
 impl HasTwo<Filesystem, GraphicsContext> for Context {
     #[inline]
-    fn get_first(&self) -> &Filesystem {
+    fn retrieve_first(&self) -> &Filesystem {
         &self.fs
     }
 
     #[inline]
-    fn get_second(&self) -> &GraphicsContext {
+    fn retrieve_second(&self) -> &GraphicsContext {
         &self.gfx
     }
 }
 
 #[cfg(feature = "audio")]
 impl HasTwo<Filesystem, crate::audio::AudioContext> for Context {
-    fn get_first(&self) -> &Filesystem {
+    fn retrieve_first(&self) -> &Filesystem {
         &self.fs
     }
 
-    fn get_second(&self) -> &crate::audio::AudioContext {
+    fn retrieve_second(&self) -> &crate::audio::AudioContext {
         &self.audio
     }
 }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -1,6 +1,9 @@
 use crevice::std140::AsStd140;
 
-use crate::{GameError, GameResult};
+use crate::{
+    context::{Has, HasMut},
+    GameError, GameResult,
+};
 
 use super::{
     gpu::arc::{ArcBindGroup, ArcBindGroupLayout},
@@ -40,7 +43,7 @@ impl Canvas {
     /// The image must be created for Canvas usage, i.e. [Image::new_canvas_image()], or [ScreenImage], and must only have a sample count of 1.
     #[inline]
     pub fn from_image(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         image: Image,
         load_op: impl Into<CanvasLoadOp>,
     ) -> Self {
@@ -50,10 +53,11 @@ impl Canvas {
     /// Helper for [`Canvas::from_image`] for construction of a [`Canvas`] from a [`ScreenImage`].
     #[inline]
     pub fn from_screen_image(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         image: &mut ScreenImage,
         load_op: impl Into<CanvasLoadOp>,
     ) -> Self {
+        let gfx = gfx.get();
         let image = image.image(gfx);
         Canvas::from_image(gfx, image, load_op)
     }
@@ -63,7 +67,7 @@ impl Canvas {
     /// Both images must be created for Canvas usage (see [Canvas::from_image]). `msaa_image` must have a sample count > 1 and `resolve_image` must strictly have a sample count of 1.
     #[inline]
     pub fn from_msaa(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         msaa_image: Image,
         resolve: Image,
         load_op: impl Into<CanvasLoadOp>,
@@ -74,7 +78,7 @@ impl Canvas {
     /// Helper for [`Canvas::from_msaa`] for construction of an MSAA [`Canvas`] from a [`ScreenImage`].
     #[inline]
     pub fn from_screen_msaa(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         msaa_image: &mut ScreenImage,
         resolve: &mut ScreenImage,
         load_op: impl Into<CanvasLoadOp>,
@@ -85,7 +89,8 @@ impl Canvas {
     }
 
     /// Create a new [Canvas] that renders directly to the window surface.
-    pub fn from_frame(gfx: &GraphicsContext, load_op: impl Into<CanvasLoadOp>) -> Self {
+    pub fn from_frame(gfx: &impl Has<GraphicsContext>, load_op: impl Into<CanvasLoadOp>) -> Self {
+        let gfx = gfx.get();
         // these unwraps will never fail
         let samples = gfx.frame_msaa_image.as_ref().unwrap().samples();
         let (target, resolve) = if samples > 1 {
@@ -100,13 +105,14 @@ impl Canvas {
     }
 
     fn new(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         target: Image,
         resolve: Option<Image>,
         load_op: CanvasLoadOp,
     ) -> Self {
-        let defaults = DefaultResources::new(gfx);
+        let gfx = gfx.get();
 
+        let defaults = DefaultResources::new(gfx);
         let drawable_size = gfx.drawable_size();
 
         let state = DrawState {
@@ -366,7 +372,8 @@ impl Canvas {
 
     /// Finish drawing with this canvas and submit all the draw calls.
     #[inline]
-    pub fn finish(mut self, gfx: &mut GraphicsContext) -> GameResult {
+    pub fn finish(mut self, gfx: &mut impl HasMut<GraphicsContext>) -> GameResult {
+        let gfx = gfx.get_mut();
         self.finalize(gfx)
     }
 

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -57,7 +57,7 @@ impl Canvas {
         image: &mut ScreenImage,
         load_op: impl Into<CanvasLoadOp>,
     ) -> Self {
-        let gfx = gfx.get();
+        let gfx = gfx.retrieve();
         let image = image.image(gfx);
         Canvas::from_image(gfx, image, load_op)
     }
@@ -90,7 +90,7 @@ impl Canvas {
 
     /// Create a new [Canvas] that renders directly to the window surface.
     pub fn from_frame(gfx: &impl Has<GraphicsContext>, load_op: impl Into<CanvasLoadOp>) -> Self {
-        let gfx = gfx.get();
+        let gfx = gfx.retrieve();
         // these unwraps will never fail
         let samples = gfx.frame_msaa_image.as_ref().unwrap().samples();
         let (target, resolve) = if samples > 1 {
@@ -110,7 +110,7 @@ impl Canvas {
         resolve: Option<Image>,
         load_op: CanvasLoadOp,
     ) -> Self {
-        let gfx = gfx.get();
+        let gfx = gfx.retrieve();
 
         let defaults = DefaultResources::new(gfx);
         let drawable_size = gfx.drawable_size();
@@ -373,7 +373,7 @@ impl Canvas {
     /// Finish drawing with this canvas and submit all the draw calls.
     #[inline]
     pub fn finish(mut self, gfx: &mut impl HasMut<GraphicsContext>) -> GameResult {
-        let gfx = gfx.get_mut();
+        let gfx = gfx.retrieve_mut();
         self.finalize(gfx)
     }
 

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -405,7 +405,7 @@ impl GraphicsContext {
         filesystem: &impl Has<Filesystem>,
         path: Option<impl AsRef<Path>>,
     ) -> GameResult {
-        let filesystem = filesystem.get();
+        let filesystem = filesystem.retrieve();
         let icon = match path {
             Some(p) => Some(load_icon(p.as_ref(), filesystem)?),
             None => None,
@@ -536,11 +536,9 @@ impl GraphicsContext {
                 depth_stencil_attachment: None,
             });
 
-            let sampler = SamplerCache::get(
-                &mut self.sampler_cache,
-                &self.wgpu.device,
-                Sampler::linear_clamp(),
-            );
+            let sampler = &mut self
+                .sampler_cache
+                .get(&self.wgpu.device, Sampler::linear_clamp());
 
             let (bind, layout) = BindGroupBuilder::new()
                 .image(&fcx.present.view, wgpu::ShaderStages::FRAGMENT)

--- a/src/graphics/draw.rs
+++ b/src/graphics/draw.rs
@@ -1,3 +1,5 @@
+use crate::context::HasMut;
+
 use super::{Canvas, Color, GraphicsContext, LinearColor, Rect};
 
 /// A struct that represents where to put a drawable object.
@@ -271,7 +273,7 @@ pub trait Drawable {
     ///
     /// It returns `Option` because some `Drawable`s may have no bounding box,
     /// namely `InstanceArray` (as there is no true bounds for the instances given the instanced mesh can differ).
-    fn dimensions(&self, gfx: &mut GraphicsContext) -> Option<Rect>;
+    fn dimensions(&self, gfx: &mut impl HasMut<GraphicsContext>) -> Option<Rect>;
 }
 
 #[derive(Debug, crevice::std140::AsStd140)]

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -123,12 +123,12 @@ impl Image {
     /// Creates a new image initialized with pixel data loaded from an encoded image `Read` (e.g. PNG or JPEG).
     #[allow(unused_results)]
     pub fn from_path(
-        extra: &impl HasTwo<Filesystem, GraphicsContext>,
+        ctxs: &impl HasTwo<Filesystem, GraphicsContext>,
         path: impl AsRef<Path>,
         srgb: bool,
     ) -> GameResult<Self> {
-        let fs = extra.get_first();
-        let gfx = extra.get_second();
+        let fs = ctxs.get_first();
+        let gfx = ctxs.get_second();
 
         let mut encoded = Vec::new();
         fs.open(path)?.read_to_end(&mut encoded)?;

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -3,7 +3,11 @@ use super::{
     gpu::arc::{ArcTexture, ArcTextureView},
     Canvas, Color, Draw, DrawParam, Drawable, Rect, WgpuContext,
 };
-use crate::{filesystem::Filesystem, Context, GameError, GameResult};
+use crate::{
+    context::{Has, HasTwo},
+    filesystem::Filesystem,
+    Context, GameError, GameResult,
+};
 use image::ImageEncoder;
 use std::path::Path;
 use std::{io::Read, num::NonZeroU32};
@@ -30,12 +34,13 @@ pub struct Image {
 impl Image {
     /// Creates a new image specifically for use with a [Canvas](crate::graphics::Canvas).
     pub fn new_canvas_image(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         format: ImageFormat,
         width: u32,
         height: u32,
         samples: u32,
     ) -> Self {
+        let gfx = gfx.get();
         Self::new(
             &gfx.wgpu,
             format,
@@ -50,12 +55,13 @@ impl Image {
 
     /// Creates a new image initialized with given pixel data.
     pub fn from_pixels(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         pixels: &[u8],
         format: ImageFormat,
         width: u32,
         height: u32,
     ) -> Self {
+        let gfx = gfx.get();
         Self::from_pixels_wgpu(&gfx.wgpu, pixels, format, width, height)
     }
 
@@ -98,7 +104,7 @@ impl Image {
     }
 
     /// A little helper function that creates a new `Image` that is just a solid square of the given size and color. Mainly useful for debugging.
-    pub fn from_solid(gfx: &GraphicsContext, size: u32, color: Color) -> Self {
+    pub fn from_solid(gfx: &impl Has<GraphicsContext>, size: u32, color: Color) -> Self {
         let pixels = (0..(size * size))
             .flat_map(|_| {
                 let (r, g, b, a) = color.to_rgba();
@@ -117,11 +123,13 @@ impl Image {
     /// Creates a new image initialized with pixel data loaded from an encoded image `Read` (e.g. PNG or JPEG).
     #[allow(unused_results)]
     pub fn from_path(
-        fs: &Filesystem,
-        gfx: &GraphicsContext,
+        extra: &impl HasTwo<Filesystem, GraphicsContext>,
         path: impl AsRef<Path>,
         srgb: bool,
     ) -> GameResult<Self> {
+        let fs = extra.get_first();
+        let gfx = extra.get_second();
+
         let mut encoded = Vec::new();
         fs.open(path)?.read_to_end(&mut encoded)?;
         let decoded = image::load_from_memory(&encoded[..])
@@ -200,7 +208,8 @@ impl Image {
     /// The format matches the GPU image format.
     ///
     /// **This is a very expensive operation - call sparingly.**
-    pub fn to_pixels(&self, gfx: &GraphicsContext) -> GameResult<Vec<u8>> {
+    pub fn to_pixels(&self, gfx: &impl Has<GraphicsContext>) -> GameResult<Vec<u8>> {
+        let gfx = gfx.get();
         if self.samples > 1 {
             return Err(GameError::RenderError(String::from(
                 "cannot read the pixels of a multisampled image; resolve this image with a canvas",
@@ -274,7 +283,7 @@ impl Image {
             }
         };
 
-        let pixels = self.to_pixels(&ctx.gfx)?;
+        let pixels = self.to_pixels(ctx)?;
         let f = ctx.fs.create(path)?;
         let writer = &mut std::io::BufWriter::new(f);
 
@@ -365,12 +374,13 @@ impl ScreenImage {
     ///
     /// If `format` is `None` then the format will be inferred from the surface format.
     pub fn new(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         format: impl Into<Option<ImageFormat>>,
         width: f32,
         height: f32,
         samples: u32,
     ) -> Self {
+        let gfx = gfx.get();
         assert!(width > 0.);
         assert!(height > 0.);
         assert!(samples > 0);
@@ -386,14 +396,15 @@ impl ScreenImage {
     }
 
     /// Returns the inner [Image], also recreating it if the framebuffer has been resized.
-    pub fn image(&mut self, gfx: &GraphicsContext) -> Image {
+    pub fn image(&mut self, gfx: &impl Has<GraphicsContext>) -> Image {
         if Self::size(gfx, self.size) != (self.image.width(), self.image.height()) {
             self.image = Self::create(gfx, self.format, self.size, self.samples);
         }
         self.image.clone()
     }
 
-    fn size(gfx: &GraphicsContext, (width, height): (f32, f32)) -> (u32, u32) {
+    fn size(gfx: &impl Has<GraphicsContext>, (width, height): (f32, f32)) -> (u32, u32) {
+        let gfx = gfx.get();
         let size = gfx.window.inner_size();
         let width = (size.width as f32 * width) as u32;
         let height = (size.height as f32 * height) as u32;
@@ -401,7 +412,7 @@ impl ScreenImage {
     }
 
     fn create(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         format: wgpu::TextureFormat,
         size: (f32, f32),
         samples: u32,

--- a/src/graphics/instance.rs
+++ b/src/graphics/instance.rs
@@ -1,4 +1,7 @@
-use crate::{context::Has, GameError, GameResult};
+use crate::{
+    context::{Has, HasMut},
+    GameError, GameResult,
+};
 
 use super::{
     context::GraphicsContext,
@@ -48,7 +51,7 @@ impl InstanceArray {
         capacity: u32,
         ordered: bool,
     ) -> Self {
-        let gfx = gfx.get();
+        let gfx = gfx.retrieve();
         InstanceArray::new_wgpu(
             &gfx.wgpu,
             image.into().unwrap_or_else(|| gfx.white_image.clone()),
@@ -270,7 +273,8 @@ impl Drawable for InstanceArray {
         );
     }
 
-    fn dimensions(&self, gfx: &mut GraphicsContext) -> Option<Rect> {
+    fn dimensions(&self, gfx: &mut impl HasMut<GraphicsContext>) -> Option<Rect> {
+        let gfx = gfx.retrieve_mut();
         if self.params.is_empty() {
             return None;
         }

--- a/src/graphics/instance.rs
+++ b/src/graphics/instance.rs
@@ -1,4 +1,4 @@
-use crate::{GameError, GameResult};
+use crate::{context::Has, GameError, GameResult};
 
 use super::{
     context::GraphicsContext,
@@ -43,11 +43,12 @@ impl InstanceArray {
     ///
     /// [z-values]:crate::graphics::ZIndex
     pub fn new(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         image: impl Into<Option<Image>>,
         capacity: u32,
         ordered: bool,
     ) -> Self {
+        let gfx = gfx.get();
         InstanceArray::new_wgpu(
             &gfx.wgpu,
             image.into().unwrap_or_else(|| gfx.white_image.clone()),

--- a/src/graphics/instance.rs
+++ b/src/graphics/instance.rs
@@ -211,7 +211,7 @@ impl InstanceArray {
     /// Changes the capacity of this `InstanceArray` while preserving instances.
     ///
     /// If `new_capacity` is less than the `len`, the instances will be truncated.
-    pub fn resize(&mut self, gfx: &GraphicsContext, new_capacity: u32) {
+    pub fn resize(&mut self, gfx: &impl Has<GraphicsContext>, new_capacity: u32) {
         let resized = InstanceArray::new(gfx, self.image.clone(), new_capacity, self.ordered);
         self.buffer = resized.buffer;
         self.indices = resized.indices;

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -2,7 +2,10 @@ use super::{
     context::GraphicsContext, gpu::arc::ArcBuffer, Canvas, Color, Draw, DrawMode, DrawParam,
     Drawable, LinearColor, Rect, WgpuContext,
 };
-use crate::{context::Has, GameError, GameResult};
+use crate::{
+    context::{Has, HasMut},
+    GameError, GameResult,
+};
 use lyon::{
     math::Point as LPoint,
     path::{traits::PathBuilder, Polygon},
@@ -63,7 +66,7 @@ pub struct Mesh {
 impl Mesh {
     /// Create a new mesh from [MeshData].
     pub fn from_data(gfx: &impl Has<GraphicsContext>, raw: MeshData) -> Self {
-        let gfx = gfx.get();
+        let gfx = gfx.retrieve();
         Self::from_data_wgpu(&gfx.wgpu, raw)
     }
 
@@ -270,7 +273,7 @@ impl Drawable for Mesh {
         );
     }
 
-    fn dimensions(&self, _gfx: &mut GraphicsContext) -> Option<Rect> {
+    fn dimensions(&self, _gfx: &mut impl HasMut<GraphicsContext>) -> Option<Rect> {
         Some(self.bounds)
     }
 }
@@ -294,7 +297,7 @@ impl Drawable for Quad {
         canvas.draw(&canvas.default_resources().mesh.clone(), param);
     }
 
-    fn dimensions(&self, _gfx: &mut GraphicsContext) -> Option<Rect> {
+    fn dimensions(&self, _gfx: &mut impl HasMut<GraphicsContext>) -> Option<Rect> {
         Some(Rect::one())
     }
 }

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -2,7 +2,7 @@ use super::{
     context::GraphicsContext, gpu::arc::ArcBuffer, Canvas, Color, Draw, DrawMode, DrawParam,
     Drawable, LinearColor, Rect, WgpuContext,
 };
-use crate::{GameError, GameResult};
+use crate::{context::Has, GameError, GameResult};
 use lyon::{
     math::Point as LPoint,
     path::{traits::PathBuilder, Polygon},
@@ -62,7 +62,8 @@ pub struct Mesh {
 
 impl Mesh {
     /// Create a new mesh from [MeshData].
-    pub fn from_data(gfx: &GraphicsContext, raw: MeshData) -> Self {
+    pub fn from_data(gfx: &impl Has<GraphicsContext>, raw: MeshData) -> Self {
+        let gfx = gfx.get();
         Self::from_data_wgpu(&gfx.wgpu, raw)
     }
 
@@ -91,7 +92,7 @@ impl Mesh {
 
     /// Create a new mesh for a line of one or more connected segments.
     pub fn new_line(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         points: &[impl Into<mint::Point2<f32>> + Clone],
         width: f32,
         color: Color,
@@ -106,7 +107,7 @@ impl Mesh {
 
     /// Create a new mesh for a circle.
     pub fn new_circle(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         mode: DrawMode,
         point: impl Into<mint::Point2<f32>>,
         radius: f32,
@@ -123,7 +124,7 @@ impl Mesh {
 
     /// Create a new mesh for an ellipse.
     pub fn new_ellipse(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         mode: DrawMode,
         point: impl Into<mint::Point2<f32>>,
         radius1: f32,
@@ -141,7 +142,7 @@ impl Mesh {
 
     /// Create a new mesh for a series of connected lines.
     pub fn new_polyline(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         mode: DrawMode,
         points: &[impl Into<mint::Point2<f32>> + Clone],
         color: Color,
@@ -156,7 +157,7 @@ impl Mesh {
     /// The points given must be in clockwise order,
     /// otherwise at best the polygon will not draw.
     pub fn new_polygon(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         mode: DrawMode,
         points: &[impl Into<mint::Point2<f32>> + Clone],
         color: Color,
@@ -169,7 +170,7 @@ impl Mesh {
 
     /// Create a new mesh for a rectangle.
     pub fn new_rectangle(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         mode: DrawMode,
         bounds: Rect,
         color: Color,
@@ -182,7 +183,7 @@ impl Mesh {
 
     /// Create a new mesh for a rounded rectangle.
     pub fn new_rounded_rectangle(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         mode: DrawMode,
         bounds: Rect,
         radius: f32,
@@ -198,7 +199,7 @@ impl Mesh {
 
     /// Create a new `Mesh` from a raw list of triangle points.
     pub fn from_triangles(
-        gfx: &GraphicsContext,
+        gfx: &impl Has<GraphicsContext>,
         triangles: &[impl Into<mint::Point2<f32>> + Clone],
         color: Color,
     ) -> GameResult<Self> {

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -1,5 +1,7 @@
 use std::marker::PhantomData;
 
+use crate::context::{Has, HasMut};
+
 use super::{
     context::GraphicsContext,
     gpu::{
@@ -8,6 +10,7 @@ use super::{
     },
     image::Image,
     sampler::Sampler,
+    SamplerCache,
 };
 use crevice::std140::Std140;
 use wgpu::util::DeviceExt;
@@ -28,22 +31,22 @@ use wgpu::util::DeviceExt;
 /// impl event::EventHandler for MainState {
 /// #   fn update(&mut self, _ctx: &mut Context) -> Result<(), GameError> { Ok(()) }
 ///     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-///         let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::BLACK);
+///         let mut canvas = graphics::Canvas::from_frame(ctx, Color::BLACK);
 ///         let dim = Dim { rate: 0.5 };
 ///         // NOTE: This is for simplicity; do not recreate your shader every frame like this!
 ///         //       For more info look at the full example.
 ///         let shader = Shader::from_wgsl(
-///             &ctx.gfx,
+///             ctx,
 ///             include_str!("../../resources/dimmer.wgsl"),
 ///             "main"
 ///         );
-///         let params = ShaderParams::new(&mut ctx.gfx, &dim, &[], &[]);
-///         params.set_uniforms(&ctx.gfx, &dim);
+///         let params = ShaderParams::new(ctx, &dim, &[], &[]);
+///         params.set_uniforms(ctx, &dim);
 ///
 ///         canvas.set_shader(shader);
 ///         canvas.set_shader_params(params);
 ///         // draw something...
-///         canvas.finish(&mut ctx.gfx)
+///         canvas.finish(ctx)
 ///     }
 ///
 ///     /* ... */
@@ -57,7 +60,8 @@ pub struct Shader {
 
 impl Shader {
     /// Creates a shader from a WGSL string.
-    pub fn from_wgsl(gfx: &GraphicsContext, wgsl: &str, fs_entry: &str) -> Self {
+    pub fn from_wgsl(gfx: &impl Has<GraphicsContext>, wgsl: &str, fs_entry: &str) -> Self {
+        let gfx = gfx.get();
         let module = ArcShaderModule::new(gfx.wgpu.device.create_shader_module(
             &wgpu::ShaderModuleDescriptor {
                 label: None,
@@ -86,11 +90,12 @@ pub struct ShaderParams<Uniforms: AsStd140> {
 impl<Uniforms: AsStd140> ShaderParams<Uniforms> {
     /// Creates a new [ShaderParams], initialized with the given uniforms, images, and samplers.
     pub fn new(
-        gfx: &mut GraphicsContext,
+        gfx: &mut impl HasMut<GraphicsContext>,
         uniforms: &Uniforms,
         images: &[&Image],
         samplers: &[Sampler],
     ) -> Self {
+        let gfx = gfx.get_mut();
         let uniforms = ArcBuffer::new(gfx.wgpu.device.create_buffer_init(
             &wgpu::util::BufferInitDescriptor {
                 label: None,
@@ -101,7 +106,7 @@ impl<Uniforms: AsStd140> ShaderParams<Uniforms> {
 
         let samplers = samplers
             .iter()
-            .map(|&sampler| gfx.sampler_cache.get(&gfx.wgpu.device, sampler))
+            .map(|&sampler| SamplerCache::get(&mut gfx.sampler_cache, &gfx.wgpu.device, sampler))
             .collect::<Vec<_>>();
 
         let mut builder = BindGroupBuilder::new();
@@ -133,7 +138,8 @@ impl<Uniforms: AsStd140> ShaderParams<Uniforms> {
     }
 
     /// Updates the uniform data.
-    pub fn set_uniforms(&self, gfx: &GraphicsContext, uniforms: &Uniforms) {
+    pub fn set_uniforms(&self, gfx: &impl Has<GraphicsContext>, uniforms: &Uniforms) {
+        let gfx = gfx.get();
         gfx.wgpu
             .queue
             .write_buffer(&self.uniforms, 0, uniforms.as_std140().as_bytes());

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -2,7 +2,7 @@ use super::{
     gpu::text::{Extra, TextRenderer},
     Canvas, Color, Draw, DrawParam, Drawable, GraphicsContext, Rect,
 };
-use crate::{filesystem::Filesystem, GameError, GameResult};
+use crate::{context::Has, filesystem::Filesystem, GameError, GameResult};
 use glyph_brush::{ab_glyph, FontId, GlyphCruncher};
 use std::{collections::HashMap, io::Read, path::Path};
 
@@ -15,7 +15,9 @@ pub struct FontData {
 impl FontData {
     /// Loads font data from a given path in the filesystem.
     #[allow(unused_results)]
-    pub fn from_path(fs: &Filesystem, path: impl AsRef<Path>) -> GameResult<Self> {
+    pub fn from_path(fs: &impl Has<Filesystem>, path: impl AsRef<Path>) -> GameResult<Self> {
+        let fs = fs.get();
+
         let mut bytes = vec![];
         fs.open(path)?.read_to_end(&mut bytes)?;
         Ok(FontData {

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -31,12 +31,12 @@
 //!
 //!     fn draw(&mut self, ctx: &mut Context) -> GameResult {
 //!         let mut canvas = graphics::Canvas::from_frame(
-//!             &ctx.gfx,
+//!             ctx,
 //!             graphics::CanvasLoadOp::Clear([0.1, 0.2, 0.3, 1.0].into()),
 //!         );
 //!         // Create a circle at `position_x` and draw
 //!         let circle = graphics::Mesh::new_circle(
-//!             &ctx.gfx,
+//!             ctx,
 //!             graphics::DrawMode::fill(),
 //!             glam::vec2(self.position_x, 380.0),
 //!             100.0,
@@ -44,7 +44,7 @@
 //!             graphics::Color::WHITE,
 //!         )?;
 //!         canvas.draw(&circle, graphics::DrawParam::default());
-//!         canvas.finish(&mut ctx.gfx)?;
+//!         canvas.finish(ctx)?;
 //!         timer::yield_now();
 //!         Ok(())
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,9 +141,9 @@
 //!     }
 //!
 //!     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
-//!         let mut canvas = graphics::Canvas::from_frame(&ctx.gfx, Color::WHITE);
+//!         let mut canvas = graphics::Canvas::from_frame(ctx, Color::WHITE);
 //!         // Draw code here...
-//!         canvas.finish(&mut ctx.gfx)
+//!         canvas.finish(ctx)
 //!     }
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ pub extern crate mint;
 
 pub mod audio;
 pub mod conf;
-mod context;
+pub mod context;
 pub mod error;
 pub mod event;
 pub mod filesystem;


### PR DESCRIPTION
this allows passing just `ctx` to functions that take sub-contexts.
You can still split borrow with a slightly uglier construction: `&(&ctx.fs, &ctx.gfx)`.
I think something like 99.9% of users won't ever have to split borrow so in my opinion, this is a good trade-off.