### PR TITLE
Remove/replace undesired panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ The following list doesn't repeat the changes already mentioned above.
 * Improved `Text` performance through better glyph re-use
 * Changed the `Drawable` trait; this will downstream require changes in projects like `ggez-egui`
 * Version bumped `zip` to 0.6, `directories` to 4.0.1, `winit` to 0.26, image to `0.24` and `rodio` to 0.15
+* `DrawParam` methods such as `dest`, `scale`, etc. no longer panic when used on a `DrawParam` which holds the matrix
+  `Transform` variant; instead the matrix is lost and a new default `Transform` is created
+
 
 ## Deprecated
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,9 @@ use std::sync::Arc;
 /// An enum containing all kinds of game framework errors.
 #[derive(Debug)]
 pub enum GameError {
+    /// An error when trying to get or set values from a `DrawParam` that are no longer available
+    /// because it has already been crunched down into a Matrix
+    DrawParamMatrixError,
     /// An error when intializing the graphics system.
     GraphicsInitializationError,
     /// An error in the filesystem layout
@@ -61,6 +64,7 @@ pub enum GameError {
 impl fmt::Display for GameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            GameError::DrawParamMatrixError => write!(f, "Tried to access a value in a `DrawParam` which had its `Transform` already reduced down to a matrix"),
             GameError::ConfigError(ref s) => write!(f, "Config error: {}", s),
             GameError::ResourceLoadError(ref s) => write!(f, "Error loading resource: {}", s),
             GameError::ResourceNotFound(ref s, ref paths) => write!(

--- a/src/graphics/draw.rs
+++ b/src/graphics/draw.rs
@@ -185,7 +185,7 @@ impl DrawParam {
             }
             Err(e) => {
                 if let GameError::DrawParamMatrixError = e {
-                    self.transform = Transform::default(); // throw away the transform matrix and start over
+                    self.lose_matrix_transform();
                     self.dest(dest)
                 } else {
                     unreachable!("only DrawParamMatrixError is thrown by get_dest_mut!")
@@ -218,7 +218,7 @@ impl DrawParam {
             *rotation = rot;
             self
         } else {
-            self.transform = Transform::default(); // throw away the transform matrix and start over
+            self.lose_matrix_transform();
             self.rotation(rot)
         }
     }
@@ -236,7 +236,7 @@ impl DrawParam {
             *scale = p;
             self
         } else {
-            self.transform = Transform::default(); // throw away the transform matrix and start over
+            self.lose_matrix_transform();
             self.scale(scale_)
         }
     }
@@ -254,9 +254,16 @@ impl DrawParam {
             *offset = p;
             self
         } else {
-            self.transform = Transform::default(); // throw away the transform matrix and start over
+            self.lose_matrix_transform();
             self.offset(offset_)
         }
+    }
+
+    #[inline]
+    fn lose_matrix_transform(&mut self) {
+        self.transform = Transform::default(); // throw away the transform matrix and start over
+        eprintln!("WARNING: Transform matrix lost, reset DrawParam transform to default.");
+        // warn the user
     }
 
     /// Set the transformation matrix.

--- a/src/graphics/draw.rs
+++ b/src/graphics/draw.rs
@@ -1,5 +1,6 @@
 use super::{Canvas, Color, GraphicsContext, LinearColor, Rect};
 use crate::context::Has;
+use crate::{GameError, GameResult};
 
 /// A struct that represents where to put a drawable object.
 ///
@@ -160,11 +161,11 @@ impl DrawParam {
         self
     }
 
-    pub(crate) fn get_dest_mut(&mut self) -> &mut mint::Point2<f32> {
+    pub(crate) fn get_dest_mut(&mut self) -> GameResult<&mut mint::Point2<f32>> {
         if let Transform::Values { dest, .. } = &mut self.transform {
-            dest
+            Ok(dest)
         } else {
-            panic!("Cannot calculate destination value for a DrawParam matrix")
+            Err(GameError::DrawParamMatrixError)
         }
     }
 
@@ -173,7 +174,13 @@ impl DrawParam {
     where
         P: Into<mint::Point2<f32>>,
     {
-        *self.get_dest_mut() = dest.into();
+        // TODO: maybe let the error cascade up instead of just printing and stopping it here?
+        match self.get_dest_mut() {
+            Ok(dest_mut) => *dest_mut = dest.into(),
+            Err(_) => println!(
+                "Cannot set destination value for a DrawParam which has a matrix as `Transform`!"
+            ),
+        }
         self
     }
 
@@ -196,10 +203,10 @@ impl DrawParam {
         } = self.transform
         {
             *rotation = rot;
-            self
         } else {
-            panic!("Cannot set values for a DrawParam matrix")
+            print!("Cannot set values for a DrawParam matrix")
         }
+        self
     }
 
     /// Set the scaling factors.
@@ -210,10 +217,10 @@ impl DrawParam {
         if let Transform::Values { ref mut scale, .. } = self.transform {
             let p: mint::Vector2<f32> = scale_.into();
             *scale = p;
-            self
         } else {
-            panic!("Cannot set values for a DrawParam matrix")
+            print!("Cannot set values for a DrawParam matrix")
         }
+        self
     }
 
     /// Set the transformation offset.
@@ -224,10 +231,10 @@ impl DrawParam {
         if let Transform::Values { ref mut offset, .. } = self.transform {
             let p: mint::Point2<f32> = offset_.into();
             *offset = p;
-            self
         } else {
-            panic!("Cannot set values for a DrawParam matrix")
+            print!("Cannot set values for a DrawParam matrix")
         }
+        self
     }
 
     /// Set the transformation matrix.

--- a/src/graphics/gpu/pipeline.rs
+++ b/src/graphics/gpu/pipeline.rs
@@ -48,7 +48,7 @@ impl PipelineCache {
                         label: None,
                         layout: Some(layout),
                         vertex: wgpu::VertexState {
-                            module: &*info.vs,
+                            module: &info.vs,
                             entry_point: &info.vs_entry,
                             buffers: if info.vertices { &vertex_buffers } else { &[] },
                         },
@@ -78,7 +78,7 @@ impl PipelineCache {
                             alpha_to_coverage_enabled: false,
                         },
                         fragment: Some(wgpu::FragmentState {
-                            module: &*info.fs,
+                            module: &info.fs,
                             entry_point: &info.fs_entry,
                             targets: &[wgpu::ColorTargetState {
                                 format: info.format,
@@ -109,16 +109,16 @@ impl PipelineCache {
         self.layouts
             .entry(key)
             .or_insert_with(|| {
-                ArcPipelineLayout::new(device.create_pipeline_layout(
-                    &wgpu::PipelineLayoutDescriptor {
+                ArcPipelineLayout::new(
+                    device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                         label: None,
                         bind_group_layouts: &bind_groups
                             .iter()
                             .map(|bg| bg.handle.as_ref())
                             .collect::<Vec<_>>(),
                         push_constant_ranges: &[],
-                    },
-                ))
+                    }),
+                )
             })
             .clone()
     }

--- a/src/graphics/gpu/pipeline.rs
+++ b/src/graphics/gpu/pipeline.rs
@@ -109,16 +109,16 @@ impl PipelineCache {
         self.layouts
             .entry(key)
             .or_insert_with(|| {
-                ArcPipelineLayout::new(
-                    device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                ArcPipelineLayout::new(device.create_pipeline_layout(
+                    &wgpu::PipelineLayoutDescriptor {
                         label: None,
                         bind_group_layouts: &bind_groups
                             .iter()
                             .map(|bg| bg.handle.as_ref())
                             .collect::<Vec<_>>(),
                         push_constant_ranges: &[],
-                    }),
-                )
+                    },
+                ))
             })
             .clone()
     }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -154,7 +154,7 @@ pub fn draw_queued_text(
     filter: FilterMode,
 ) -> GameResult {
     let mut param = param.into();
-    let param_dest = *param.get_dest_mut();
+    let param_dest = *param.get_dest_mut()?;
 
     canvas.set_sampler(filter);
     if let Some(blend) = blend {

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -13,7 +13,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::fmt::{self, Debug};
 use std::fs;
-use std::io::{self, Read, Seek, Write};
+use std::io::{self, ErrorKind, Read, Seek, Write};
 use std::path::{self, Path, PathBuf};
 
 use crate::error::{GameError, GameResult};
@@ -677,7 +677,10 @@ impl io::Read for ZipFileWrapper {
 
 impl io::Write for ZipFileWrapper {
     fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-        panic!("Cannot write to a zip file!")
+        Err(io::Error::new(
+            ErrorKind::Unsupported,
+            "Can't write to a zip file!",
+        ))
     }
 
     fn flush(&mut self) -> io::Result<()> {


### PR DESCRIPTION
We shouldn't panic when there's no unrecoverable error. Instead we should return the errors, so that the user can decide how to react to them.

In some cases I for now opted for simply printing a message instead. This is very primitive and perhaps not ideal. But I'm unsure as to whether we really want to return `GameResult`s on most of `DrawParam`s methods. What I do know is that I don't want these functions to panic.

Instead of printing we could also use `warn!`, but many users won't see these messages, as they probably won't use a logger to listen to them.