### PR TITLE
Fix breakage due to lower limits by bumping max_texture_dimension_1d/max_texture_dimension_2d back to previous values

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -194,6 +194,8 @@ impl GraphicsContext {
                     // InstanceArray uses 2 storage buffers.
                     max_storage_buffers_per_shader_stage: 2,
                     max_storage_buffer_binding_size: INSTANCE_BUFFER_SIZE,
+                    max_texture_dimension_1d: 8192,
+                    max_texture_dimension_2d: 8192,
                     ..wgpu::Limits::downlevel_webgl2_defaults()
                 },
             },


### PR DESCRIPTION
- Fixes https://github.com/ggez/ggez/issues/1097

In 4b86be71df9ddadf0f270e987354777f5041d6fb the limits were reduced to lower numbers. However, they cause my macOS application that was previously working to fail with:

```
    In Device::create_texture
    Dimension X value 2400 exceeds the limit of 2048
```

By setting max_texture_dimension_1d/max_texture_dimension_2d back to the values they were before the change, my app started working again.

I am blindly doing this, I am not certain is is correct.