### PR TITLE
Add support for user-supplied vertex shaders

### DIFF
--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -23,7 +23,7 @@ impl MainState {
         let dim = Dim { rate: 0.5 };
         let shader = graphics::ShaderBuilder::new_wgsl()
             .fragment_code(include_str!("../resources/dimmer.wgsl"))
-            .build(&mut ctx.gfx)?;
+            .build(&ctx.gfx)?;
         let params = graphics::ShaderParams::new(ctx, &dim, &[], &[]);
         Ok(MainState {
             dim,

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -24,7 +24,7 @@ impl MainState {
         let shader = graphics::ShaderBuilder::new_wgsl()
             .fragment_path("/dimmer.wgsl")
             .build(&ctx.gfx)?;
-        let params = graphics::ShaderParams::new(ctx, &dim, &[], &[]);
+        let params = graphics::ShaderParamsBuilder::new(&dim).build(&mut ctx.gfx);
         Ok(MainState {
             dim,
             shader,

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -22,7 +22,7 @@ impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         let dim = Dim { rate: 0.5 };
         let shader = graphics::ShaderBuilder::new_wgsl()
-            .fragment_code(include_str!("../resources/dimmer.wgsl"))
+            .fragment_path("/dimmer.wgsl")
             .build(&ctx.gfx)?;
         let params = graphics::ShaderParams::new(ctx, &dim, &[], &[]);
         Ok(MainState {

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -21,8 +21,9 @@ struct MainState {
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         let dim = Dim { rate: 0.5 };
-        let shader =
-            graphics::Shader::new_wgsl(ctx, include_str!("../resources/dimmer.wgsl"), "main");
+        let shader = graphics::ShaderBuilder::new_wgsl()
+            .fragment_code(include_str!("../resources/dimmer.wgsl"))
+            .build(&mut ctx.gfx)?;
         let params = graphics::ShaderParams::new(ctx, &dim, &[], &[]);
         Ok(MainState {
             dim,

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -22,7 +22,7 @@ impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         let dim = Dim { rate: 0.5 };
         let shader =
-            graphics::Shader::from_wgsl(ctx, include_str!("../resources/dimmer.wgsl"), "main");
+            graphics::Shader::new_wgsl(ctx, include_str!("../resources/dimmer.wgsl"), "main");
         let params = graphics::ShaderParams::new(ctx, &dim, &[], &[]);
         Ok(MainState {
             dim,

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -121,13 +121,13 @@ impl MainState {
 
         let occlusions_shader = ShaderBuilder::new_wgsl()
             .fragment_code(OCCLUSIONS_SHADER_SOURCE)
-            .build(&mut ctx.gfx)?;
+            .build(&ctx.gfx)?;
         let shadows_shader = ShaderBuilder::new_wgsl()
             .fragment_code(SHADOWS_SHADER_SOURCE)
-            .build(&mut ctx.gfx)?;
+            .build(&ctx.gfx)?;
         let lights_shader = ShaderBuilder::new_wgsl()
             .fragment_code(LIGHTS_SHADER_SOURCE)
-            .build(&mut ctx.gfx)?;
+            .build(&ctx.gfx)?;
 
         Ok(MainState {
             background,

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -119,9 +119,9 @@ impl MainState {
         let shadows = graphics::ScreenImage::new(ctx, None, 1., 1., 1);
         let lights = graphics::ScreenImage::new(ctx, None, 1., 1., 1);
 
-        let occlusions_shader = Shader::from_wgsl(ctx, OCCLUSIONS_SHADER_SOURCE, "main");
-        let shadows_shader = Shader::from_wgsl(ctx, SHADOWS_SHADER_SOURCE, "main");
-        let lights_shader = Shader::from_wgsl(ctx, LIGHTS_SHADER_SOURCE, "main");
+        let occlusions_shader = Shader::new_wgsl(ctx, OCCLUSIONS_SHADER_SOURCE, "main");
+        let shadows_shader = Shader::new_wgsl(ctx, SHADOWS_SHADER_SOURCE, "main");
+        let lights_shader = Shader::new_wgsl(ctx, LIGHTS_SHADER_SOURCE, "main");
 
         Ok(MainState {
             background,

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -2,7 +2,9 @@
 //! and canvas's to do 2D GPU shadows.
 
 use ggez::glam::Vec2;
-use ggez::graphics::{self, AsStd140, BlendMode, Canvas, Color, DrawParam, Shader, ShaderBuilder};
+use ggez::graphics::{
+    self, AsStd140, BlendMode, Canvas, Color, DrawParam, Shader, ShaderBuilder, ShaderParamsBuilder,
+};
 use ggez::{event, graphics::ShaderParams};
 use ggez::{Context, GameResult};
 use std::env;
@@ -97,7 +99,7 @@ impl MainState {
             glow: 0.0,
             strength: LIGHT_STRENGTH,
         };
-        let torch_params = ShaderParams::new(ctx, &torch, &[], &[]);
+        let torch_params = ShaderParamsBuilder::new(&torch).build(&mut ctx.gfx);
 
         let (w, h) = ctx.gfx.size();
         let (x, y) = (100.0 / w as f32, 75.0 / h as f32);
@@ -110,7 +112,7 @@ impl MainState {
             glow: 0.0,
             strength: LIGHT_STRENGTH,
         };
-        let static_light_params = ShaderParams::new(ctx, &static_light, &[], &[]);
+        let static_light_params = ShaderParamsBuilder::new(&static_light).build(&mut ctx.gfx);
 
         let color_format = ctx.gfx.surface_format();
         let foreground = graphics::ScreenImage::new(ctx, None, 1., 1., 1);

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -2,7 +2,7 @@
 //! and canvas's to do 2D GPU shadows.
 
 use ggez::glam::Vec2;
-use ggez::graphics::{self, AsStd140, BlendMode, Canvas, Color, DrawParam, Shader};
+use ggez::graphics::{self, AsStd140, BlendMode, Canvas, Color, DrawParam, Shader, ShaderBuilder};
 use ggez::{event, graphics::ShaderParams};
 use ggez::{Context, GameResult};
 use std::env;
@@ -119,9 +119,15 @@ impl MainState {
         let shadows = graphics::ScreenImage::new(ctx, None, 1., 1., 1);
         let lights = graphics::ScreenImage::new(ctx, None, 1., 1., 1);
 
-        let occlusions_shader = Shader::new_wgsl(ctx, OCCLUSIONS_SHADER_SOURCE, "main");
-        let shadows_shader = Shader::new_wgsl(ctx, SHADOWS_SHADER_SOURCE, "main");
-        let lights_shader = Shader::new_wgsl(ctx, LIGHTS_SHADER_SOURCE, "main");
+        let occlusions_shader = ShaderBuilder::new_wgsl()
+            .fragment_code(OCCLUSIONS_SHADER_SOURCE)
+            .build(&mut ctx.gfx)?;
+        let shadows_shader = ShaderBuilder::new_wgsl()
+            .fragment_code(SHADOWS_SHADER_SOURCE)
+            .build(&mut ctx.gfx)?;
+        let lights_shader = ShaderBuilder::new_wgsl()
+            .fragment_code(LIGHTS_SHADER_SOURCE)
+            .build(&mut ctx.gfx)?;
 
         Ok(MainState {
             background,

--- a/examples/vertex_shader.rs
+++ b/examples/vertex_shader.rs
@@ -27,7 +27,7 @@ impl MainState {
             Color::WHITE,
         )?;
         let shader = graphics::ShaderBuilder::new_wgsl()
-            .vertex_code(include_str!("../resources/vertex.wgsl"))
+            .vertex_path("/vertex.wgsl")
             .build(&ctx.gfx)?;
         let shader_params = graphics::ShaderParams::new(
             &mut ctx.gfx,
@@ -85,7 +85,7 @@ pub fn main() -> GameResult {
         path::PathBuf::from("./resources")
     };
 
-    let cb = ggez::ContextBuilder::new("colorspace", "ggez").add_resource_path(resource_dir);
+    let cb = ggez::ContextBuilder::new("vertex_shader", "ggez").add_resource_path(resource_dir);
     let (mut ctx, event_loop) = cb.build()?;
 
     let state = MainState::new(&mut ctx)?;

--- a/examples/vertex_shader.rs
+++ b/examples/vertex_shader.rs
@@ -1,0 +1,95 @@
+//! An example demonstrating vertex shaders.
+
+use ggez::event;
+use ggez::glam::*;
+use ggez::graphics::AsStd140;
+use ggez::graphics::{self, Color, DrawParam};
+use ggez::{Context, GameResult};
+use mint::ColumnMatrix4;
+
+#[derive(AsStd140)]
+struct ShaderUniforms {
+    transform: ColumnMatrix4<f32>,
+    rotation: ColumnMatrix4<f32>,
+}
+
+struct MainState {
+    square_mesh: graphics::Mesh,
+    shader: graphics::Shader,
+    shader_params: graphics::ShaderParams<ShaderUniforms>,
+}
+
+impl MainState {
+    fn new(ctx: &mut Context) -> GameResult<MainState> {
+        let square_mesh = graphics::Mesh::new_rectangle(
+            ctx,
+            graphics::DrawMode::fill(),
+            graphics::Rect::new(0.0, 0.0, 400.0, 400.0),
+            Color::WHITE,
+        )?;
+        let shader = graphics::Shader::new_wgsl(
+            &ctx.gfx,
+            include_str!("../resources/vertex.wgsl"),
+            "fs_main",
+        )
+        .with_vertex("vs_main");
+        let shader_params = graphics::ShaderParams::new(
+            &mut ctx.gfx,
+            &ShaderUniforms {
+                transform: Mat4::IDENTITY.into(),
+                rotation: Mat4::IDENTITY.into(),
+            },
+            &[],
+            &[],
+        );
+
+        let s = MainState {
+            square_mesh,
+            shader,
+            shader_params,
+        };
+        Ok(s)
+    }
+}
+
+impl event::EventHandler<ggez::GameError> for MainState {
+    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+        Ok(())
+    }
+
+    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+        let mut canvas = graphics::Canvas::from_frame(ctx, graphics::Color::BLACK);
+
+        canvas.set_shader(self.shader.clone());
+        self.shader_params.set_uniforms(
+            &mut ctx.gfx,
+            &ShaderUniforms {
+                transform: Mat4::from_translation(Vec3::new(200.0, 100.0, 0.0)).into(),
+                rotation: Mat4::from_rotation_z(ctx.time.time_since_start().as_secs_f32()).into(),
+            },
+        );
+        canvas.draw(&self.square_mesh, DrawParam::default());
+
+        canvas.finish(ctx)?;
+
+        Ok(())
+    }
+}
+
+pub fn main() -> GameResult {
+    use std::env;
+    use std::path;
+    let resource_dir = if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
+        let mut path = path::PathBuf::from(manifest_dir);
+        path.push("resources");
+        path
+    } else {
+        path::PathBuf::from("./resources")
+    };
+
+    let cb = ggez::ContextBuilder::new("colorspace", "ggez").add_resource_path(resource_dir);
+    let (mut ctx, event_loop) = cb.build()?;
+
+    let state = MainState::new(&mut ctx)?;
+    event::run(ctx, event_loop, state)
+}

--- a/examples/vertex_shader.rs
+++ b/examples/vertex_shader.rs
@@ -63,7 +63,10 @@ impl event::EventHandler<ggez::GameError> for MainState {
         );
         canvas.set_shader(self.shader.clone());
         canvas.set_shader_params(self.shader_params.clone());
-        canvas.draw(&self.square_mesh, DrawParam::default());
+        canvas.draw(
+            &self.square_mesh,
+            DrawParam::default().dest(Vec2::new(200.0, 100.0)),
+        );
 
         canvas.finish(ctx)?;
 

--- a/examples/vertex_shader.rs
+++ b/examples/vertex_shader.rs
@@ -9,7 +9,6 @@ use mint::ColumnMatrix4;
 
 #[derive(AsStd140)]
 struct ShaderUniforms {
-    transform: ColumnMatrix4<f32>,
     rotation: ColumnMatrix4<f32>,
 }
 
@@ -27,16 +26,12 @@ impl MainState {
             graphics::Rect::new(0.0, 0.0, 400.0, 400.0),
             Color::WHITE,
         )?;
-        let shader = graphics::Shader::new_wgsl(
-            &ctx.gfx,
-            include_str!("../resources/vertex.wgsl"),
-            "fs_main",
-        )
-        .with_vertex("vs_main");
+        let shader = graphics::ShaderBuilder::new_wgsl()
+            .vertex_code(include_str!("../resources/vertex.wgsl"))
+            .build(&mut ctx.gfx)?;
         let shader_params = graphics::ShaderParams::new(
             &mut ctx.gfx,
             &ShaderUniforms {
-                transform: Mat4::IDENTITY.into(),
                 rotation: Mat4::IDENTITY.into(),
             },
             &[],
@@ -60,14 +55,14 @@ impl event::EventHandler<ggez::GameError> for MainState {
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         let mut canvas = graphics::Canvas::from_frame(ctx, graphics::Color::BLACK);
 
-        canvas.set_shader(self.shader.clone());
         self.shader_params.set_uniforms(
             &mut ctx.gfx,
             &ShaderUniforms {
-                transform: Mat4::from_translation(Vec3::new(200.0, 100.0, 0.0)).into(),
                 rotation: Mat4::from_rotation_z(ctx.time.time_since_start().as_secs_f32()).into(),
             },
         );
+        canvas.set_shader(self.shader.clone());
+        canvas.set_shader_params(self.shader_params.clone());
         canvas.draw(&self.square_mesh, DrawParam::default());
 
         canvas.finish(ctx)?;

--- a/examples/vertex_shader.rs
+++ b/examples/vertex_shader.rs
@@ -29,14 +29,10 @@ impl MainState {
         let shader = graphics::ShaderBuilder::new_wgsl()
             .vertex_path("/vertex.wgsl")
             .build(&ctx.gfx)?;
-        let shader_params = graphics::ShaderParams::new(
-            &mut ctx.gfx,
-            &ShaderUniforms {
-                rotation: Mat4::IDENTITY.into(),
-            },
-            &[],
-            &[],
-        );
+        let shader_params = graphics::ShaderParamsBuilder::new(&ShaderUniforms {
+            rotation: Mat4::IDENTITY.into(),
+        })
+        .build(&mut ctx.gfx);
 
         let s = MainState {
             square_mesh,

--- a/examples/vertex_shader.rs
+++ b/examples/vertex_shader.rs
@@ -28,7 +28,7 @@ impl MainState {
         )?;
         let shader = graphics::ShaderBuilder::new_wgsl()
             .vertex_code(include_str!("../resources/vertex.wgsl"))
-            .build(&mut ctx.gfx)?;
+            .build(&ctx.gfx)?;
         let shader_params = graphics::ShaderParams::new(
             &mut ctx.gfx,
             &ShaderUniforms {
@@ -56,7 +56,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
         let mut canvas = graphics::Canvas::from_frame(ctx, graphics::Color::BLACK);
 
         self.shader_params.set_uniforms(
-            &mut ctx.gfx,
+            &ctx.gfx,
             &ShaderUniforms {
                 rotation: Mat4::from_rotation_z(ctx.time.time_since_start().as_secs_f32()).into(),
             },

--- a/resources/dimmer.wgsl
+++ b/resources/dimmer.wgsl
@@ -18,6 +18,6 @@ var s: sampler;
 var<uniform> dim: Dim;
 
 @fragment
-fn main(in: VertexOutput) -> @location(0) vec4<f32> {
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return textureSample(t, s, in.uv) * in.color * dim.rate;
 }

--- a/resources/lights.wgsl
+++ b/resources/lights.wgsl
@@ -27,7 +27,7 @@ fn degrees(x: f32) -> f32 {
 }
 
 @fragment
-fn main(in: VertexOutput) -> @location(0) vec4<f32> {
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var rel = light.pos - in.uv;
     var theta = atan2(rel.y, rel.x);
     var ox = (theta + 3.1415926) / 6.2831853;

--- a/resources/occlusions.wgsl
+++ b/resources/occlusions.wgsl
@@ -23,7 +23,7 @@ var s: sampler;
 var<uniform> light: Light;
 
 @fragment
-fn main(in: VertexOutput) -> @location(0) vec4<f32> {
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var dist = 1.0;
     var theta = in.uv.x * 6.28318530718;
     var dir = vec2<f32>(cos(theta), sin(theta));

--- a/resources/shadows.wgsl
+++ b/resources/shadows.wgsl
@@ -27,7 +27,7 @@ fn degrees(x: f32) -> f32 {
 }
 
 @fragment
-fn main(in: VertexOutput) -> @location(0) vec4<f32> {
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var rel = light.pos - in.uv;
     var theta = atan2(rel.y, rel.x);
     var ox = (theta + 3.1415926) / 6.2831853;

--- a/resources/vertex.wgsl
+++ b/resources/vertex.wgsl
@@ -1,0 +1,20 @@
+struct DrawUniforms {
+    transform: mat4x4<f32>,
+    rotation: mat4x4<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> uniforms: DrawUniforms;
+
+@vertex
+fn vs_main(
+    @location(0) position: vec2<f32>,
+) -> @builtin(position) vec4<f32> {
+    //return uniforms.transform * uniforms.rotation * vec4<f32>(position, 0.0, 1.0);
+    return uniforms.transform * vec4<f32>(position, 0.0, 1.0);
+}
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+}

--- a/resources/vertex.wgsl
+++ b/resources/vertex.wgsl
@@ -1,20 +1,34 @@
-struct DrawUniforms {
-    transform: mat4x4<f32>,
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) color: vec4<f32>,
+}
+
+struct MyCustomDrawUniforms {
     rotation: mat4x4<f32>,
-};
+}
+
+struct GgezDrawUniforms {
+    color: vec4<f32>,
+    src_rect: vec4<f32>,
+    transform: mat4x4<f32>,
+}
 
 @group(0) @binding(0)
-var<uniform> uniforms: DrawUniforms;
+var<uniform> uniforms: GgezDrawUniforms;
+
+@group(3) @binding(0)
+var<uniform> my_uniforms: MyCustomDrawUniforms;
 
 @vertex
 fn vs_main(
     @location(0) position: vec2<f32>,
-) -> @builtin(position) vec4<f32> {
-    //return uniforms.transform * uniforms.rotation * vec4<f32>(position, 0.0, 1.0);
-    return uniforms.transform * vec4<f32>(position, 0.0, 1.0);
-}
-
-@fragment
-fn fs_main() -> @location(0) vec4<f32> {
-    return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+    @location(1) uv: vec2<f32>,
+    @location(2) color: vec4<f32>,
+) -> VertexOutput {
+    var out: VertexOutput;
+    out.position = uniforms.transform * my_uniforms.rotation * vec4<f32>(position, 0.0, 1.0);
+    out.uv = mix(uniforms.src_rect.xy, uniforms.src_rect.zw, uv);
+    out.color = uniforms.color * color;
+    return out;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! Error types and conversion functions.
 use std::error::Error;
 use std::fmt;
+use std::string::FromUtf8Error;
 use std::sync::Arc;
 
 /// An enum containing all kinds of game framework errors.
@@ -34,6 +35,8 @@ pub enum GameError {
     IOError(Arc<std::io::Error>),
     /// Something went wrong trying to load a font
     FontError(glyph_brush::ab_glyph::InvalidFont),
+    /// Shader encoding error (not valid utf-8)
+    ShaderEncodingError(FromUtf8Error),
     /// Something went wrong applying video settings.
     VideoError(String),
     /// Something went wrong with the `gilrs` gamepad-input library.

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -571,13 +571,15 @@ pub(crate) struct DefaultResources {
 impl DefaultResources {
     fn new(gfx: &GraphicsContext) -> Self {
         let shader = Shader {
-            fragment: gfx.draw_shader.clone(),
+            module: gfx.draw_shader.clone(),
             fs_entry: "fs_main".into(),
+            vs_entry: None,
         };
 
         let text_shader = Shader {
-            fragment: gfx.text_shader.clone(),
+            module: gfx.text_shader.clone(),
             fs_entry: "fs_main".into(),
+            vs_entry: None,
         };
 
         let mesh = gfx.rect_mesh.clone();

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -120,7 +120,7 @@ impl Canvas {
         let state = DrawState {
             shader: defaults.shader.clone(),
             params: None,
-            text_shader: defaults.text_shader.clone(),
+            text_shader: defaults.shader.clone(),
             text_params: None,
             sampler: Sampler::linear_clamp(),
             blend_mode: BlendMode::ALPHA,
@@ -205,7 +205,7 @@ impl Canvas {
     /// Resets the active text shader to the default.
     #[inline]
     pub fn set_default_text_shader(&mut self) {
-        self.state.text_shader = self.defaults.text_shader.clone();
+        self.state.text_shader = self.defaults.shader.clone();
     }
 
     /// Sets the active sampler used to sample images.
@@ -563,7 +563,6 @@ struct DrawCommand {
 #[derive(Debug)]
 pub(crate) struct DefaultResources {
     pub shader: Shader,
-    pub text_shader: Shader,
     pub mesh: Mesh,
     pub image: Image,
 }
@@ -571,12 +570,7 @@ pub(crate) struct DefaultResources {
 impl DefaultResources {
     fn new(gfx: &GraphicsContext) -> Self {
         let shader = Shader {
-            fs_module: Some(gfx.draw_shader.clone()),
-            vs_module: None,
-        };
-
-        let text_shader = Shader {
-            fs_module: Some(gfx.text_shader.clone()),
+            fs_module: None,
             vs_module: None,
         };
 
@@ -585,7 +579,6 @@ impl DefaultResources {
 
         DefaultResources {
             shader,
-            text_shader,
             mesh,
             image,
         }

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -571,15 +571,13 @@ pub(crate) struct DefaultResources {
 impl DefaultResources {
     fn new(gfx: &GraphicsContext) -> Self {
         let shader = Shader {
-            module: gfx.draw_shader.clone(),
-            fs_entry: "fs_main".into(),
-            vs_entry: None,
+            fs_module: Some(gfx.draw_shader.clone()),
+            vs_module: None,
         };
 
         let text_shader = Shader {
-            module: gfx.text_shader.clone(),
-            fs_entry: "fs_main".into(),
-            vs_entry: None,
+            fs_module: Some(gfx.text_shader.clone()),
+            vs_module: None,
         };
 
         let mesh = gfx.rect_mesh.clone();

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -170,7 +170,7 @@ impl Canvas {
 
     /// Sets the shader parameters to use when drawing meshes.
     ///
-    /// **Bound to bind group 4.**
+    /// **Bound to bind group 3.**
     #[inline]
     pub fn set_shader_params<Uniforms: AsStd140>(&mut self, params: ShaderParams<Uniforms>) {
         self.state.params = Some((params.bind_group.clone(), params.layout));

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -118,9 +118,9 @@ impl Canvas {
         let defaults = DefaultResources::new(gfx);
 
         let state = DrawState {
-            shader: defaults.shader.clone(),
+            shader: default_shader(),
             params: None,
-            text_shader: defaults.shader.clone(),
+            text_shader: default_text_shader(),
             text_params: None,
             sampler: Sampler::linear_clamp(),
             blend_mode: BlendMode::ALPHA,
@@ -199,13 +199,13 @@ impl Canvas {
     /// Resets the active mesh shader to the default.
     #[inline]
     pub fn set_default_shader(&mut self) {
-        self.state.shader = self.defaults.shader.clone();
+        self.state.shader = default_shader();
     }
 
     /// Resets the active text shader to the default.
     #[inline]
     pub fn set_default_text_shader(&mut self) {
-        self.state.text_shader = self.defaults.shader.clone();
+        self.state.text_shader = default_text_shader();
     }
 
     /// Sets the active sampler used to sample images.
@@ -562,25 +562,31 @@ struct DrawCommand {
 
 #[derive(Debug)]
 pub(crate) struct DefaultResources {
-    pub shader: Shader,
     pub mesh: Mesh,
     pub image: Image,
 }
 
 impl DefaultResources {
     fn new(gfx: &GraphicsContext) -> Self {
-        let shader = Shader {
-            fs_module: None,
-            vs_module: None,
-        };
-
         let mesh = gfx.rect_mesh.clone();
         let image = gfx.white_image.clone();
 
-        DefaultResources {
-            shader,
-            mesh,
-            image,
-        }
+        DefaultResources { mesh, image }
+    }
+}
+
+/// The default shader.
+pub fn default_shader() -> Shader {
+    Shader {
+        fs_module: None,
+        vs_module: None,
+    }
+}
+
+/// The default text shader.
+pub fn default_text_shader() -> Shader {
+    Shader {
+        fs_module: None,
+        vs_module: None,
     }
 }

--- a/src/graphics/internal_canvas.rs
+++ b/src/graphics/internal_canvas.rs
@@ -176,12 +176,12 @@ impl<'a> InternalCanvas<'a> {
 
         let shader = Shader {
             vs_module: None,
-            fs_module: Some(gfx.draw_shader.clone()),
+            fs_module: None,
         };
 
         let text_shader = Shader {
             vs_module: None,
-            fs_module: Some(gfx.text_shader.clone()),
+            fs_module: None,
         };
 
         let text_uniforms = uniform_arena.allocate(

--- a/src/graphics/internal_canvas.rs
+++ b/src/graphics/internal_canvas.rs
@@ -538,7 +538,7 @@ impl<'a> InternalCanvas<'a> {
             if let ShaderType::Instance { .. } = ty {
                 groups.push(instance_layout);
             } else {
-                // the dummy group ensures the user's bind group is at index 4
+                // the dummy group ensures the user's bind group is at index 3
                 groups.push(dummy_layout);
                 self.pass
                     .set_bind_group(2, self.arenas.bind_groups.alloc(dummy_group), &[]);

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -143,7 +143,7 @@ impl<'a> ShaderBuilder<'a> {
 /// ```
 /// if the fragment shader is left unspecified.
 ///
-/// Produce a Shader using ShaderBuilder.
+/// Produce a Shader using [ShaderBuilder].
 ///
 /// Adapted from the `shader.rs` example:
 /// ```rust
@@ -194,13 +194,13 @@ pub use crevice::std140::AsStd140;
 /// ```
 /// Corresponds to...
 /// ```ignore
-/// @group(4) @binding(0)
+/// @group(3) @binding(0)
 /// var<uniform> my_uniforms: MyUniforms;
-/// @group(4) @binding(1)
+/// @group(3) @binding(1)
 /// var image1: texture_2d<f32>;
-/// @group(4) @binding(2)
+/// @group(3) @binding(2)
 /// var image2: texture_2d<f32>;
-/// @group(4) @binding(3)
+/// @group(3) @binding(3)
 /// var sampler1: sampler;
 /// ```
 #[derive(Debug, PartialEq, Eq)]

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -217,7 +217,7 @@ impl<'a, Uniforms: AsStd140> ShaderParamsBuilder<'a, Uniforms> {
     pub fn images(self, images: &'a [(&'a Image, Sampler)], vs_visible: bool) -> Self {
         ShaderParamsBuilder {
             uniforms: self.uniforms,
-            images: images,
+            images,
             images_vs_visible: vs_visible,
         }
     }

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -103,7 +103,7 @@ impl<'a> ShaderBuilder<'a> {
             let mut encoded = Vec::new();
             _ = gfx.fs.open(path)?.read_to_end(&mut encoded)?;
             Ok(load(
-                &String::from_utf8(encoded).map_err(|e| GameError::ShaderEncodingError(e))?,
+                &String::from_utf8(encoded).map_err(GameError::ShaderEncodingError)?,
             ))
         };
         let load_any = |source| -> GameResult<Option<ArcShaderModule>> {

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -53,13 +53,14 @@ use wgpu::util::DeviceExt;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Shader {
-    pub(crate) fragment: ArcShaderModule,
+    pub(crate) module: ArcShaderModule,
     pub(crate) fs_entry: String,
+    pub(crate) vs_entry: Option<String>,
 }
 
 impl Shader {
     /// Creates a shader from a WGSL string.
-    pub fn from_wgsl(gfx: &impl Has<GraphicsContext>, wgsl: &str, fs_entry: &str) -> Self {
+    pub fn new_wgsl(gfx: &impl Has<GraphicsContext>, wgsl: &str, fs_entry: &str) -> Self {
         let gfx = gfx.retrieve();
         let module = ArcShaderModule::new(gfx.wgpu.device.create_shader_module(
             wgpu::ShaderModuleDescriptor {
@@ -69,8 +70,18 @@ impl Shader {
         ));
 
         Shader {
-            fragment: module,
+            module,
             fs_entry: fs_entry.into(),
+            vs_entry: None,
+        }
+    }
+
+    /// Use the function with the specified name as the vertex shader (instead of the default)
+    pub fn with_vertex(self, vs_entry: &str) -> Self {
+        Shader {
+            module: self.module,
+            fs_entry: self.fs_entry,
+            vs_entry: Some(vs_entry.into()),
         }
     }
 }

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -128,11 +128,11 @@ impl<'a> ShaderBuilder<'a> {
     }
 }
 
-/// A custom fragment shader that can be used to render with shader effects.
+/// A custom shader that can be used to render with shader effects.
 ///
-/// The program may have a user specified vertex shader, fragment shader, both,
-/// or neither. The fragment shader entry point must be named fs_main. The
-/// vertex shader entry point must be named vs_main. The vertex shader must
+/// The shader may have a user specified vertex module, fragment module, both,
+/// or neither. The fragment module entry point must be named fs_main. The
+/// vertex module entry point must be named vs_main. The vertex module must
 /// have an output of type
 /// ```wgsl
 /// struct VertexOutput {
@@ -141,7 +141,7 @@ impl<'a> ShaderBuilder<'a> {
 ///     @location(1) color: vec4<f32>,
 /// }
 /// ```
-/// if the fragment shader is left unspecified.
+/// if the fragment module is left unspecified (default).
 ///
 /// Produce a Shader using [ShaderBuilder].
 ///

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -278,7 +278,9 @@ impl<'a, Uniforms: AsStd140> ShaderParamsBuilder<'a, Uniforms> {
 ///
 /// These parameters are bound to group 3. With WGSL, for example,
 /// ```rust,ignore
-/// ggez::graphics::ShaderParams::new(ctx, &my_uniforms, &[&image1, &image2], &[sampler1])
+/// ggez::graphics::ShaderParamsBuilder::new(&my_uniforms)
+///     .images(&[(&image1, &sampler1), (&image2, &sampler2)], false)
+///     .build(&mut ctx.gfx)
 /// ```
 /// Corresponds to...
 /// ```ignore
@@ -290,6 +292,8 @@ impl<'a, Uniforms: AsStd140> ShaderParamsBuilder<'a, Uniforms> {
 /// var image2: texture_2d<f32>;
 /// @group(3) @binding(3)
 /// var sampler1: sampler;
+/// @group(3) @binding(4)
+/// var sampler2: sampler;
 /// ```
 #[derive(Debug, PartialEq, Eq)]
 pub struct ShaderParams<Uniforms: AsStd140> {


### PR DESCRIPTION
So the main things
* I changed `from_wgsl` to `new_wgsl` and made it buildery, there were a hundred ways I could have done this though.  New builder type? Mutable and use `&mut self` to modify? I have no idea the best choice here, but returning new objects means you have more flexibility chaining and storing.
* The examples I've seen have both the vertex and fragment shader in a single source file, so I made the `with_vertex` method just store the new entry point.  Should this actually take two different shader files?
* The example doesn't work for me (WIP), it shows white stretching from the center of the screen in a couple directions. I think some sort of base matrices from `DrawUniforms` are lost when using the user-supplied stuff, but I couldn't figure out what they were (projection? or something else?).

I'm not sure what to do for the third point.  Should the user uniforms implement some interface to merge it with the base `DrawUniforms` data?  Or should methods be provided to get the data that would have gone into the original draw shader?

I think it would be useful to document somewhere "the default vertex shader gets this data and does these things, if you supply your own shader you can (use them with these names|get the data to include yourself by calling these methods)".

closes #1113