### PR TITLE
Split text alignment and wrapping

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -82,14 +82,14 @@ impl App {
         // vertical bound will cut off the extra off the bottom.
         // Alignment within the bounds can be set by `Align` enum.
         text.set_bounds(Vec2::new(400.0, f32::INFINITY))
-            .set_layout(TextLayout::Wrap {
+            .set_layout(TextLayout {
                 h_align: TextAlign::Begin,
                 v_align: TextAlign::Begin,
             });
         texts.insert("1_demo_text_2", text.clone());
 
         text.set_bounds(Vec2::new(500.0, f32::INFINITY))
-            .set_layout(TextLayout::Wrap {
+            .set_layout(TextLayout {
                 h_align: TextAlign::End,
                 v_align: TextAlign::Begin,
             });
@@ -102,7 +102,7 @@ impl App {
         text.set_font("Fancy font")
             .set_scale(16.0)
             .set_bounds(Vec2::new(300.0, f32::INFINITY))
-            .set_layout(TextLayout::Wrap {
+            .set_layout(TextLayout {
                 h_align: TextAlign::Middle,
                 v_align: TextAlign::Begin,
             });

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -114,6 +114,7 @@ impl<S: Into<String>> From<S> for TextFragment {
 pub struct Text {
     fragments: Vec<TextFragment>,
     layout: TextLayout,
+    wrap: bool,
     bounds: mint::Vector2<f32>,
     scale: PxScale,
     font: String,
@@ -123,7 +124,8 @@ impl Default for Text {
     fn default() -> Self {
         Self {
             fragments: Vec::new(),
-            layout: TextLayout::tl_wrap(),
+            layout: TextLayout::top_left(),
+            wrap: true,
             bounds: mint::Vector2::<f32> {
                 x: f32::INFINITY,
                 y: f32::INFINITY,
@@ -175,11 +177,15 @@ impl Text {
         self
     }
 
-    /// Specifies how the text will wrap within the bounds specified by [`Text::set_bounds`].
-    ///
-    /// Wrapping can be disabled by setting `layout` to `TextLayout::SingleLine`.
+    /// Specifies how the text will be layed out.
     pub fn set_layout(&mut self, layout: TextLayout) -> &mut Self {
         self.layout = layout;
+        self
+    }
+
+    /// Specifies whether or not the text will be wrapped within the bounds bounds specified by [`Text::set_bounds`].
+    pub fn set_wrap(&mut self, wrap: bool) -> &mut Self {
+        self.wrap = wrap;
         self
     }
 
@@ -246,31 +252,18 @@ impl Text {
         fonts: &HashMap<String, FontId>,
         param: DrawParam,
     ) -> GameResult<glyph_brush::Section<'a, Extra>> {
-        let x = match self.layout.h_align() {
-            TextAlign::Begin => 0.,
-            TextAlign::Middle => self.bounds.x / 2.,
-            TextAlign::End => self.bounds.x,
-        };
-
-        let y = match self.layout.v_align() {
-            TextAlign::Begin => 0.,
-            TextAlign::Middle => self.bounds.y / 2.,
-            TextAlign::End => self.bounds.y,
-        };
-
         Ok(glyph_brush::Section {
-            screen_position: (x, y),
+            screen_position: (0., 0.),
+
             bounds: (self.bounds.x, self.bounds.x),
-            layout: match self.layout {
-                TextLayout::SingleLine { h_align, v_align } => {
-                    glyph_brush::Layout::default_single_line()
-                        .h_align(h_align.into())
-                        .v_align(v_align.into())
-                }
-                TextLayout::Wrap { h_align, v_align } => glyph_brush::Layout::default_wrap()
-                    .h_align(h_align.into())
-                    .v_align(v_align.into()),
-            },
+            layout: if self.wrap {
+                glyph_brush::Layout::default_wrap()
+            } else {
+                glyph_brush::Layout::default_single_line()
+            }
+            .h_align(self.layout.h_align.into())
+            .v_align(self.layout.v_align.into()),
+
             text: self
                 .fragments
                 .iter()
@@ -342,59 +335,27 @@ impl From<TextAlign> for glyph_brush::VerticalAlign {
 
 /// Describes text alignment along both axes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum TextLayout {
-    /// Text is layed out in a single line.
-    SingleLine {
-        /// Horizontal alignment.
-        h_align: TextAlign,
-        /// Vertical alignment.
-        v_align: TextAlign,
-    },
-    /// Text wraps around the bounds.
-    Wrap {
-        /// Horizontal alignment.
-        h_align: TextAlign,
-        /// Vertical alignment.
-        v_align: TextAlign,
-    },
+pub struct TextLayout {
+    /// Horizontal alignment.
+    pub h_align: TextAlign,
+    /// Vertical alignment.
+    pub v_align: TextAlign,
 }
 
 impl TextLayout {
-    /// Text on a single line aligned to the top-left.
-    pub fn tl_single_line() -> Self {
-        TextLayout::SingleLine {
+    /// Text aligned to the top-left.
+    pub fn top_left() -> Self {
+        TextLayout {
             h_align: TextAlign::Begin,
             v_align: TextAlign::Begin,
         }
     }
 
-    /// Text wrapped and aligned to the top-left.
-    pub fn tl_wrap() -> Self {
-        TextLayout::Wrap {
-            h_align: TextAlign::Begin,
-            v_align: TextAlign::Begin,
-        }
-    }
-
-    /// Text wrapped and aligned to the center.
-    pub fn center_wrap() -> Self {
-        TextLayout::Wrap {
+    /// Text aligned to the center.
+    pub fn center() -> Self {
+        TextLayout {
             h_align: TextAlign::Middle,
             v_align: TextAlign::Middle,
-        }
-    }
-
-    /// Returns the horizontal alignment, regardless of wrapping behaviour.
-    pub fn h_align(&self) -> TextAlign {
-        match self {
-            TextLayout::SingleLine { h_align, .. } | TextLayout::Wrap { h_align, .. } => *h_align,
-        }
-    }
-
-    /// Returns the vertical alignment, regardless of wrapping behaviour.
-    pub fn v_align(&self) -> TextAlign {
-        match self {
-            TextLayout::SingleLine { v_align, .. } | TextLayout::Wrap { v_align, .. } => *v_align,
         }
     }
 }


### PR DESCRIPTION
Also makes screen_coordinates which depended on bounds before for some reason?