### PR TITLE
final 0.8.0 touches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,11 @@ The downside of this is that it's a bit more verbose and that you have to pass a
 There's a new struct `ShaderParams`allowing you to pass images, samplers and uniforms to shaders.
 Both `ShaderParam`s and `Shader`s are now set per `Canvas` (as well as blend modes and projection matrices).
 
+`Shader`s and `ShaderParam`s are created through `ShaderBuilder` and `ShaderParamBuilder` respectively, allowing you to
+only set the parameters you're interested in, without worrying about the rest.
+
 Uniforms are now no longer created using the `gfx!` macro. No need to include `gfx-rs` in your own project, just to be
-able to create shaders. Now, simply deriving `AsStd140` is all you usually need (see the shader examples).
+able to create shader uniforms. Now, simply deriving `AsStd140` is all you usually need (see the shader examples).
 At the time of writing you're sadly also required to depend on `crevice 0.11` directly, as `AsStd140` needs to have it
 visible globally (and re-exporting it on our side doesn't seem to be enough). If you know a way around this, let us know!
 
@@ -104,7 +107,8 @@ The following list doesn't repeat the changes already mentioned above.
  functionality itself
 * Removed `From<tuple>` implementations for `DrawParam`, as they're non-transparent and weird
 * Removed `event::quit`, as it was replaced by `Context::request_quit`
-* Removed `Image::from_bytes` (atm, but is intended to be re-added before the release of 0.8.0)
+* Removed the ability to update only parts of the `DrawParams` inside a `MeshBatch` (now `InstanceArray`)
+  * If you want that ability back let us know! Atm it's staged as "maybe in `0.8.1`" 
 
 ## Fixed
 Many graphics bugs that were caused by the use of the discontinued `gfx-rs` were fixed by the switch to `wgpu`. The

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/ggez/ggez/blob/master/LICENSE)
 [![Crates.io](https://img.shields.io/crates/v/ggez.svg)](https://crates.io/crates/ggez)
 [![Crates.io](https://img.shields.io/crates/d/ggez.svg)](https://crates.io/crates/ggez)
+[![Discord chat](https://img.shields.io/discord/1031224392174293002.svg?label=discord%20chat)](https://discord.gg/48VycPe2ZX)
+
 
 ggez is a Rust library to create a Good Game Easily.
 

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -4,9 +4,10 @@
 //! the underlying `gfx-rs` data types, so you can bypass ggez's
 //! drawing code entirely and write your own.
 
+use crevice::std140::AsStd140;
+use ggez::event;
 use ggez::glam::*;
 use ggez::graphics;
-use ggez::{event, graphics::AsStd140};
 use ggez::{Context, GameResult};
 use std::env;
 use std::f32;

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -205,7 +205,7 @@ impl MainState {
             .gfx
             .wgpu()
             .device
-            .create_sampler(&graphics::Sampler::linear_clamp().into());
+            .create_sampler(&graphics::Sampler::default().into());
 
         let locals = ctx
             .gfx

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -1,8 +1,9 @@
 //! A very simple shader example.
 
+use crevice::std140::AsStd140;
+use ggez::event;
 use ggez::glam::Vec2;
 use ggez::graphics::{self, Color, DrawMode};
-use ggez::{event, graphics::AsStd140};
 use ggez::{Context, GameResult};
 use std::env;
 use std::path;

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -1,9 +1,10 @@
 //! A more sophisticated example of how to use shaders
 //! and canvas's to do 2D GPU shadows.
 
+use crevice::std140::AsStd140;
 use ggez::glam::Vec2;
 use ggez::graphics::{
-    self, AsStd140, BlendMode, Canvas, Color, DrawParam, Shader, ShaderBuilder, ShaderParamsBuilder,
+    self, BlendMode, Canvas, Color, DrawParam, Shader, ShaderBuilder, ShaderParamsBuilder,
 };
 use ggez::{event, graphics::ShaderParams};
 use ggez::{Context, GameResult};

--- a/examples/vertex_shader.rs
+++ b/examples/vertex_shader.rs
@@ -1,8 +1,8 @@
 //! An example demonstrating vertex shaders.
 
+use crevice::std140::AsStd140;
 use ggez::event;
 use ggez::glam::*;
-use ggez::graphics::AsStd140;
 use ggez::graphics::{self, Color, DrawParam};
 use ggez::{Context, GameResult};
 use mint::ColumnMatrix4;

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -122,7 +122,7 @@ impl Canvas {
             params: None,
             text_shader: default_text_shader(),
             text_params: None,
-            sampler: Sampler::linear_clamp(),
+            sampler: Sampler::default(),
             blend_mode: BlendMode::ALPHA,
             premul_text: true,
             projection: glam::Mat4::IDENTITY.into(),
@@ -225,7 +225,7 @@ impl Canvas {
     /// This is equivalent to `set_sampler(Sampler::linear_clamp())`.
     #[inline]
     pub fn set_default_sampler(&mut self) {
-        self.set_sampler(Sampler::linear_clamp());
+        self.set_sampler(Sampler::default());
     }
 
     /// Sets the active blend mode used when drawing images.

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -591,7 +591,7 @@ impl GraphicsContext {
 
             let sampler = &mut self
                 .sampler_cache
-                .get(&self.wgpu.device, Sampler::linear_clamp());
+                .get(&self.wgpu.device, Sampler::default());
 
             let (bind, layout) = BindGroupBuilder::new()
                 .image(&fcx.present.view, wgpu::ShaderStages::FRAGMENT)

--- a/src/graphics/internal_canvas.rs
+++ b/src/graphics/internal_canvas.rs
@@ -243,8 +243,8 @@ impl<'a> InternalCanvas<'a> {
 
             transform,
             curr_image: None,
-            curr_sampler: Sampler::linear_clamp(),
-            next_sampler: Sampler::linear_clamp(),
+            curr_sampler: Sampler::default(),
+            next_sampler: Sampler::default(),
             premul_text: true,
         })
     }

--- a/src/graphics/sampler.rs
+++ b/src/graphics/sampler.rs
@@ -40,6 +40,12 @@ impl Sampler {
     }
 }
 
+impl Default for Sampler {
+    fn default() -> Self {
+        Self::linear_clamp()
+    }
+}
+
 impl<'a> From<Sampler> for wgpu::SamplerDescriptor<'a> {
     fn from(sampler: Sampler) -> Self {
         wgpu::SamplerDescriptor {

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -165,7 +165,7 @@ impl<'a> ShaderBuilder<'a> {
 ///         //       For more info look at the full example.
 ///         let shader = ShaderBuilder::new_wgsl()
 ///             .fragment_code(include_str!("../../resources/dimmer.wgsl"))
-///             .build(&mut ctx.gfx);
+///             .build(&mut ctx.gfx)?;
 ///         let params = ShaderParamsBuilder::new(&dim).build(&mut ctx.gfx);
 ///         params.set_uniforms(ctx, &dim);
 ///
@@ -184,7 +184,7 @@ pub struct Shader {
     pub(crate) fs_module: Option<ArcShaderModule>,
 }
 
-pub use crevice::std140::AsStd140;
+use crevice::std140::AsStd140;
 
 /// A builder for [ShaderParams]
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/ggez/ggez/blob/master/LICENSE)
 //! [![Crates.io](https://img.shields.io/crates/v/ggez.svg)](https://crates.io/crates/ggez)
 //! [![Crates.io](https://img.shields.io/crates/d/ggez.svg)](https://crates.io/crates/ggez)
+//! [![Discord chat](https://img.shields.io/discord/1031224392174293002.svg?label=discord%20chat)](https://discord.gg/48VycPe2ZX)
 //!
 //! ggez is a Rust library to create a Good Game Easily.
 //!


### PR DESCRIPTION
updated changelog to no longer mention missing `from_bytes`;
updated it to mention missing ability to modify parts of the `DrawPram` slice on `InstanceArray`;
removed reexport of `crevice::std::AsStd140`;
implemented `Default` for `Sampler` to have the default be explicit and controlled in one place.