### PR TITLE
Set two symbols required for custom event loops public

### DIFF
--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -289,7 +289,9 @@ impl KeyboardContext {
         }
     }
 
-    pub(crate) fn set_modifiers(&mut self, keymods: KeyMods) {
+    /// Set the keyboard active modifiers
+    /// Really useful only if you are writing your own event loop
+    pub fn set_modifiers(&mut self, keymods: KeyMods) {
         self.active_modifiers = keymods;
     }
 

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -136,7 +136,8 @@ impl MouseContext {
     }
 
     /// Get the distance the cursor was moved between the latest two mouse_motion_events.
-    pub(crate) fn last_delta(&self) -> mint::Point2<f32> {
+    /// Really useful only if you are writing your own event loop
+    pub fn last_delta(&self) -> mint::Point2<f32> {
         self.last_delta.into()
     }
 }


### PR DESCRIPTION
- Fixes https://github.com/ggez/ggez/issues/1099

I actually gave up on the feature that requires it, but it seems like a good idea in general. 