### PR TITLE
Add logical_size to WindowMode and use it when set to add DPI aware window sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ If you didn't split it then you can comfortably hand around and pass the context
   * `event::request_quit` works like `event::quit` did before, except that instead of directly breaking the game loop it
   now triggers a `quit_event`, which allows you to handle all attempts to quit the game in one place.
 * Added a re-export for `glam`, as ggez is aimed at beginners for whom it's convenient to just have it at hand directly; most people will want/need to use it anyway
+* Added `logical_size` as optional argument in `WindowMode` which overrides width/height with a `LogicalSize` which supports high DPI systems.
 
 ## Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ zip = { version = "0.6", default-features = false, features = ["deflate"]  }
 directories = "4.0.1"
 wgpu = "0.13"
 glyph_brush = "0.7"
-winit = "0.26"
+winit = { version = "0.26", features = ["serde"] }
 image = { version = "0.24", default-features = false, features = [
    "gif",
    "png",

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -8,6 +8,7 @@
   * [How do I make a GUI?](#gfx_gui)
   * [Resolution independence (or "Why do things not end up where I want them to be?")](#gfx_resolution)
   * [Relative and absolute offsets with `DrawParam::offset`](#offsets)
+  * [Logical vs Pixel Sized](#logical-vs-pixel)
 * **[Input](#input)**
   * [Returned mouse coordinates are wrong!](#mouse_coords)
 * **[Libraries](#libraries)**
@@ -174,6 +175,34 @@ if let Transform::Values { offset, .. } = param.trans {
     }
 }
 ```
+
+<a name="logical-vs-pixel">
+
+## Logical vs Pixel Sized
+
+The standard window mode configuration requests a window size in absolute pixels:
+
+```
+        conf::WindowMode {
+            width: 800.0,
+            height: 600.0,
+            ..Default::default()
+        }
+```
+
+This can be problematic on high DPI screens where a 800x600 window is very small. 
+
+A new logical_size option will scale the requested window to be the same effective size on all screens by requesting a window with more pixels (1.5 or 2 times more for example).
+
+```
+        conf::WindowMode {
+            logical_size: Some(LogicalSize::new(800.0, 600.0)),
+            ..Default::default()
+        }
+```
+
+
+More details can be found [here](https://docs.rs/winit/latest/winit/dpi/index.html).
 
 <a name="input">
 

--- a/docs/conf.toml
+++ b/docs/conf.toml
@@ -9,21 +9,22 @@ width = 800
 height = 600
 borderless = false
 fullscreen_type = "Off"
-vsync = true
+maximized = false
+transparent = false
 min_width = 0
 min_height = 0
 max_width = 0
 max_height = 0
-
-[window_mode.logical_size]
+resizable = false
+visible = true
+resize_on_scale_factor_change = false
 
 [window_setup]
 title = "An easy, good game"
 icon = ""
-resizable = false
-allow_highdpi = true
 samples = "One"
+vsync = true
+srgb = true
+
 [backend]
-type = "OpenGL"
-major = 3
-minor = 2
+type = 'All'

--- a/docs/conf.toml
+++ b/docs/conf.toml
@@ -14,6 +14,9 @@ min_width = 0
 min_height = 0
 max_width = 0
 max_height = 0
+
+[window_mode.logical_size]
+
 [window_setup]
 title = "An easy, good game"
 icon = ""

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -65,6 +65,8 @@ pub struct WindowMode {
     /// Window height in physical pixels
     #[default = 600.0]
     pub height: f32,
+    /// Window height/width but allows LogicalSize for high DPI systems. If Some will be used instead of width/height.
+    pub logical_size: Option<winit::dpi::LogicalSize<f32>>,
     /// Whether or not to maximize the window
     #[default = false]
     pub maximized: bool,
@@ -190,6 +192,17 @@ impl WindowMode {
     pub fn resize_on_scale_factor_change(mut self, resize_on_scale_factor_change: bool) -> Self {
         self.resize_on_scale_factor_change = resize_on_scale_factor_change;
         self
+    }
+
+    // Use logical_size if set, else convert width/height to PhysicalSize
+    pub(crate) fn actual_size(&self) -> winit::dpi::Size {
+        if let Some(logical_size) = self.logical_size {
+            logical_size.into()
+        } else {
+            let physical_size = winit::dpi::PhysicalSize::<f64>::from((self.width, self.height));
+            assert!(physical_size.width >= 1.0 && physical_size.height >= 1.0); // wgpu needs surfaces > 0
+            physical_size.into()
+        }
     }
 }
 

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -15,6 +15,8 @@
 use std::convert::TryFrom;
 use std::io;
 
+use winit::dpi::PhysicalSize;
+
 use crate::error::{GameError, GameResult};
 
 /// Possible fullscreen modes.
@@ -196,25 +198,19 @@ impl WindowMode {
 
     // Use logical_size if set, else convert width/height to PhysicalSize
     pub(crate) fn actual_size(&self) -> GameResult<winit::dpi::Size> {
-        if let Some(logical_size) = self.logical_size {
-            if logical_size.width >= 1.0 && logical_size.height >= 1.0 {
-                Ok(logical_size.into())
-            } else {
-                Err(GameError::WindowError(format!(
-                    "window width and height need to be at least 1; actual values: {}, {}",
-                    logical_size.width, logical_size.height
-                )))
-            }
+        let actual_size: winit::dpi::Size = if let Some(logical_size) = self.logical_size {
+            logical_size.into()
         } else {
-            let physical_size = winit::dpi::PhysicalSize::<f64>::from((self.width, self.height));
-            if physical_size.width >= 1.0 && physical_size.height >= 1.0 {
-                Ok(physical_size.into())
-            } else {
-                Err(GameError::WindowError(format!(
-                    "window width and height need to be at least 1; actual values: {}, {}",
-                    physical_size.width, physical_size.height
-                )))
-            }
+            winit::dpi::PhysicalSize::<f64>::from((self.width, self.height)).into()
+        };
+        let physical_size: PhysicalSize<f64> = actual_size.to_physical(1.0);
+        if physical_size.width >= 1.0 && physical_size.height >= 1.0 {
+            Ok(actual_size)
+        } else {
+            Err(GameError::WindowError(format!(
+                "window width and height need to be at least 1; actual values: {}, {}",
+                physical_size.width, physical_size.height
+            )))
         }
     }
 }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -67,8 +67,6 @@ pub struct WindowMode {
     /// Window height in physical pixels
     #[default = 600.0]
     pub height: f32,
-    /// Window height/width but allows LogicalSize for high DPI systems. If Some will be used instead of width/height.
-    pub logical_size: Option<winit::dpi::LogicalSize<f32>>,
     /// Whether or not to maximize the window
     #[default = false]
     pub maximized: bool,
@@ -112,6 +110,10 @@ pub struct WindowMode {
     /// For more context on this take a look at [this conversation](https://github.com/ggez/ggez/pull/949#issuecomment-854731226).
     #[default = false]
     pub resize_on_scale_factor_change: bool,
+    // logical_size is serialized as a table, so it must be at the end of the struct for toml
+    /// Window height/width but allows LogicalSize for high DPI systems. If Some will be used instead of width/height.
+    #[default(None)]
+    pub logical_size: Option<winit::dpi::LogicalSize<f32>>,
 }
 
 impl WindowMode {
@@ -203,6 +205,7 @@ impl WindowMode {
         } else {
             winit::dpi::PhysicalSize::<f64>::from((self.width, self.height)).into()
         };
+
         let physical_size: PhysicalSize<f64> = actual_size.to_physical(1.0);
         if physical_size.width >= 1.0 && physical_size.height >= 1.0 {
             Ok(actual_size)

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -195,13 +195,26 @@ impl WindowMode {
     }
 
     // Use logical_size if set, else convert width/height to PhysicalSize
-    pub(crate) fn actual_size(&self) -> winit::dpi::Size {
+    pub(crate) fn actual_size(&self) -> GameResult<winit::dpi::Size> {
         if let Some(logical_size) = self.logical_size {
-            logical_size.into()
+            if logical_size.width >= 1.0 && logical_size.height >= 1.0 {
+                Ok(logical_size.into())
+            } else {
+                Err(GameError::WindowError(format!(
+                    "window width and height need to be at least 1; actual values: {}, {}",
+                    logical_size.width, logical_size.height
+                )))
+            }
         } else {
             let physical_size = winit::dpi::PhysicalSize::<f64>::from((self.width, self.height));
-            assert!(physical_size.width >= 1.0 && physical_size.height >= 1.0); // wgpu needs surfaces > 0
-            physical_size.into()
+            if physical_size.width >= 1.0 && physical_size.height >= 1.0 {
+                Ok(physical_size.into())
+            } else {
+                Err(GameError::WindowError(format!(
+                    "window width and height need to be at least 1; actual values: {}, {}",
+                    physical_size.width, physical_size.height
+                )))
+            }
         }
     }
 }

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -150,7 +150,7 @@ impl GraphicsContext {
     ) -> GameResult<Self> {
         let mut window_builder = winit::window::WindowBuilder::new()
             .with_title(conf.window_setup.title.clone())
-            .with_inner_size(conf.window_mode.actual_size())
+            .with_inner_size(conf.window_mode.actual_size().unwrap())
             .with_resizable(conf.window_mode.resizable)
             .with_visible(conf.window_mode.visible)
             .with_transparent(conf.window_mode.transparent);
@@ -691,7 +691,7 @@ impl GraphicsContext {
             FullscreenType::Windowed => {
                 window.set_fullscreen(None);
                 window.set_decorations(!mode.borderless);
-                window.set_inner_size(mode.actual_size());
+                window.set_inner_size(mode.actual_size()?);
                 window.set_resizable(mode.resizable);
                 window.set_maximized(mode.maximized);
             }

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -148,12 +148,9 @@ impl GraphicsContext {
         conf: &Conf,
         filesystem: &Filesystem,
     ) -> GameResult<Self> {
-        let physical_size =
-            dpi::PhysicalSize::<f64>::from((conf.window_mode.width, conf.window_mode.height));
-        assert!(physical_size.width >= 1.0 && physical_size.height >= 1.0); // wgpu needs surfaces > 0
         let mut window_builder = winit::window::WindowBuilder::new()
             .with_title(conf.window_setup.title.clone())
-            .with_inner_size(physical_size)
+            .with_inner_size(conf.window_mode.actual_size())
             .with_resizable(conf.window_mode.resizable)
             .with_visible(conf.window_mode.visible)
             .with_transparent(conf.window_mode.transparent);
@@ -694,17 +691,7 @@ impl GraphicsContext {
             FullscreenType::Windowed => {
                 window.set_fullscreen(None);
                 window.set_decorations(!mode.borderless);
-                if mode.width >= 1.0 && mode.height >= 1.0 {
-                    window.set_inner_size(dpi::PhysicalSize {
-                        width: f64::from(mode.width),
-                        height: f64::from(mode.height),
-                    });
-                } else {
-                    return Err(GameError::WindowError(format!(
-                        "window width and height need to be at least 1; actual values: {}, {}",
-                        mode.width, mode.height
-                    )));
-                }
+                window.set_inner_size(mode.actual_size());
                 window.set_resizable(mode.resizable);
                 window.set_maximized(mode.maximized);
             }


### PR DESCRIPTION
- Fixes https://github.com/ggez/ggez/issues/1091

The default width/height ggez uses is converted into a winit's PhysicalSize and used in two places:
  - The WindowBuilder for creating the window initially
  - set_window_mode which is called shortly after the window is first shown (1 frame from what I can tell)

This works great, except on high DPI machines, where 800x600 is exceptionally small.

winit has a LogicalSize which is correctly scaled by the current screen's DPI. However, as we do not want to break the common/easy case of width/height, it is being added as a optional argument on WindowMode (width/height is ignored when set to Some).

To add this to WindowMode, winit must include the serde feature as WindowMode is marked Serialize.

Usages of `dpi::PhysicalSize` that access conf.width/conf.height are now incorrect, so I added a crate public to create actual_size on WindowMode to prevent duplication.

One error case in resizing has been converted into an assert for simplicity, it only appears to be possible if the Window is set to a larger than 1x1 size and then resized to 0x0.