### PR TITLE
Solved errors while compiling with `cargo clippy --all-targets --package ggez -- -D warnings`

### DIFF
--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -493,7 +493,7 @@ impl EventHandler for MainState {
             // but for now we just quit.
             if self.player.life <= 0.0 {
                 println!("Game over!");
-                let _ = event::request_quit(ctx);
+                event::request_quit(ctx);
             }
         }
 

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -177,7 +177,7 @@ impl event::EventHandler<ggez::GameError> for App {
                 TextFragment::new(ch).scale(PxScale::from(10.0 + 6.0 * self.rng.rand_float())),
             );
         }
-        let wobble_rect = (&wobble).dimensions(ctx).unwrap();
+        let wobble_rect = wobble.dimensions(ctx).unwrap();
         canvas.draw(
             &wobble,
             graphics::DrawParam::new()

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -411,7 +411,7 @@ mod tests {
     fn headless_encode_round_trip() {
         let c1 = conf::Conf::new();
         let mut writer = Vec::new();
-        let _c = c1.to_toml_file(&mut writer).unwrap();
+        c1.to_toml_file(&mut writer).unwrap();
         let mut reader = writer.as_slice();
         let c2 = conf::Conf::from_toml_file(&mut reader).unwrap();
         assert_eq!(c1, c2);

--- a/src/graphics/gpu/pipeline.rs
+++ b/src/graphics/gpu/pipeline.rs
@@ -48,7 +48,7 @@ impl PipelineCache {
                         label: None,
                         layout: Some(layout),
                         vertex: wgpu::VertexState {
-                            module: &*info.vs,
+                            module: &info.vs,
                             entry_point: &info.vs_entry,
                             buffers: if info.vertices { &vertex_buffers } else { &[] },
                         },
@@ -78,7 +78,7 @@ impl PipelineCache {
                             alpha_to_coverage_enabled: false,
                         },
                         fragment: Some(wgpu::FragmentState {
-                            module: &*info.fs,
+                            module: &info.fs,
                             entry_point: &info.fs_entry,
                             targets: &[wgpu::ColorTargetState {
                                 format: info.format,

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -122,6 +122,6 @@ mod tests {
 
     #[test]
     fn gilrs_init() {
-        assert!(GamepadContext::new().is_ok());
+        let _ = GamepadContext::new().unwrap();
     }
 }


### PR DESCRIPTION
Solved errors:

error: this let-binding has unit value
   --> src/conf.rs:414:9
    |
414 |         let _c = c1.to_toml_file(&mut writer).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `c1.to_toml_file(&mut writer).unwrap();`
    |
    = note: `-D clippy::let-unit-value` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value

error: deref which would be done by auto-deref
  --> src/graphics/gpu/pipeline.rs:51:38
   |
51 | ...                   module: &*info.vs,
   |                                ^^^^^^^^ help: try this: `info.vs`
   |
   = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: deref which would be done by auto-deref
  --> src/graphics/gpu/pipeline.rs:81:38
   |
81 | ...                   module: &*info.fs,
   |                                ^^^^^^^^ help: try this: `info.fs`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: called `assert!` with `Result::is_ok`
   --> src/input/gamepad.rs:125:9
    |
125 |         assert!(GamepadContext::new().is_ok());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `GamepadContext::new().unwrap()`
    |
    = note: `-D clippy::assertions-on-result-states` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_result_states


Which caused:

error: could not compile `ggez` due to previous error
warning: build failed, waiting for other jobs to finish...
error: this let-binding has unit value
   --> examples/05_astroblasto.rs:496:17
    |
496 |                 let _ = event::request_quit(ctx);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `event::request_quit(ctx);`
    |
    = note: `-D clippy::let-unit-value` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value

error: could not compile `ggez` due to previous error
error: unused result of type `input::gamepad::GamepadContext`
   --> src/input/gamepad.rs:125:9
    |
125 |         GamepadContext::new().unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:183:9
    |
183 | #![deny(unused_results)]
    |         ^^^^^^^^^^^^^^


Which caused:

error: this expression borrows a value the compiler would automatically borrow
   --> examples/text.rs:180:27
    |
180 |         let wobble_rect = (&wobble).dimensions(ctx).unwrap();
    |                           ^^^^^^^^^ help: change this to: `wobble`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow