### PR TITLE
Minor changes

### DIFF
--- a/examples/03_drawing.rs
+++ b/examples/03_drawing.rs
@@ -19,8 +19,8 @@ struct MainState {
 impl MainState {
     /// Load images and create meshes.
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let image1 = graphics::Image::from_path(ctx, "/dragon1.png", true)?;
-        let image2 = graphics::Image::from_path(ctx, "/shot.png", true)?;
+        let image1 = graphics::Image::from_path(ctx, "/dragon1.png")?;
+        let image2 = graphics::Image::from_path(ctx, "/shot.png")?;
 
         let mb = &mut graphics::MeshBuilder::new();
         mb.rectangle(
@@ -29,7 +29,7 @@ impl MainState {
             graphics::Color::new(1.0, 0.0, 0.0, 1.0),
         )?;
 
-        let rock = graphics::Image::from_path(ctx, "/rock.png", true)?;
+        let rock = graphics::Image::from_path(ctx, "/rock.png")?;
 
         let meshes = vec![
             (None, build_mesh(ctx)?),

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -246,9 +246,9 @@ struct Assets {
 
 impl Assets {
     fn new(ctx: &mut Context) -> GameResult<Assets> {
-        let player_image = graphics::Image::from_path(ctx, "/player.png", true)?;
-        let shot_image = graphics::Image::from_path(ctx, "/shot.png", true)?;
-        let rock_image = graphics::Image::from_path(ctx, "/rock.png", true)?;
+        let player_image = graphics::Image::from_path(ctx, "/player.png")?;
+        let shot_image = graphics::Image::from_path(ctx, "/shot.png")?;
+        let rock_image = graphics::Image::from_path(ctx, "/rock.png")?;
 
         let shot_sound = audio::Source::new(ctx, "/pew.ogg")?;
         let hit_sound = audio::Source::new(ctx, "/boom.ogg")?;

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -234,7 +234,7 @@ impl MainState {
             Color::WHITE,
         )?;
 
-        let img = graphics::Image::from_path(ctx, "/player_sheet.png", true)?;
+        let img = graphics::Image::from_path(ctx, "/player_sheet.png")?;
         let s = MainState {
             ball,
             spritesheet: img,

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -54,7 +54,7 @@ impl GameState {
     fn new(ctx: &mut Context) -> ggez::GameResult<GameState> {
         // We just use the same RNG seed every time.
         let mut rng = Rand32::new(12345);
-        let texture = Image::from_path(ctx, "/wabbit_alpha.png", true)?;
+        let texture = Image::from_path(ctx, "/wabbit_alpha.png")?;
         let mut bunnies = Vec::with_capacity(INITIAL_BUNNIES);
         let max_x = (WIDTH - texture.width() as u16) as f32;
         let max_y = (HEIGHT - texture.height() as u16) as f32;

--- a/examples/canvas_subframe.rs
+++ b/examples/canvas_subframe.rs
@@ -21,7 +21,7 @@ struct MainState {
 
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let image = graphics::Image::from_path(ctx, "/tile.png", true).unwrap();
+        let image = graphics::Image::from_path(ctx, "/tile.png").unwrap();
         let instances = graphics::InstanceArray::new(ctx, image, 150 * 150, false);
         let canvas_image = graphics::ScreenImage::new(ctx, None, 1., 1., 1);
         let draw_pt = Point2::new(0.0, 0.0);

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -38,7 +38,7 @@ impl MainState {
         let s = MainState {
             angle: 0.0,
             zoom: 1.0,
-            image: graphics::Image::from_path(ctx, "/tile.png", true)?,
+            image: graphics::Image::from_path(ctx, "/tile.png")?,
             window_settings: WindowSettings {
                 toggle_fullscreen: false,
                 is_fullscreen: false,

--- a/examples/imageview.rs
+++ b/examples/imageview.rs
@@ -44,7 +44,7 @@ impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         ctx.fs.print_all();
 
-        let image = graphics::Image::from_path(ctx, "/dragon1.png", true)?;
+        let image = graphics::Image::from_path(ctx, "/dragon1.png")?;
 
         let mut sound = audio::Source::new(ctx, "/sound.ogg")?;
 

--- a/examples/instance_array.rs
+++ b/examples/instance_array.rs
@@ -17,7 +17,7 @@ struct MainState {
 
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let image = graphics::Image::from_path(ctx, "/tile.png", true)?;
+        let image = graphics::Image::from_path(ctx, "/tile.png")?;
         let instances = graphics::InstanceArray::new(ctx, image, 150 * 150, false);
         Ok(MainState { instances })
     }

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -25,57 +25,7 @@ struct Light {
 /// and encoded in the red channel (it is halved because if the distance can be
 /// greater than 1.0 - think bottom left to top right corner, that sqrt(1) and
 /// will not get properly encoded).
-const OCCLUSIONS_SHADER_SOURCE: &str = "
-struct VertexOutput {
-    @builtin(position) position: vec4<f32>;
-    @location(0) uv: vec2<f32>;
-    @location(1) color: vec4<f32>;
-};
-
-struct Light {
-    light_color: vec4<f32>,
-    shadow_color: vec4<f32>,
-    pos: vec2<f32>,
-    screen_size: vec2<f32>,
-    glow: f32,
-    strength: f32,
-}
-
-@group(1) @binding(0)
-var t: texture_2d<f32>;
-
-<<<<<<< HEAD
-@group(1) @binding(1)
-var s: sampler;
-
-@group(3) @binding(0)
-=======
-[[group(2), binding(0)]]
-var s: sampler;
-
-[[group(4), binding(0)]]
->>>>>>> ec2076b1421aec71939a0eafcbabc43ec5deb4b5
-var<uniform> light: Light;
-
-@fragment
-fn main(in: VertexOutput) -> @location(0) vec4<f32> {
-    var dist = 1.0;
-    var theta = in.uv.x * 6.28318530718;
-    var dir = vec2<f32>(cos(theta), sin(theta));
-    for (var i: i32 = 0; i < 1024; i = i + 1) {
-        var fi = f32(i);
-        var r = fi / 1024.0;
-        var rel = r * dir;
-        var p = clamp(light.pos + rel, vec2<f32>(0.0), vec2<f32>(1.0));
-        if (textureSample(t, s, p).a > 0.8) {
-            dist = distance(light.pos, p) * 0.5;
-            break;
-        }
-    }
-    var others = select(dist, 0.0, dist == 1.0);
-    return vec4<f32>(dist, others, others, 1.0);
-}
-";
+const OCCLUSIONS_SHADER_SOURCE: &str = include_str!("../resources/occlusions.wgsl");
 
 /// Shader for drawing shadows based on a 1D shadow map. It takes current
 /// fragment coordinates and converts them to polar coordinates centered
@@ -84,58 +34,7 @@ fn main(in: VertexOutput) -> @location(0) vec4<f32> {
 /// closest reported shadow, then the output is the shadow color, else it calculates some
 /// shadow based on the distance from light source based on strength and glow
 /// uniform parameters.
-const SHADOWS_SHADER_SOURCE: &str = "
-struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
-    @location(1) color: vec4<f32>,
-}
-
-struct Light {
-    light_color: vec4<f32>,
-    shadow_color: vec4<f32>,
-    pos: vec2<f32>,
-    screen_size: vec2<f32>,
-    glow: f32,
-    strength: f32,
-}
-
-@group(1) @binding(0)
-var t: texture_2d<f32>;
-
-<<<<<<< HEAD
-@group(1) @binding(1)
-var s: sampler;
-
-@group(0) binding(0)
-=======
-[[group(2), binding(0)]]
-var s: sampler;
-
-[[group(4), binding(0)]]
->>>>>>> ec2076b1421aec71939a0eafcbabc43ec5deb4b5
-var<uniform> light: Light;
-
-fn degrees(x: f32) -> f32 {
-    return x * 57.2957795130823208767981548141051703;
-}
-
-@fragment
-fn main(in: VertexOutput) -> @location(0) vec4<f32> {
-    var rel = light.pos - in.uv;
-    var theta = atan2(rel.y, rel.x);
-    var ox = (theta + 3.1415926) / 6.2831853;
-    var r = length(rel);
-    var occl = 1.0 - step(r, textureSample(t, s, vec2<f32>(ox, 0.5)).r * 2.0);
-
-    var g = light.screen_size / light.screen_size.y;
-    var p = light.strength + light.glow;
-    var d = distance(g * in.uv, g * light.pos);
-    var intensity = 1.0 - clamp(p/(d*d), 0.0, 1.0);
-
-    return light.shadow_color * vec4<f32>(vec3<f32>(mix(intensity, 1.0, occl)), 1.0);
-}
-";
+const SHADOWS_SHADER_SOURCE: &str = include_str!("../resources/shadows.wgsl");
 
 /// Shader for drawing lights based on a 1D shadow map. It takes current
 /// fragment coordinates and converts them to polar coordinates centered
@@ -145,70 +44,7 @@ fn main(in: VertexOutput) -> @location(0) vec4<f32> {
 /// light based on the distance from light source based on strength and glow
 /// uniform parameters. It is meant to be used additively for drawing multiple
 /// lights.
-const LIGHTS_SHADER_SOURCE: &str = "
-struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
-    @location(1) color: vec4<f32>,
-}
-
-struct Light {
-    light_color: vec4<f32>,
-    shadow_color: vec4<f32>,
-    pos: vec2<f32>,
-    screen_size: vec2<f32>,
-    glow: f32,
-    strength: f32,
-}
-
-@group(1) @binding(0)
-var t: texture_2d<f32>;
-
-<<<<<<< HEAD
-@group(1) @binding(1)
-var s: sampler;
-
-@group(0) binding(0)
-=======
-[[group(2), binding(0)]]
-var s: sampler;
-
-[[group(4), binding(0)]]
->>>>>>> ec2076b1421aec71939a0eafcbabc43ec5deb4b5
-var<uniform> light: Light;
-
-fn degrees(x: f32) -> f32 {
-    return x * 57.2957795130823208767981548141051703;
-}
-
-@fragment
-fn main(in: VertexOutput) -> @location(0) vec4<f32> {
-    var rel = light.pos - in.uv;
-    var theta = atan2(rel.y, rel.x);
-    var ox = (theta + 3.1415926) / 6.2831853;
-    var r = length(rel);
-    var occl = step(r, textureSample(t, s, vec2<f32>(ox, 0.5)).r * 2.0);
-
-    var g = light.screen_size / light.screen_size.y;
-    var p = light.strength + light.glow;
-    var d = distance(g * in.uv, g * light.pos);
-    var intensity = clamp(p/(d*d), 0.0, 0.6);
-
-    var blur = (2.5 / light.screen_size.x) * smoothStep(0.0, 1.0, r);
-    var sum = 0.0;
-    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox - 4.0 * blur, 0.5)).r * 2.0) * 0.05;
-    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox - 3.0 * blur, 0.5)).r * 2.0) * 0.09;
-    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox - 2.0 * blur, 0.5)).r * 2.0) * 0.12;
-    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox - 1.0 * blur, 0.5)).r * 2.0) * 0.15;
-    sum = sum + occl * 0.16;
-    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox + 1.0 * blur, 0.5)).r * 2.0) * 0.15;
-    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox + 2.0 * blur, 0.5)).r * 2.0) * 0.12;
-    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox + 3.0 * blur, 0.5)).r * 2.0) * 0.09;
-    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox + 4.0 * blur, 0.5)).r * 2.0) * 0.05;
-
-    return light.light_color * vec4<f32>(vec3<f32>(sum * intensity), 1.0);
-}
-";
+const LIGHTS_SHADER_SOURCE: &str = include_str!("../resources/lights.wgsl");
 
 struct MainState {
     background: graphics::Image,

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -81,8 +81,8 @@ const LIGHT_GLOW_RATE: f32 = 0.9;
 
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let background = graphics::Image::from_path(ctx, "/bg_top.png", true)?;
-        let tile = graphics::Image::from_path(ctx, "/tile.png", true)?;
+        let background = graphics::Image::from_path(ctx, "/bg_top.png")?;
+        let tile = graphics::Image::from_path(ctx, "/tile.png")?;
 
         let screen_size = {
             let size = ctx.gfx.drawable_size();

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -22,7 +22,7 @@ impl MainState {
     const GRID_POINT_RADIUS: f32 = 5.0;
 
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let angle = graphics::Image::from_path(ctx, "/angle.png", true)?;
+        let angle = graphics::Image::from_path(ctx, "/angle.png")?;
         let gridmesh_builder = &mut graphics::MeshBuilder::new();
         for x in 0..Self::GRID_SIZE {
             for y in 0..Self::GRID_SIZE {

--- a/resources/lights.wgsl
+++ b/resources/lights.wgsl
@@ -1,0 +1,55 @@
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
+}
+
+struct Light {
+    light_color: vec4<f32>,
+    shadow_color: vec4<f32>,
+    pos: vec2<f32>,
+    screen_size: vec2<f32>,
+    glow: f32,
+    strength: f32,
+}
+
+@group(1) @binding(0)
+var t: texture_2d<f32>;
+
+@group(2) @binding(0)
+var s: sampler;
+
+@group(4) @binding(0)
+var<uniform> light: Light;
+
+fn degrees(x: f32) -> f32 {
+    return x * 57.2957795130823208767981548141051703;
+}
+
+@fragment
+fn main(in: VertexOutput) -> @location(0) vec4<f32> {
+    var rel = light.pos - in.uv;
+    var theta = atan2(rel.y, rel.x);
+    var ox = (theta + 3.1415926) / 6.2831853;
+    var r = length(rel);
+    var occl = step(r, textureSample(t, s, vec2<f32>(ox, 0.5)).r * 2.0);
+
+    var g = light.screen_size / light.screen_size.y;
+    var p = light.strength + light.glow;
+    var d = distance(g * in.uv, g * light.pos);
+    var intensity = clamp(p / (d * d), 0.0, 0.6);
+
+    var blur = (2.5 / light.screen_size.x) * smoothstep(0.0, 1.0, r);
+    var sum = 0.0;
+    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox - 4.0 * blur, 0.5)).r * 2.0) * 0.05;
+    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox - 3.0 * blur, 0.5)).r * 2.0) * 0.09;
+    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox - 2.0 * blur, 0.5)).r * 2.0) * 0.12;
+    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox - 1.0 * blur, 0.5)).r * 2.0) * 0.15;
+    sum = sum + occl * 0.16;
+    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox + 1.0 * blur, 0.5)).r * 2.0) * 0.15;
+    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox + 2.0 * blur, 0.5)).r * 2.0) * 0.12;
+    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox + 3.0 * blur, 0.5)).r * 2.0) * 0.09;
+    sum = sum + step(r, textureSample(t, s, vec2<f32>(ox + 4.0 * blur, 0.5)).r * 2.0) * 0.05;
+
+    return light.light_color * vec4<f32>(vec3<f32>(sum * intensity), 1.0);
+}

--- a/resources/occlusions.wgsl
+++ b/resources/occlusions.wgsl
@@ -1,0 +1,42 @@
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
+};
+
+struct Light {
+    light_color: vec4<f32>,
+    shadow_color: vec4<f32>,
+    pos: vec2<f32>,
+    screen_size: vec2<f32>,
+    glow: f32,
+    strength: f32,
+}
+
+@group(1) @binding(0)
+var t: texture_2d<f32>;
+
+@group(2) @binding(0)
+var s: sampler;
+
+@group(4) @binding(0)
+var<uniform> light: Light;
+
+@fragment
+fn main(in: VertexOutput) -> @location(0) vec4<f32> {
+    var dist = 1.0;
+    var theta = in.uv.x * 6.28318530718;
+    var dir = vec2<f32>(cos(theta), sin(theta));
+    for (var i: i32 = 0; i < 1024; i = i + 1) {
+        var fi = f32(i);
+        var r = fi / 1024.0;
+        var rel = r * dir;
+        var p = clamp(light.pos + rel, vec2<f32>(0.0), vec2<f32>(1.0));
+        if (textureSample(t, s, p).a > 0.8) {
+            dist = distance(light.pos, p) * 0.5;
+            break;
+        }
+    }
+    var others = select(dist, 0.0, dist == 1.0);
+    return vec4<f32>(dist, others, others, 1.0);
+}

--- a/resources/shadows.wgsl
+++ b/resources/shadows.wgsl
@@ -1,0 +1,43 @@
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
+}
+
+struct Light {
+    light_color: vec4<f32>,
+    shadow_color: vec4<f32>,
+    pos: vec2<f32>,
+    screen_size: vec2<f32>,
+    glow: f32,
+    strength: f32,
+}
+
+@group(1) @binding(0)
+var t: texture_2d<f32>;
+
+@group(2) @binding(0)
+var s: sampler;
+
+@group(4) @binding(0)
+var<uniform> light: Light;
+
+fn degrees(x: f32) -> f32 {
+    return x * 57.2957795130823208767981548141051703;
+}
+
+@fragment
+fn main(in: VertexOutput) -> @location(0) vec4<f32> {
+    var rel = light.pos - in.uv;
+    var theta = atan2(rel.y, rel.x);
+    var ox = (theta + 3.1415926) / 6.2831853;
+    var r = length(rel);
+    var occl = 1.0 - step(r, textureSample(t, s, vec2<f32>(ox, 0.5)).r * 2.0);
+
+    var g = light.screen_size / light.screen_size.y;
+    var p = light.strength + light.glow;
+    var d = distance(g * in.uv, g * light.pos);
+    var intensity = 1.0 - clamp(p / (d * d), 0.0, 1.0);
+
+    return light.shadow_color * vec4<f32>(vec3<f32>(mix(intensity, 1.0, occl)), 1.0);
+}

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -56,6 +56,7 @@ pub enum FullscreenType {
 ///     visible: true,
 ///     transparent: false,
 ///     resize_on_scale_factor_change: false,
+///     logical_size: None,
 /// }
 /// # , WindowMode::default());}
 /// ```

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -131,11 +131,7 @@ impl Image {
 
     /// Creates a new image initialized with pixel data loaded from an encoded image `Read` (e.g. PNG or JPEG).
     #[allow(unused_results)]
-    pub fn from_path(
-        ctxs: &impl Has<GraphicsContext>,
-        path: impl AsRef<Path>,
-        srgb: bool,
-    ) -> GameResult<Self> {
+    pub fn from_path(ctxs: &impl Has<GraphicsContext>, path: impl AsRef<Path>) -> GameResult<Self> {
         let gfx = ctxs.retrieve();
 
         let mut encoded = Vec::new();
@@ -148,11 +144,7 @@ impl Image {
         Ok(Self::from_pixels(
             gfx,
             rgba8.as_ref(),
-            if srgb {
-                ImageFormat::Rgba8UnormSrgb
-            } else {
-                ImageFormat::Rgba8Unorm
-            },
+            ImageFormat::Rgba8UnormSrgb,
             width,
             height,
         ))


### PR DESCRIPTION
The srgb parameter is always going to be true, if there's demand we can add an additional non-srgb function. Removing the srgb parameter simplifies `Image` usage. What do you think of this @PSteinhaus?

Also fixes the shadow example so it actually compiles

(Just saw shadow example fix in #1090 after fixing it myself)