### PR TITLE
Default shader params sampler

### DIFF
--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -122,7 +122,7 @@ impl Canvas {
             params: None,
             text_shader: default_text_shader(),
             text_params: None,
-            sampler: Sampler::linear_clamp(),
+            sampler: default_sampler(),
             blend_mode: BlendMode::ALPHA,
             premul_text: true,
             projection: glam::Mat4::IDENTITY.into(),
@@ -589,4 +589,9 @@ pub fn default_text_shader() -> Shader {
         fs_module: None,
         vs_module: None,
     }
+}
+
+/// The default sampler
+pub fn default_sampler() -> Sampler {
+    Sampler::linear_clamp()
 }


### PR DESCRIPTION
To be stacked on https://github.com/ggez/ggez/pull/1115 for #1118

I assume the intent is to simplify the interface with reasonable default behavior.  It didn't look easy to get the sampler from the canvas (would the user necessarily have a canvas during setup?) so I opted to make the default sampler into a new function and use that as the default.

Some other options were
* Take canvas as an argument to the builder
* ~If there are zero samplers, use the canvas's current sampler (but would prevent user from having zero samplers... would that ever be wanted.~  Edit: I realize we need to use the sampler in `build()` so I think this wouldn't work, or would be more or less the same as the above.