### PR TITLE
shadow example fix and crevice re-export

### DIFF
--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -2,7 +2,7 @@
 
 use ggez::glam::Vec2;
 use ggez::graphics::{self, Color, DrawMode};
-use ggez::{event, graphics::AsStd140};
+use ggez::{event, graphics::crevice::std140::AsStd140};
 use ggez::{Context, GameResult};
 use std::env;
 use std::path;

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -2,7 +2,7 @@
 
 use ggez::glam::Vec2;
 use ggez::graphics::{self, Color, DrawMode};
-use ggez::{event, graphics::crevice::std140::AsStd140};
+use ggez::{event, graphics::AsStd140};
 use ggez::{Context, GameResult};
 use std::env;
 use std::path;

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -2,7 +2,7 @@
 //! and canvas's to do 2D GPU shadows.
 
 use ggez::glam::Vec2;
-use ggez::graphics::{self, AsStd140, BlendMode, Canvas, Color, DrawParam, Shader};
+use ggez::graphics::{self, crevice::std140::AsStd140, BlendMode, Canvas, Color, DrawParam, Shader};
 use ggez::{event, graphics::ShaderParams};
 use ggez::{Context, GameResult};
 use std::env;
@@ -27,9 +27,9 @@ struct Light {
 /// will not get properly encoded).
 const OCCLUSIONS_SHADER_SOURCE: &str = "
 struct VertexOutput {
-    @builtin(position) position: vec4<f32>;
-    @location(0) uv: vec2<f32>;
-    @location(1) color: vec4<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
 };
 
 struct Light {
@@ -44,17 +44,10 @@ struct Light {
 @group(1) @binding(0)
 var t: texture_2d<f32>;
 
-<<<<<<< HEAD
-@group(1) @binding(1)
+@group(2) @binding(0)
 var s: sampler;
 
-@group(3) @binding(0)
-=======
-[[group(2), binding(0)]]
-var s: sampler;
-
-[[group(4), binding(0)]]
->>>>>>> ec2076b1421aec71939a0eafcbabc43ec5deb4b5
+@group(4) @binding(0)
 var<uniform> light: Light;
 
 @fragment
@@ -103,17 +96,10 @@ struct Light {
 @group(1) @binding(0)
 var t: texture_2d<f32>;
 
-<<<<<<< HEAD
-@group(1) @binding(1)
+@group(2) @binding(0)
 var s: sampler;
 
-@group(0) binding(0)
-=======
-[[group(2), binding(0)]]
-var s: sampler;
-
-[[group(4), binding(0)]]
->>>>>>> ec2076b1421aec71939a0eafcbabc43ec5deb4b5
+@group(4) @binding(0)
 var<uniform> light: Light;
 
 fn degrees(x: f32) -> f32 {
@@ -164,17 +150,10 @@ struct Light {
 @group(1) @binding(0)
 var t: texture_2d<f32>;
 
-<<<<<<< HEAD
-@group(1) @binding(1)
+@group(2) @binding(0)
 var s: sampler;
 
-@group(0) binding(0)
-=======
-[[group(2), binding(0)]]
-var s: sampler;
-
-[[group(4), binding(0)]]
->>>>>>> ec2076b1421aec71939a0eafcbabc43ec5deb4b5
+@group(4) @binding(0)
 var<uniform> light: Light;
 
 fn degrees(x: f32) -> f32 {
@@ -194,7 +173,7 @@ fn main(in: VertexOutput) -> @location(0) vec4<f32> {
     var d = distance(g * in.uv, g * light.pos);
     var intensity = clamp(p/(d*d), 0.0, 0.6);
 
-    var blur = (2.5 / light.screen_size.x) * smoothStep(0.0, 1.0, r);
+    var blur = (2.5 / light.screen_size.x) * smoothstep(0.0, 1.0, r);
     var sum = 0.0;
     sum = sum + step(r, textureSample(t, s, vec2<f32>(ox - 4.0 * blur, 0.5)).r * 2.0) * 0.05;
     sum = sum + step(r, textureSample(t, s, vec2<f32>(ox - 3.0 * blur, 0.5)).r * 2.0) * 0.09;

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -2,7 +2,7 @@
 //! and canvas's to do 2D GPU shadows.
 
 use ggez::glam::Vec2;
-use ggez::graphics::{self, crevice::std140::AsStd140, BlendMode, Canvas, Color, DrawParam, Shader};
+use ggez::graphics::{self, AsStd140, BlendMode, Canvas, Color, DrawParam, Shader};
 use ggez::{event, graphics::ShaderParams};
 use ggez::{Context, GameResult};
 use std::env;

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -75,7 +75,9 @@ impl Shader {
     }
 }
 
-pub use crevice::std140::AsStd140;
+/// necessary because AsStd140 expects crevice to be available globally, see #1084
+pub use crevice;
+use crevice::std140::AsStd140;
 
 /// Parameters that can be passed to a custom shader, including uniforms, images, and samplers.
 ///

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -76,8 +76,8 @@ impl Shader {
 }
 
 /// necessary because AsStd140 expects crevice to be available globally, see #1084
-pub use crevice;
-use crevice::std140::AsStd140;
+pub extern crate crevice;
+pub use crevice::std140::AsStd140;
 
 /// Parameters that can be passed to a custom shader, including uniforms, images, and samplers.
 ///


### PR DESCRIPTION
fixed shadows example;
re-exported crevice as a whole for the AsStd140 macro to work outside of ggez;

The thing is: Whatever I do, I still can't use the `AsStd140` macro outside of ggez (i.e. when creating a test project and depending on ggez, but not crevice directly). Whenever I try I only get this:

```
error[E0433]: failed to resolve: could not find `crevice` in the list of imported crates
  --> src\main.rs:13:10
   |
13 | #[derive(AsStd140)]
   |          ^^^^^^^^ could not find `crevice` in the list of imported crates
   |
   = note: this error originates in the derive macro `AsStd140` (in Nightly builds, run with -Z macro-backtrace for more info)
```
no matter if I `use ggez::graphics::crevice` or not