### PR TITLE
fix buffer write queue order

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 /// An enum containing all kinds of game framework errors.
 #[derive(Debug)]
 pub enum GameError {
+    /// Something went wrong trying to write to a wgpu buffer.
+    BufferWriteError(String),
     /// An error when intializing the graphics system.
     GraphicsInitializationError,
     /// An error in the filesystem layout


### PR DESCRIPTION
Wrote a function to replace `wgpu.queue.write_buffer` with in cases where writes should be placed in correct command encoder order using a `StagingBelt`.

If we can agree that such a function (the name can be changed of course) is better (in terms of easier to use) than exposing the `StagingBelt::write_buffer` API, then I'll go over all the usages of `wgpu.queue.write_buffer` and change them to this function where appropriate.