### PR TITLE
Fixed text example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ The following list doesn't repeat the changes already mentioned above.
   done now), as it makes things like centering text on positions easier (see the blend modes example)
 * Also `Text` is now a first class citizen and can be drawn normally with `DrawParam`, implementing things like rotation
  that weren't possible in batched text rendering before
+* Changed how bounds on Text work as well as layouting
+  * `Text::set_bounds` now expects width and height of the bounds, but not the destination point, as that's handled through the `DrawParam`
+  * additionally to horizontal alignment vertical alignment is now possible as well
 * Improved `Text` performance through better glyph re-use
 * Changed the `Drawable` trait; this will downstream require changes in projects like `ggez-egui`
 * Version bumped `zip` to 0.6, `directories` to 4.0.1, `winit` to 0.27.3, image to `0.24` and `rodio` to 0.16

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -90,7 +90,7 @@ impl App {
 
         text.set_bounds(Vec2::new(500.0, f32::INFINITY))
             .set_layout(TextLayout {
-                h_align: TextAlign::End,
+                h_align: TextAlign::Begin,
                 v_align: TextAlign::Begin,
             });
         texts.insert("1_demo_text_3", text.clone());
@@ -148,10 +148,11 @@ impl event::EventHandler<ggez::GameError> for App {
         );
 
         let mut height = 0.0;
-        for text in self.texts.values() {
+        for (key, text) in self.texts.iter() {
             // Calling `.queue()` for all bits of text that can share a `DrawParam`,
             // followed with `::draw_queued()` with said params, is the intended way.
-            canvas.draw(text, Vec2::new(20.0, 20.0 + height));
+            let x = if *key == "1_demo_text_4" { 250.0 } else { 20.0 };
+            canvas.draw(text, Vec2::new(x, 20.0 + height));
             //height += 20.0 + text.height(ctx) as f32;
             height += 20.0 + text.dimensions(ctx).unwrap().h as f32;
         }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -96,7 +96,7 @@ impl App {
         texts.insert("1_demo_text_3", text.clone());
 
         // This can be used to set the font and scale unformatted fragments will use.
-        // Color is specified when drawing (or queueing), via `DrawParam`.
+        // Color is specified when drawing, via `DrawParam`.
         // Side note: TrueType fonts aren't very consistent between themselves in terms
         // of apparent scale - this font with default scale will appear too small.
         text.set_font("Fancy font")
@@ -149,8 +149,6 @@ impl event::EventHandler<ggez::GameError> for App {
 
         let mut height = 0.0;
         for (key, text) in self.texts.iter() {
-            // Calling `.queue()` for all bits of text that can share a `DrawParam`,
-            // followed with `::draw_queued()` with said params, is the intended way.
             let x = if *key == "1_demo_text_4" { 250.0 } else { 20.0 };
             canvas.draw(text, Vec2::new(x, 20.0 + height));
             //height += 20.0 + text.height(ctx) as f32;
@@ -165,7 +163,7 @@ impl event::EventHandler<ggez::GameError> for App {
             text.fragments_mut()[3].color = Some(random_color(&mut self.rng));
         }
 
-        // Another animation example. Note, this is very inefficient as-is.
+        // Another animation example. Note, this is relatively inefficient as-is.
         let wobble_string = "WOBBLE";
         let mut wobble = Text::default();
         for ch in wobble_string.chars() {


### PR DESCRIPTION
The new bounds no longer taking a desination point means that we have to adapt the text example a little.

My change fixes the example and is OK I think, but we could perhaps go another way and collect destinations together with texts while in `update`, so that we only need to draw what we have in `draw`, without that weird little if.

I also removed the reference to `queue` (and that you should use it for better performance, very happy that these times are gone), now that it's just no longer there :)