### PR TITLE
fixed `InstanceArray::resize`

### DIFF
--- a/src/graphics/instance.rs
+++ b/src/graphics/instance.rs
@@ -192,7 +192,6 @@ impl InstanceArray {
         &self.params
     }
 
-    #[allow(unsafe_code)]
     pub(crate) fn flush_wgpu(&self, wgpu: &WgpuContext) -> GameResult {
         if !self.dirty.load(SeqCst) {
             return Ok(());
@@ -243,6 +242,9 @@ impl InstanceArray {
     /// Changes the capacity of this `InstanceArray` while preserving instances.
     ///
     /// If `new_capacity` is less than the `len`, the instances will be truncated.
+    ///
+    /// # Panics
+    /// Panics if `new_capacity` is 0.
     pub fn resize(&mut self, gfx: &impl Has<GraphicsContext>, new_capacity: u32) {
         let gfx: &GraphicsContext = gfx.retrieve();
         let resized = InstanceArray::new_wgpu(

--- a/src/graphics/instance.rs
+++ b/src/graphics/instance.rs
@@ -247,21 +247,23 @@ impl InstanceArray {
         let gfx: &GraphicsContext = gfx.retrieve();
         let resized = InstanceArray::new_wgpu(
             &gfx.wgpu,
-            gfx.instance_bind_layout.clone(),
+            self.bind_layout.clone(),
             self.image.clone(),
-            DEFAULT_CAPACITY,
+            new_capacity,
             self.ordered,
         );
         self.buffer = resized.buffer;
         self.indices = resized.indices;
+        self.bind_group = resized.bind_group;
+
         self.capacity.store(new_capacity, SeqCst);
         self.dirty.store(true, SeqCst);
         self.uniforms.truncate(new_capacity as usize);
         self.params.truncate(new_capacity as usize);
         self.uniforms
-            .reserve((new_capacity as usize).min(self.uniforms.len()) - self.uniforms.len());
+            .reserve(new_capacity as usize - self.uniforms.len());
         self.params
-            .reserve((new_capacity as usize).min(self.params.len()) - self.params.len());
+            .reserve(new_capacity as usize - self.params.len());
     }
 
     /// Returns this `InstanceArray`'s associated `image`.

--- a/src/graphics/instance.rs
+++ b/src/graphics/instance.rs
@@ -246,6 +246,8 @@ impl InstanceArray {
     /// # Panics
     /// Panics if `new_capacity` is 0.
     pub fn resize(&mut self, gfx: &impl Has<GraphicsContext>, new_capacity: u32) {
+        assert!(new_capacity > 0);
+
         let gfx: &GraphicsContext = gfx.retrieve();
         let resized = InstanceArray::new_wgpu(
             &gfx.wgpu,


### PR DESCRIPTION
`InstanceArray::resize` was really a massive oversight until now. Luckily [removing the `capacity` parameter](https://github.com/ggez/ggez/commit/4e0f8e0d56019e8025638d5fcdd4ac86ceaef241) in its constructor forced us to actually use it for once and realize that ^^

What I'm not sure about yet is: I simply replacing the whole Mutex, like I do now, is better, or copying only the contents, like we do in `flush_wgpu`:
https://github.com/ggez/ggez/blob/6a99d360669ea121f277501062378130fb63cd91/src/graphics/instance.rs#L205-L218
