### PR TITLE
fixed vsync by adopting wgpu's built-in enums

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -216,9 +216,9 @@ impl GraphicsContext {
             width: size.width,
             height: size.height,
             present_mode: if conf.window_setup.vsync {
-                wgpu::PresentMode::Fifo
+                wgpu::PresentMode::AutoVsync
             } else {
-                wgpu::PresentMode::Mailbox
+                wgpu::PresentMode::AutoNoVsync
             },
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
         };


### PR DESCRIPTION
I tested some examples and `vsync(false)` now gives me my proper 300 FPS on bunnymark, while `vsync(true)` stays at 120. So it seems to work out.

closing #1130 