### PR TITLE
Adds deprecated functions, compatiblity changes and moves request_quit to be a method on context

### DIFF
--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -493,7 +493,7 @@ impl EventHandler for MainState {
             // but for now we just quit.
             if self.player.life <= 0.0 {
                 println!("Game over!");
-                let _ = event::request_quit(ctx);
+                ctx.request_quit();
             }
         }
 
@@ -580,7 +580,7 @@ impl EventHandler for MainState {
                     "/screenshot.png",
                 )?;
             }
-            Some(KeyCode::Escape) => event::request_quit(ctx),
+            Some(KeyCode::Escape) => ctx.request_quit(),
             _ => (), // Do nothing
         }
         Ok(())

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -41,7 +41,7 @@ pub fn main() -> GameResult {
         event::process_event(ctx, &mut event);
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => event::request_quit(ctx),
+                WindowEvent::CloseRequested => ctx.request_quit(),
                 WindowEvent::KeyboardInput {
                     input:
                         KeyboardInput {
@@ -51,7 +51,7 @@ pub fn main() -> GameResult {
                     ..
                 } => {
                     if let keyboard::KeyCode::Escape = keycode {
-                        event::request_quit(ctx);
+                        ctx.request_quit();
                     }
                 }
                 // `CloseRequested` and `KeyboardInput` events won't appear here.

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -105,7 +105,7 @@ impl EventHandler for App {
         );
         if input.keycode == Some(KeyCode::Escape) {
             // Escape key closes the app.
-            ggez::event::request_quit(ctx);
+            ctx.request_quit();
         }
         Ok(())
     }

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -92,7 +92,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             Some(input::keyboard::KeyCode::Key4) => self.play_highpitch(ctx),
             Some(input::keyboard::KeyCode::Key5) => self.play_lowpitch(ctx),
             Some(input::keyboard::KeyCode::Key6) => self.play_stats(ctx),
-            Some(input::keyboard::KeyCode::Escape) => event::request_quit(ctx),
+            Some(input::keyboard::KeyCode::Escape) => ctx.request_quit(),
             _ => (),
         }
         Ok(())

--- a/src/context.rs
+++ b/src/context.rs
@@ -67,6 +67,16 @@ pub struct Context {
     pub quit_requested: bool,
 }
 
+impl Context {
+    /// Attempts to terminate the [`ggez::event::run()`](fn.run.html) loop by requesting a
+    /// [`quit_event`](EventHandler::quit_event) at the very start of the next frame. If this event
+    /// returns `Ok(false)`, then [`Context.continuing`](struct.Context.html#structfield.continuing)
+    /// is set to `false` and the loop breaks.
+    pub fn request_quit(&mut self) {
+        self.quit_requested = true;
+    }
+}
+
 // This is ugly and hacky but greatly improves ergonomics.
 
 /// Used to represent types that can provide a certain context type.
@@ -369,6 +379,15 @@ impl ContextBuilder {
 
         Context::from_conf(config, fs)
     }
+}
+
+/// Attempts to terminate the [`ggez::event::run()`](fn.run.html) loop by requesting a
+/// [`quit_event`](EventHandler::quit_event) at the very start of the next frame. If this event
+/// returns `Ok(false)`, then [`Context.continuing`](struct.Context.html#structfield.continuing)
+/// is set to `false` and the loop breaks.
+#[deprecated(since = "0.8.0", note = "Use `ctx.request_quit` instead.")]
+pub fn quit(ctx: &mut Context) {
+    ctx.request_quit();
 }
 
 #[cfg(test)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -166,7 +166,7 @@ where
         _repeated: bool,
     ) -> Result<(), E> {
         if input.keycode == Some(KeyCode::Escape) {
-            request_quit(ctx);
+            ctx.request_quit();
         }
         Ok(())
     }
@@ -275,14 +275,6 @@ where
     fn on_error(&mut self, _ctx: &mut Context, _origin: ErrorOrigin, _e: E) -> bool {
         true
     }
-}
-
-/// Attempts to terminate the [`ggez::event::run()`](fn.run.html) loop by requesting a
-/// [`quit_event`](EventHandler::quit_event) at the very start of the next frame. If this event
-/// returns `Ok(false)`, then [`Context.continuing`](struct.Context.html#structfield.continuing)
-/// is set to `false` and the loop breaks.
-pub fn request_quit(ctx: &mut Context) {
-    ctx.quit_requested = true;
 }
 
 /// Runs the game's main loop, calling event callbacks on the given state

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -378,7 +378,7 @@ impl Filesystem {
 
 /// Opens the given path and returns the resulting `File`
 /// in read-only mode.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.open` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.open` instead")]
 pub fn open<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult<File> {
     ctx.fs.open(path)
 }
@@ -397,7 +397,7 @@ pub fn open_options<P: AsRef<path::Path>>(
 
 /// Creates a new file in the user directory and opens it
 /// to be written to, truncating it if it already exists.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.create` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.create` instead")]
 pub fn create<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult<File> {
     ctx.fs.create(path)
 }
@@ -405,63 +405,63 @@ pub fn create<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult<File> 
 /// Create an empty directory in the user dir
 /// with the given name.  Any parents to that directory
 /// that do not exist will be created.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.create_dir` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.create_dir` instead")]
 pub fn create_dir<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult {
     ctx.fs.create_dir(path.as_ref())
 }
 
 /// Deletes the specified file in the user dir.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.delete` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.delete` instead")]
 pub fn delete<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult {
     ctx.fs.delete(path.as_ref())
 }
 
 /// Deletes the specified directory in the user dir,
 /// and all its contents!
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.delete_dir` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.delete_dir` instead")]
 pub fn delete_dir<P: AsRef<path::Path>>(ctx: &Context, path: P) -> GameResult {
     ctx.fs.delete_dir(path.as_ref())
 }
 
 /// Check whether a file or directory exists.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.exists` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.exists` instead")]
 pub fn exists<P: AsRef<path::Path>>(ctx: &Context, path: P) -> bool {
     ctx.fs.exists(path.as_ref())
 }
 
 /// Check whether a path points at a file.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.is_file` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.is_file` instead")]
 pub fn is_file<P: AsRef<path::Path>>(ctx: &Context, path: P) -> bool {
     ctx.fs.is_file(path)
 }
 
 /// Check whether a path points at a directory.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.is_dir` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.is_dir` instead")]
 pub fn is_dir<P: AsRef<path::Path>>(ctx: &Context, path: P) -> bool {
     ctx.fs.is_dir(path)
 }
 
 /// Return the full path to the user data directory.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.user_data_dir` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.user_data_dir` instead")]
 pub fn user_data_dir(ctx: &Context) -> &path::Path {
     &ctx.fs.user_data_dir
 }
 
 /// Return the full path to the user config directory.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.user_config_dir` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.user_config_dir` instead")]
 pub fn user_config_dir(ctx: &Context) -> &path::Path {
     &ctx.fs.user_config_dir
 }
 
 /// Returns the full path to the resource directory
 /// (even if it doesn't exist)
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.resources_dir` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.resources_dir` instead")]
 pub fn resources_dir(ctx: &Context) -> &path::Path {
     &ctx.fs.resources_dir
 }
 
 /// Return the full path to the user data directory
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.zip_dir` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.zip_dir` instead")]
 pub fn zip_dir(ctx: &Context) -> &path::Path {
     &ctx.fs.zip_dir
 }
@@ -470,7 +470,7 @@ pub fn zip_dir(ctx: &Context) -> &path::Path {
 /// in no particular order.
 ///
 /// Lists the base directory if an empty path is given.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.read_dir` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.read_dir` instead")]
 pub fn read_dir<P: AsRef<path::Path>>(
     ctx: &Context,
     path: P,
@@ -480,7 +480,7 @@ pub fn read_dir<P: AsRef<path::Path>>(
 
 /// Prints the contents of all data directories.
 /// Useful for debugging.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.print_all` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.print_all` instead")]
 pub fn print_all(ctx: &Context) {
     ctx.fs.print_all()
 }
@@ -491,7 +491,7 @@ pub fn print_all(ctx: &Context) {
 ///
 /// See the [`logging` example](https://github.com/ggez/ggez/blob/master/examples/eventloop.rs)
 /// for how to collect log information.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.log_all` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.log_all` instead")]
 pub fn log_all(ctx: &Context) {
     ctx.fs.log_all()
 }
@@ -503,7 +503,7 @@ pub fn log_all(ctx: &Context) {
 /// harder than it looks to make it bulletproof across platforms.
 /// But it can be very nice for debugging and dev purposes, such as
 /// by pushing `$CARGO_MANIFEST_DIR/resources` to it
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.mount` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.mount` instead")]
 pub fn mount(ctx: &mut Context, path: &path::Path, readonly: bool) {
     ctx.fs.mount(path, readonly)
 }
@@ -511,14 +511,14 @@ pub fn mount(ctx: &mut Context, path: &path::Path, readonly: bool) {
 /// Looks for a file named `/conf.toml` in any resource directory and
 /// loads it if it finds it.
 /// If it can't read it for some reason, returns an error.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.read_config` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.read_config` instead")]
 pub fn read_config(ctx: &Context) -> GameResult<conf::Conf> {
     ctx.fs.read_config()
 }
 
 /// Takes a `Conf` object and saves it to the user directory,
 /// overwriting any file already there.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.fs.write_config` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.fs.write_config` instead")]
 pub fn write_config(ctx: &Context, conf: &conf::Conf) -> GameResult {
     ctx.fs.write_config(conf)
 }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -35,6 +35,9 @@ pub struct Canvas {
     target: Image,
     resolve: Option<Image>,
     load_op: CanvasLoadOp,
+
+    // This will be removed after queue_text and draw_queued_text have been removed.
+    pub(crate) queued_texts: Vec<(Text, mint::Point2<f32>, Option<Color>)>,
 }
 
 impl Canvas {
@@ -145,6 +148,8 @@ impl Canvas {
             target,
             resolve,
             load_op,
+
+            queued_texts: Vec::new(),
         };
 
         this.set_screen_coordinates(screen);
@@ -206,8 +211,8 @@ impl Canvas {
 
     /// Sets the active sampler used to sample images.
     #[inline]
-    pub fn set_sampler(&mut self, sampler: Sampler) {
-        self.state.sampler = sampler;
+    pub fn set_sampler(&mut self, sampler: impl Into<Sampler>) {
+        self.state.sampler = sampler.into();
     }
 
     /// Returns the currently active sampler used to sample images.
@@ -340,7 +345,7 @@ impl Canvas {
     /// Draws the given `Drawable` to the canvas with a given `DrawParam`.
     #[inline]
     pub fn draw(&mut self, drawable: &impl Drawable, param: impl Into<DrawParam>) {
-        drawable.draw(self, param.into())
+        drawable.draw(self, param)
     }
 
     /// Draws a `Mesh` textured with an `Image`.
@@ -352,7 +357,7 @@ impl Canvas {
 
     /// Draws an `InstanceArray` textured with a `Mesh`.
     ///
-    /// This differs from `cavnas.draw(instances, param)` as in that case, the instances are
+    /// This differs from `canvas.draw(instances, param)` as in that case, the instances are
     /// drawn as quads.
     pub fn draw_instanced_mesh(
         &mut self,

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -274,7 +274,7 @@ impl Canvas {
     /// Sets the bounds of the screen viewport. This is a shortcut for `set_projection`
     /// and thus will override any previous projection matrix set.
     ///
-    /// The default coordinate system has (0,0) at the top-left corner
+    /// The default coordinate system has \[0.0, 0.0\] at the top-left corner
     /// with X increasing to the right and Y increasing down, with the
     /// viewport scaled such that one coordinate unit is one pixel on the
     /// screen.  This function lets you change this coordinate system to

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -400,14 +400,14 @@ impl GraphicsContext {
         &self.window
     }
 
-    /// Sets the window icon.
-    pub fn set_window_icon(
-        &mut self,
+    /// Sets the window icon. `None` for path removes the icon.
+    pub fn set_window_icon<P: AsRef<Path>>(
+        &self,
         filesystem: &impl Has<Filesystem>,
-        path: Option<impl AsRef<Path>>,
+        path: impl Into<Option<P>>,
     ) -> GameResult {
         let filesystem = filesystem.retrieve();
-        let icon = match path {
+        let icon = match path.into() {
             Some(p) => Some(load_icon(p.as_ref(), filesystem)?),
             None => None,
         };

--- a/src/graphics/draw.rs
+++ b/src/graphics/draw.rs
@@ -125,7 +125,7 @@ pub type ZIndex = i32;
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct DrawParam {
     /// A portion of the drawable to clip, as a fraction of the whole image.
-    /// Defaults to the whole image `(0,0 to 1,1)` if omitted.
+    /// Defaults to the whole image (\[0.0, 0.0\] to \[1.0, 1.0\]) if omitted.
     pub src: Rect,
     /// Default: white.
     pub color: Color,

--- a/src/graphics/draw.rs
+++ b/src/graphics/draw.rs
@@ -161,18 +161,21 @@ impl DrawParam {
         self
     }
 
+    pub(crate) fn get_dest_mut(&mut self) -> &mut mint::Point2<f32> {
+        if let Transform::Values { dest, .. } = &mut self.transform {
+            dest
+        } else {
+            panic!("Cannot calculate destination value for a DrawParam matrix")
+        }
+    }
+
     /// Set the dest point.
-    pub fn dest<P>(mut self, dest_: P) -> Self
+    pub fn dest<P>(mut self, dest: P) -> Self
     where
         P: Into<mint::Point2<f32>>,
     {
-        if let Transform::Values { ref mut dest, .. } = self.transform {
-            let p: mint::Point2<f32> = dest_.into();
-            *dest = p;
-            self
-        } else {
-            panic!("Cannot set values for a DrawParam matrix")
-        }
+        *self.get_dest_mut() = dest.into();
+        self
     }
 
     /// Set the `dest` and `scale` together.
@@ -272,7 +275,7 @@ where
 /// All types that can be drawn onto a canvas implement the `Drawable` trait.
 pub trait Drawable {
     /// Draws the drawable onto the canvas.
-    fn draw(&self, canvas: &mut Canvas, param: DrawParam);
+    fn draw(&self, canvas: &mut Canvas, param: impl Into<DrawParam>);
 
     /// Returns a bounding box in the form of a `Rect`.
     ///

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -336,13 +336,13 @@ impl Image {
 }
 
 impl Drawable for Image {
-    fn draw(&self, canvas: &mut Canvas, param: DrawParam) {
+    fn draw(&self, canvas: &mut Canvas, param: impl Into<DrawParam>) {
         canvas.push_draw(
             Draw::Mesh {
                 mesh: canvas.default_resources().mesh.clone(),
                 image: self.clone(),
             },
-            param,
+            param.into(),
         );
     }
 

--- a/src/graphics/instance.rs
+++ b/src/graphics/instance.rs
@@ -266,14 +266,14 @@ impl InstanceArray {
 }
 
 impl Drawable for InstanceArray {
-    fn draw(&self, canvas: &mut Canvas, param: DrawParam) {
+    fn draw(&self, canvas: &mut Canvas, param: impl Into<DrawParam>) {
         self.flush_wgpu(&canvas.wgpu).unwrap();
         canvas.push_draw(
             Draw::MeshInstances {
                 mesh: canvas.default_resources().mesh.clone(),
                 instances: InstanceArrayView::from_instances(self).unwrap(),
             },
-            param,
+            param.into(),
         );
     }
 

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -53,7 +53,7 @@ impl Vertex {
     }
 }
 
-/// Mesh data stored on the GPU as a vertex and index buffer.
+/// Mesh data stored on the GPU as a vertex and index buffer. Cheap to clone.
 #[derive(Debug, Clone)]
 pub struct Mesh {
     pub(crate) verts: ArcBuffer,
@@ -263,13 +263,13 @@ impl Mesh {
 }
 
 impl Drawable for Mesh {
-    fn draw(&self, canvas: &mut Canvas, param: DrawParam) {
+    fn draw(&self, canvas: &mut Canvas, param: impl Into<DrawParam>) {
         canvas.push_draw(
             Draw::Mesh {
                 mesh: self.clone(),
                 image: canvas.default_resources().image.clone(),
             },
-            param,
+            param.into(),
         );
     }
 
@@ -293,8 +293,8 @@ pub struct Quad;
 
 // draw quad
 impl Drawable for Quad {
-    fn draw(&self, canvas: &mut Canvas, param: DrawParam) {
-        canvas.draw(&canvas.default_resources().mesh.clone(), param);
+    fn draw(&self, canvas: &mut Canvas, param: impl Into<DrawParam>) {
+        canvas.default_resources().mesh.clone().draw(canvas, param);
     }
 
     fn dimensions(&self, _gfx: &mut impl HasMut<GraphicsContext>) -> Option<Rect> {

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -73,3 +73,103 @@ pub fn transform_rect(rect: Rect, param: DrawParam) -> Rect {
         Transform::Matrix(_m) => todo!("Fix me"),
     }
 }
+
+use crate::{
+    context::{Has, HasTwo},
+    filesystem::Filesystem,
+    GameResult,
+};
+use mint::Point2;
+use std::path::Path;
+
+/// Draws the given Drawable object to the screen by calling its draw() method.
+#[deprecated(
+    since = "0.8.0",
+    note = "Use `drawable.draw` or `canvas.draw` instead."
+)]
+pub fn draw(canvas: &mut Canvas, drawable: &impl Drawable, param: impl Into<DrawParam>) {
+    drawable.draw(canvas, param);
+}
+
+/// Sets the window icon. `None` for path removes the icon.
+#[deprecated(since = "0.8.0", note = "Use `ctx.gfx.set_window_icon` instead.")]
+pub fn set_window_icon<P: AsRef<Path>>(
+    ctx: &impl HasTwo<GraphicsContext, Filesystem>,
+    path: impl Into<Option<P>>,
+) -> GameResult {
+    let gfx: &GraphicsContext = ctx.retrieve_first();
+    let fs: &Filesystem = ctx.retrieve_second();
+    gfx.set_window_icon(fs, path)
+}
+
+/// Sets the window position.
+#[deprecated(since = "0.8.0", note = "Use `ctx.gfx.set_window_position` instead.")]
+pub fn set_window_position(
+    ctx: &impl Has<GraphicsContext>,
+    position: impl Into<winit::dpi::Position>,
+) -> GameResult {
+    let gfx: &GraphicsContext = ctx.retrieve();
+    gfx.set_window_position(position)
+}
+
+/// Returns a reference to the Winit window.
+#[deprecated(since = "0.8.0", note = "Use `ctx.gfx.window` instead.")]
+pub fn window(ctx: &impl Has<GraphicsContext>) -> &winit::window::Window {
+    let gfx: &GraphicsContext = ctx.retrieve();
+    gfx.window()
+}
+
+/// Sets the window title.
+#[deprecated(since = "0.8.0", note = "Use `ctx.gfx.set_window_title` instead.")]
+pub fn set_window_title(ctx: &impl Has<GraphicsContext>, title: &str) {
+    let gfx: &GraphicsContext = ctx.retrieve();
+    gfx.set_window_title(title);
+}
+
+/// Draws text.
+#[deprecated(
+    since = "0.8.0",
+    note = "Don't use the `queue_text` and `draw_queued_text` system. Instead draw the texts directly."
+)]
+pub fn queue_text(
+    canvas: &mut Canvas,
+    text: &Text,
+    relative_dest: impl Into<Point2<f32>>,
+    color: Option<Color>,
+) {
+    canvas
+        .queued_texts
+        .push((text.clone(), relative_dest.into(), color));
+}
+
+/// Draws all of the Texts added via queue_text().
+#[deprecated(
+    since = "0.8.0",
+    note = "Don't use the `queue_text` and `draw_queued_text` system. Instead draw the texts directly."
+)]
+pub fn draw_queued_text(
+    canvas: &mut Canvas,
+    param: impl Into<DrawParam>,
+    blend: Option<BlendMode>,
+    filter: FilterMode,
+) -> GameResult {
+    let mut param = param.into();
+    let param_dest = *param.get_dest_mut();
+
+    canvas.set_sampler(filter);
+    if let Some(blend) = blend {
+        canvas.set_blend_mode(blend);
+    }
+
+    for queued_text in std::mem::take(&mut canvas.queued_texts) {
+        queued_text.0.draw(
+            canvas,
+            param.dest(mint::Point2 {
+                x: param_dest.x + queued_text.1.x,
+                y: param_dest.y + queued_text.1.y,
+            }),
+        )
+    }
+
+    Ok(())
+}

--- a/src/graphics/sampler.rs
+++ b/src/graphics/sampler.rs
@@ -59,6 +59,15 @@ impl<'a> From<Sampler> for wgpu::SamplerDescriptor<'a> {
     }
 }
 
+impl From<FilterMode> for Sampler {
+    fn from(filter: FilterMode) -> Self {
+        match filter {
+            FilterMode::Nearest => Self::nearest_clamp(),
+            FilterMode::Linear => Self::linear_clamp(),
+        }
+    }
+}
+
 /// Describes the clamping mode of a sampler, used when the shader writes to sample outside of texture boundaries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ClampMode {

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -298,8 +298,8 @@ impl Text {
 }
 
 impl Drawable for Text {
-    fn draw(&self, canvas: &mut Canvas, param: DrawParam) {
-        canvas.push_draw(Draw::BoundedText { text: self.clone() }, param);
+    fn draw(&self, canvas: &mut Canvas, param: impl Into<DrawParam>) {
+        canvas.push_draw(Draw::BoundedText { text: self.clone() }, param.into());
     }
 
     fn dimensions(&self, gfx: &mut impl HasMut<GraphicsContext>) -> Option<Rect> {

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -1,7 +1,6 @@
-use crate::graphics::{FillOptions, StrokeOptions};
+use mint::Point2;
 
-/// A 2 dimensional point representing a location
-pub(crate) type Point2 = glam::Vec2;
+use crate::graphics::{FillOptions, StrokeOptions};
 
 /// A simple 2D rectangle.
 ///
@@ -123,8 +122,8 @@ impl Rect {
     }
 
     /// Checks whether the `Rect` overlaps a circle.
-    pub fn overlaps_circle(&self, point: impl Into<Point2>, radius: f32) -> bool {
-        let point: glam::Vec2 = point.into();
+    pub fn overlaps_circle(&self, point: impl Into<Point2<f32>>, radius: f32) -> bool {
+        let point = glam::Vec2::from(point.into());
         let rect_center: glam::Vec2 = self.center().into();
         let circle_distance = (point - rect_center).abs();
 
@@ -179,10 +178,10 @@ impl Rect {
         let x1 = self.right();
         let y1 = self.bottom();
         let points = [
-            rotation * Point2::new(x0, y0),
-            rotation * Point2::new(x0, y1),
-            rotation * Point2::new(x1, y0),
-            rotation * Point2::new(x1, y1),
+            rotation * glam::Vec2::new(x0, y0),
+            rotation * glam::Vec2::new(x0, y1),
+            rotation * glam::Vec2::new(x1, y0),
+            rotation * glam::Vec2::new(x1, y1),
         ];
         let p0 = points[0];
         let mut x_max = p0.x;
@@ -627,10 +626,10 @@ mod tests {
     fn headless_test_rect_contains() {
         let r = Rect::new(0.0, 0.0, 128.0, 128.0);
         println!("{} {} {} {}", r.top(), r.bottom(), r.left(), r.right());
-        let p = Point2::new(1.0, 1.0);
+        let p = glam::Vec2::new(1.0, 1.0);
         assert!(r.contains(p));
 
-        let p = Point2::new(500.0, 0.0);
+        let p = glam::Vec2::new(500.0, 0.0);
         assert!(!r.contains(p));
     }
 
@@ -665,7 +664,7 @@ mod tests {
 
         let mut r1 = Rect::new(32.0, 32.0, 64.0, 64.0);
         let r2 = Rect::new(64.0, 64.0, 64.0, 64.0);
-        r1.move_to(Point2::new(64.0, 64.0));
+        r1.move_to(glam::Vec2::new(64.0, 64.0));
         assert!(r1 == r2);
     }
 

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -52,7 +52,7 @@ impl Rect {
         Self::new(0.0, 0.0, 0.0, 0.0)
     }
 
-    /// Creates a new `Rect` at `0,0` with width and height 1.
+    /// Creates a new `Rect` at \[0.0, 0.0\] with width and height 1.
     pub const fn one() -> Self {
         Self::new(0.0, 0.0, 1.0, 1.0)
     }

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -81,13 +81,13 @@ impl<'a> Iterator for GamepadsIterator<'a> {
 }
 
 /// Returns the `Gamepad` associated with an `id`.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.gamepad.gamepad` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.gamepad.gamepad` instead")]
 pub fn gamepad(ctx: &Context, id: GamepadId) -> Gamepad {
     ctx.gamepad.gamepad(id)
 }
 
 /// Return an iterator of all the `Gamepads` that are connected.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.gamepad.gamepads` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.gamepad.gamepads` instead")]
 pub fn gamepads(ctx: &Context) -> GamepadsIterator {
     ctx.gamepad.gamepads()
 }

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -330,17 +330,14 @@ impl Default for KeyboardContext {
 }
 
 /// Checks if a key is currently pressed down.
-#[deprecated(
-    since = "0.8.0-rc0",
-    note = "Use `ctx.keyboard.is_key_pressed` instead"
-)]
+#[deprecated(since = "0.8.0", note = "Use `ctx.keyboard.is_key_pressed` instead")]
 pub fn is_key_pressed(ctx: &Context, key: KeyCode) -> bool {
     ctx.keyboard.is_key_pressed(key)
 }
 
 /// Checks if a key has been pressed down this frame.
 #[deprecated(
-    since = "0.8.0-rc0",
+    since = "0.8.0",
     note = "Use `ctx.keyboard.is_key_just_pressed` instead"
 )]
 pub fn is_key_just_pressed(ctx: &Context, key: KeyCode) -> bool {
@@ -349,7 +346,7 @@ pub fn is_key_just_pressed(ctx: &Context, key: KeyCode) -> bool {
 
 /// Checks if a key has been released this frame.
 #[deprecated(
-    since = "0.8.0-rc0",
+    since = "0.8.0",
     note = "Use `ctx.keyboard.is_key_just_released` instead"
 )]
 pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
@@ -358,28 +355,25 @@ pub fn is_key_just_released(ctx: &Context, key: KeyCode) -> bool {
 
 /// Checks if the last keystroke sent by the system is repeated,
 /// like when a key is held down for a period of time.
-#[deprecated(
-    since = "0.8.0-rc0",
-    note = "Use `ctx.keyboard.is_key_repeated` instead"
-)]
+#[deprecated(since = "0.8.0", note = "Use `ctx.keyboard.is_key_repeated` instead")]
 pub fn is_key_repeated(ctx: &Context) -> bool {
     ctx.keyboard.is_key_repeated()
 }
 
 /// Returns a reference to the set of currently pressed keys.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.keyboard.pressed_keys` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.keyboard.pressed_keys` instead")]
 pub fn pressed_keys(ctx: &Context) -> &HashSet<KeyCode> {
     ctx.keyboard.pressed_keys()
 }
 
 /// Checks if keyboard modifier (or several) is active.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.keyboard.is_mod_active` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.keyboard.is_mod_active` instead")]
 pub fn is_mod_active(ctx: &Context, keymods: KeyMods) -> bool {
     ctx.keyboard.is_mod_active(keymods)
 }
 
 /// Returns currently active keyboard modifiers.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.keyboard.active_mods` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.keyboard.active_mods` instead")]
 pub fn active_mods(ctx: &Context) -> KeyMods {
     ctx.keyboard.active_mods()
 }

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -3,7 +3,6 @@
 use crate::context::Context;
 use crate::error::GameError;
 use crate::error::GameResult;
-use crate::graphics::Point2;
 use std::collections::HashSet;
 use winit::dpi;
 pub use winit::event::MouseButton;
@@ -13,9 +12,9 @@ pub use winit::window::CursorIcon;
 // TODO: Add "differences with window cursor" notice
 #[derive(Clone, Debug)]
 pub struct MouseContext {
-    last_position: Point2,
-    last_delta: Point2,
-    delta: Point2,
+    last_position: glam::Vec2,
+    last_delta: glam::Vec2,
+    delta: glam::Vec2,
     buttons_pressed: HashSet<MouseButton>,
     cursor_type: CursorIcon,
     cursor_grabbed: bool,
@@ -26,9 +25,9 @@ pub struct MouseContext {
 impl MouseContext {
     pub(crate) fn new() -> Self {
         Self {
-            last_position: Point2::ZERO,
-            last_delta: Point2::ZERO,
-            delta: Point2::ZERO,
+            last_position: glam::Vec2::ZERO,
+            last_delta: glam::Vec2::ZERO,
+            delta: glam::Vec2::ZERO,
             cursor_type: CursorIcon::Default,
             buttons_pressed: HashSet::new(),
             cursor_grabbed: false,
@@ -90,23 +89,23 @@ impl MouseContext {
     pub fn handle_move(&mut self, new_x: f32, new_y: f32) {
         let current_delta = self.delta();
         let current_pos = self.position();
-        let diff = crate::graphics::Point2::new(new_x - current_pos.x, new_y - current_pos.y);
+        let diff = glam::Vec2::new(new_x - current_pos.x, new_y - current_pos.y);
         // Sum up the cumulative mouse change for this frame in `delta`:
-        self.set_delta(crate::graphics::Point2::new(
+        self.set_delta(glam::Vec2::new(
             current_delta.x + diff.x,
             current_delta.y + diff.y,
         ));
         // `last_delta` is not cumulative.
         // It represents only the change between the last mouse event and the current one.
         self.set_last_delta(diff);
-        self.set_last_position(crate::graphics::Point2::new(new_x as f32, new_y as f32));
+        self.set_last_position(glam::Vec2::new(new_x as f32, new_y as f32));
     }
 
     /// Resets the value returned by [`mouse::delta`](fn.delta.html) to zero.
     /// You shouldn't need to call this, except when you're running your own event loop.
     /// In this case call it right at the end, after `draw` and `update` have finished.
     pub fn reset_delta(&mut self) {
-        self.delta = Point2::ZERO;
+        self.delta = glam::Vec2::ZERO;
     }
 
     /// Copies the current state of the mouse buttons into the context. If you are writing your own event loop
@@ -116,15 +115,15 @@ impl MouseContext {
         self.previous_buttons_pressed = self.buttons_pressed.clone();
     }
 
-    pub(crate) fn set_last_position(&mut self, p: Point2) {
+    pub(crate) fn set_last_position(&mut self, p: glam::Vec2) {
         self.last_position = p;
     }
 
-    pub(crate) fn set_last_delta(&mut self, p: Point2) {
+    pub(crate) fn set_last_delta(&mut self, p: glam::Vec2) {
         self.last_delta = p;
     }
 
-    pub(crate) fn set_delta(&mut self, p: Point2) {
+    pub(crate) fn set_delta(&mut self, p: glam::Vec2) {
         self.delta = p;
     }
 
@@ -149,13 +148,13 @@ impl Default for MouseContext {
 }
 
 /// Returns the current mouse cursor type of the window.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.mouse.cursor_type` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.mouse.cursor_type` instead")]
 pub fn cursor_type(ctx: &Context) -> CursorIcon {
     ctx.mouse.cursor_type()
 }
 
 /// Set whether or not the mouse is hidden (invisible)
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.mouse.cursor_hidden` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.mouse.cursor_hidden` instead")]
 pub fn cursor_hidden(ctx: &Context) -> bool {
     ctx.mouse.cursor_hidden()
 }
@@ -163,37 +162,31 @@ pub fn cursor_hidden(ctx: &Context) -> bool {
 /// Get the current position of the mouse cursor, in pixels.
 /// Complement to [`set_position()`](fn.set_position.html).
 /// Uses strictly window-only coordinates.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.mouse.position` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.mouse.position` instead")]
 pub fn position(ctx: &Context) -> mint::Point2<f32> {
     ctx.mouse.position()
 }
 
 /// Get the distance the cursor was moved during the current frame, in pixels.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.mouse.delta` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.mouse.delta` instead")]
 pub fn delta(ctx: &Context) -> mint::Point2<f32> {
     ctx.mouse.delta()
 }
 
 /// Returns whether or not the given mouse button is pressed.
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.mouse.button_pressed` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.mouse.button_pressed` instead")]
 pub fn button_pressed(ctx: &Context, button: MouseButton) -> bool {
     ctx.mouse.button_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been pressed this frame.
-#[deprecated(
-    since = "0.8.0-rc0",
-    note = "Use `ctx.mouse.button_just_pressed` instead"
-)]
+#[deprecated(since = "0.8.0", note = "Use `ctx.mouse.button_just_pressed` instead")]
 pub fn button_just_pressed(ctx: &Context, button: MouseButton) -> bool {
     ctx.mouse.button_just_pressed(button)
 }
 
 /// Returns whether or not the given mouse button has been released this frame.
-#[deprecated(
-    since = "0.8.0-rc0",
-    note = "Use `ctx.mouse.button_just_released` instead"
-)]
+#[deprecated(since = "0.8.0", note = "Use `ctx.mouse.button_just_released` instead")]
 pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
     ctx.mouse.button_just_released(button)
 }
@@ -210,7 +203,7 @@ pub fn button_just_released(ctx: &Context, button: MouseButton) -> bool {
 /// (Note that the default implementation of
 /// [`touch_event`](../../event/trait.EventHandler.html#method.touch_event) DOES trigger one, but
 /// it does so by invoking it on the `EventHandler` manually.)
-#[deprecated(since = "0.8.0-rc0", note = "Use `ctx.mouse.handle_move` instead")]
+#[deprecated(since = "0.8.0", note = "Use `ctx.mouse.handle_move` instead")]
 pub fn handle_move(ctx: &mut Context, new_x: f32, new_y: f32) {
     ctx.mouse.handle_move(new_x, new_y)
 }
@@ -252,13 +245,13 @@ pub fn set_position<P>(ctx: &mut Context, point: P) -> GameResult<()>
 where
     P: Into<mint::Point2<f32>>,
 {
-    let mintpoint = point.into();
-    ctx.mouse.last_position = Point2::from(mintpoint);
+    let point = glam::Vec2::from(point.into());
+    ctx.mouse.last_position = point;
     ctx.gfx
         .window
         .set_cursor_position(dpi::LogicalPosition {
-            x: f64::from(mintpoint.x),
-            y: f64::from(mintpoint.y),
+            x: f64::from(point.x),
+            y: f64::from(point.y),
         })
         .map_err(|_| GameError::WindowError("Couldn't set mouse cursor position!".to_owned()))
 }


### PR DESCRIPTION
While making this, I also realized we were exposing glam::Vec2 rather than mint::Point2 in some functions, removed the type alias to prevent such mistakes again.