### PR TITLE
remove all aliased buffer overwrites

### DIFF
--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -25,7 +25,7 @@ impl MainState {
         let shader = graphics::ShaderBuilder::new_wgsl()
             .fragment_path("/dimmer.wgsl")
             .build(&ctx.gfx)?;
-        let params = graphics::ShaderParamsBuilder::new(&dim).build(&mut ctx.gfx);
+        let params = graphics::ShaderParamsBuilder::new(&dim).build(ctx);
         Ok(MainState {
             dim,
             shader,
@@ -55,7 +55,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
         self.params.set_uniforms(ctx, &self.dim);
         canvas.set_shader(self.shader.clone());
-        canvas.set_shader_params(self.params.clone());
+        canvas.set_shader_params(&self.params);
         let circle = graphics::Mesh::new_circle(
             ctx,
             DrawMode::fill(),

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -53,9 +53,9 @@ impl event::EventHandler<ggez::GameError> for MainState {
         )?;
         canvas.draw(&circle, Vec2::new(0.0, 0.0));
 
-        self.params.set_uniforms(ctx, &self.dim);
+        self.params.set_uniforms(ctx, &self.dim)?;
         canvas.set_shader(self.shader.clone());
-        canvas.set_shader_params(&self.params);
+        canvas.set_shader_params(self.params.clone())?;
         let circle = graphics::Mesh::new_circle(
             ctx,
             DrawMode::fill(),

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -52,10 +52,7 @@ const LIGHTS_SHADER_SOURCE: &str = include_str!("../resources/lights.wgsl");
 struct MainState {
     background: graphics::Image,
     tile: graphics::Image,
-    torch: Light,
-    torch_params: ShaderParams<Light>,
-    static_light: Light,
-    static_light_params: ShaderParams<Light>,
+    light_list: Vec<(Light, ShaderParams<Light>)>,
     foreground: graphics::ScreenImage,
     occlusions: graphics::Image,
     shadows: graphics::ScreenImage,
@@ -100,7 +97,7 @@ impl MainState {
             glow: 0.0,
             strength: LIGHT_STRENGTH,
         };
-        let torch_params = ShaderParamsBuilder::new(&torch).build(&mut ctx.gfx);
+        let torch_params = ShaderParamsBuilder::new(&torch).build(ctx);
 
         let (w, h) = ctx.gfx.size();
         let (x, y) = (100.0 / w as f32, 75.0 / h as f32);
@@ -113,7 +110,9 @@ impl MainState {
             glow: 0.0,
             strength: LIGHT_STRENGTH,
         };
-        let static_light_params = ShaderParamsBuilder::new(&static_light).build(&mut ctx.gfx);
+        let static_light_params = ShaderParamsBuilder::new(&static_light).build(ctx);
+
+        let light_list = vec![(torch, torch_params), (static_light, static_light_params)];
 
         let color_format = ctx.gfx.surface_format();
         let foreground = graphics::ScreenImage::new(ctx, None, 1., 1., 1);
@@ -135,10 +134,7 @@ impl MainState {
         Ok(MainState {
             background,
             tile,
-            torch,
-            torch_params,
-            static_light,
-            static_light_params,
+            light_list,
             foreground,
             occlusions,
             shadows,
@@ -151,7 +147,7 @@ impl MainState {
     fn render_light(
         &mut self,
         ctx: &mut Context,
-        light: ShaderParams<Light>,
+        light_idx: usize,
         origin: DrawParam,
         canvas_origin: DrawParam,
         clear: Option<graphics::Color>,
@@ -159,12 +155,13 @@ impl MainState {
         let foreground = self.foreground.image(ctx);
 
         let size = ctx.gfx.drawable_size();
+
         // Now we want to run the occlusions shader to calculate our 1D shadow
         // distances into the `occlusions` canvas.
         let mut canvas = Canvas::from_image(ctx, self.occlusions.clone(), None);
         canvas.set_screen_coordinates(graphics::Rect::new(0., 0., size.0, size.1));
         canvas.set_shader(self.occlusions_shader.clone());
-        canvas.set_shader_params(light.clone());
+        canvas.set_shader_params(&self.light_list[light_idx].1);
         canvas.draw(&foreground, canvas_origin);
         canvas.finish(ctx)?;
 
@@ -174,7 +171,7 @@ impl MainState {
         let mut canvas = Canvas::from_screen_image(ctx, &mut self.shadows, clear);
         canvas.set_screen_coordinates(graphics::Rect::new(0., 0., size.0, size.1));
         canvas.set_shader(self.shadows_shader.clone());
-        canvas.set_shader_params(light.clone());
+        canvas.set_shader_params(&self.light_list[light_idx].1);
         canvas.draw(
             &self.occlusions,
             origin.scale([
@@ -188,7 +185,7 @@ impl MainState {
         canvas.set_screen_coordinates(graphics::Rect::new(0., 0., size.0, size.1));
         canvas.set_blend_mode(BlendMode::ADD);
         canvas.set_shader(self.lights_shader.clone());
-        canvas.set_shader_params(light);
+        canvas.set_shader_params(&self.light_list[light_idx].1);
         canvas.draw(
             &self.occlusions,
             origin.scale([
@@ -208,17 +205,17 @@ impl event::EventHandler<ggez::GameError> for MainState {
             println!("Average FPS: {}", ctx.time.fps());
         }
 
-        self.torch.glow =
+        self.light_list[0].0.glow =
             LIGHT_GLOW_FACTOR * (ctx.time.time_since_start().as_secs_f32() * LIGHT_GLOW_RATE).cos();
-        self.static_light.glow = LIGHT_GLOW_FACTOR
+        self.light_list[1].0.glow = LIGHT_GLOW_FACTOR
             * (ctx.time.time_since_start().as_secs_f32() * LIGHT_GLOW_RATE * 0.75).sin();
         Ok(())
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        self.torch_params.set_uniforms(ctx, &self.torch);
-        self.static_light_params
-            .set_uniforms(ctx, &self.static_light);
+        for (light, light_params) in &mut self.light_list {
+            light_params.set_uniforms(ctx, light);
+        }
 
         let origin = DrawParam::new()
             .dest(Vec2::new(0.0, 0.0))
@@ -245,20 +242,15 @@ impl event::EventHandler<ggez::GameError> for MainState {
         canvas.finish(ctx)?;
 
         // Then we draw our light and shadow maps
-        self.render_light(
-            ctx,
-            self.torch_params.clone(),
-            origin,
-            canvas_origin,
-            Some(Color::BLACK),
-        )?;
-        self.render_light(
-            ctx,
-            self.static_light_params.clone(),
-            origin,
-            canvas_origin,
-            None,
-        )?;
+        for i in 0..self.light_list.len() {
+            self.render_light(
+                ctx,
+                i,
+                origin,
+                canvas_origin,
+                if i > 0 { None } else { Some(Color::BLACK) },
+            )?;
+        }
 
         // Now lets finally render to screen starting out with background, then
         // the shadows and lights overtop and finally our foreground.
@@ -293,7 +285,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
     ) -> GameResult {
         let (w, h) = ctx.gfx.drawable_size();
         let (x, y) = (x / w as f32, y / h as f32);
-        self.torch.pos = [x, y].into();
+        self.light_list[0].0.pos = [x, y].into();
         Ok(())
     }
 }

--- a/examples/vertex_shader.rs
+++ b/examples/vertex_shader.rs
@@ -28,11 +28,11 @@ impl MainState {
         )?;
         let shader = graphics::ShaderBuilder::new_wgsl()
             .vertex_path("/vertex.wgsl")
-            .build(&ctx.gfx)?;
+            .build(ctx)?;
         let shader_params = graphics::ShaderParamsBuilder::new(&ShaderUniforms {
             rotation: Mat4::IDENTITY.into(),
         })
-        .build(&mut ctx.gfx);
+        .build(ctx);
 
         let s = MainState {
             square_mesh,
@@ -52,13 +52,13 @@ impl event::EventHandler<ggez::GameError> for MainState {
         let mut canvas = graphics::Canvas::from_frame(ctx, graphics::Color::BLACK);
 
         self.shader_params.set_uniforms(
-            &ctx.gfx,
+            ctx,
             &ShaderUniforms {
                 rotation: Mat4::from_rotation_z(ctx.time.time_since_start().as_secs_f32()).into(),
             },
         );
         canvas.set_shader(self.shader.clone());
-        canvas.set_shader_params(self.shader_params.clone());
+        canvas.set_shader_params(&self.shader_params);
         canvas.draw(
             &self.square_mesh,
             DrawParam::default().dest(Vec2::new(200.0, 100.0)),

--- a/examples/vertex_shader.rs
+++ b/examples/vertex_shader.rs
@@ -56,9 +56,9 @@ impl event::EventHandler<ggez::GameError> for MainState {
             &ShaderUniforms {
                 rotation: Mat4::from_rotation_z(ctx.time.time_since_start().as_secs_f32()).into(),
             },
-        );
+        )?;
         canvas.set_shader(self.shader.clone());
-        canvas.set_shader_params(&self.shader_params);
+        canvas.set_shader_params(self.shader_params.clone())?;
         canvas.draw(
             &self.square_mesh,
             DrawParam::default().dest(Vec2::new(200.0, 100.0)),

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -176,12 +176,17 @@ impl Canvas {
     ///
     /// **Bound to bind group 3.**
     #[inline]
-    pub fn set_shader_params<Uniforms: AsStd140>(&mut self, params: &ShaderParams<Uniforms>) {
+    pub fn set_shader_params<Uniforms: AsStd140>(
+        &mut self,
+        params: ShaderParams<Uniforms>,
+    ) -> GameResult {
+        let params = params.lock()?;
         self.state.params = Some((
             params.bind_group.clone().unwrap(/* always Some */),
             params.layout.clone().unwrap(/* always Some */),
             params.buffer_offset,
         ));
+        Ok(())
     }
 
     /// Sets the shader to use when drawing text.
@@ -200,12 +205,17 @@ impl Canvas {
     ///
     /// **Bound to bind group 3.**
     #[inline]
-    pub fn set_text_shader_params<Uniforms: AsStd140>(&mut self, params: &ShaderParams<Uniforms>) {
+    pub fn set_text_shader_params<Uniforms: AsStd140>(
+        &mut self,
+        params: ShaderParams<Uniforms>,
+    ) -> GameResult {
+        let params = params.lock()?;
         self.state.text_params = Some((
             params.bind_group.clone().unwrap(/* always Some */),
             params.layout.clone().unwrap(/* always Some */),
             params.buffer_offset,
         ));
+        Ok(())
     }
 
     /// Resets the active mesh shader to the default.

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -176,8 +176,12 @@ impl Canvas {
     ///
     /// **Bound to bind group 3.**
     #[inline]
-    pub fn set_shader_params<Uniforms: AsStd140>(&mut self, params: ShaderParams<Uniforms>) {
-        self.state.params = Some((params.bind_group.clone(), params.layout));
+    pub fn set_shader_params<Uniforms: AsStd140>(&mut self, params: &ShaderParams<Uniforms>) {
+        self.state.params = Some((
+            params.bind_group.clone().unwrap(/* always Some */),
+            params.layout.clone().unwrap(/* always Some */),
+            params.buffer_offset,
+        ));
     }
 
     /// Sets the shader to use when drawing text.
@@ -196,8 +200,12 @@ impl Canvas {
     ///
     /// **Bound to bind group 3.**
     #[inline]
-    pub fn set_text_shader_params<Uniforms: AsStd140>(&mut self, params: ShaderParams<Uniforms>) {
-        self.state.text_params = Some((params.bind_group.clone(), params.layout));
+    pub fn set_text_shader_params<Uniforms: AsStd140>(&mut self, params: &ShaderParams<Uniforms>) {
+        self.state.text_params = Some((
+            params.bind_group.clone().unwrap(/* always Some */),
+            params.layout.clone().unwrap(/* always Some */),
+            params.buffer_offset,
+        ));
     }
 
     /// Resets the active mesh shader to the default.
@@ -418,13 +426,13 @@ impl Canvas {
 
         // apply initial state
         canvas.set_shader(state.shader.clone());
-        if let Some((bind_group, layout)) = &state.params {
-            canvas.set_shader_params(bind_group.clone(), layout.clone());
+        if let Some((bind_group, layout, offset)) = &state.params {
+            canvas.set_shader_params(bind_group.clone(), layout.clone(), *offset);
         }
 
         canvas.set_text_shader(state.text_shader.clone());
-        if let Some((bind_group, layout)) = &state.text_params {
-            canvas.set_text_shader_params(bind_group.clone(), layout.clone());
+        if let Some((bind_group, layout, offset)) = &state.text_params {
+            canvas.set_text_shader_params(bind_group.clone(), layout.clone(), *offset);
         }
 
         canvas.set_sampler(state.sampler);
@@ -444,8 +452,8 @@ impl Canvas {
                 }
 
                 if draw.state.params != state.params {
-                    if let Some((bind_group, layout)) = &draw.state.params {
-                        canvas.set_shader_params(bind_group.clone(), layout.clone());
+                    if let Some((bind_group, layout, offset)) = &draw.state.params {
+                        canvas.set_shader_params(bind_group.clone(), layout.clone(), *offset);
                     }
                 }
 
@@ -454,8 +462,8 @@ impl Canvas {
                 }
 
                 if draw.state.text_params != state.text_params {
-                    if let Some((bind_group, layout)) = &draw.state.text_params {
-                        canvas.set_text_shader_params(bind_group.clone(), layout.clone());
+                    if let Some((bind_group, layout, offset)) = &draw.state.text_params {
+                        canvas.set_text_shader_params(bind_group.clone(), layout.clone(), *offset);
                     }
                 }
 
@@ -504,9 +512,9 @@ impl Canvas {
 #[derive(Debug, Clone)]
 struct DrawState {
     shader: Shader,
-    params: Option<(ArcBindGroup, ArcBindGroupLayout)>,
+    params: Option<(ArcBindGroup, ArcBindGroupLayout, u32)>,
     text_shader: Shader,
-    text_params: Option<(ArcBindGroup, ArcBindGroupLayout)>,
+    text_params: Option<(ArcBindGroup, ArcBindGroupLayout, u32)>,
     sampler: Sampler,
     blend_mode: BlendMode,
     premul_text: bool,

--- a/src/graphics/gpu/bind_group.rs
+++ b/src/graphics/gpu/bind_group.rs
@@ -187,6 +187,7 @@ impl<'a> BindGroupBuilder<'a> {
         (group, layout)
     }
 
+    #[allow(unused)]
     pub fn create_uncached(self, device: &wgpu::Device) -> (ArcBindGroup, ArcBindGroupLayout) {
         let layout = self.layout.create_uncached(device);
         let group = ArcBindGroup::new(device.create_bind_group(&wgpu::BindGroupDescriptor {

--- a/src/graphics/gpu/bind_group.rs
+++ b/src/graphics/gpu/bind_group.rs
@@ -1,14 +1,29 @@
 use super::arc::{ArcBindGroup, ArcBindGroupLayout, ArcBuffer, ArcSampler, ArcTextureView};
-use std::{collections::HashMap, num::NonZeroU64};
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap},
+    hash::{Hash, Hasher},
+    num::NonZeroU64,
+};
 
 /// Builder pattern for bind group layouts; basically just produces a Vec<BindGroupLayoutEntry>.
 pub struct BindGroupLayoutBuilder {
     entries: Vec<wgpu::BindGroupLayoutEntry>,
+    seed: u64,
 }
 
 impl BindGroupLayoutBuilder {
     pub fn new() -> Self {
-        BindGroupLayoutBuilder { entries: vec![] }
+        BindGroupLayoutBuilder {
+            entries: vec![],
+            seed: 0,
+        }
+    }
+
+    pub fn seed(mut self, seed: impl Hash) -> Self {
+        let mut hasher = DefaultHasher::new();
+        seed.hash(&mut hasher);
+        self.seed = hasher.finish();
+        self
     }
 
     pub fn buffer(
@@ -57,7 +72,7 @@ impl BindGroupLayoutBuilder {
     pub fn create(self, device: &wgpu::Device, cache: &mut BindGroupCache) -> ArcBindGroupLayout {
         cache
             .layouts
-            .entry(self.entries.clone())
+            .entry((self.entries.clone(), self.seed))
             .or_insert_with(|| self.create_uncached(device))
             .clone()
     }
@@ -206,7 +221,7 @@ impl<'a> BindGroupBuilder<'a> {
 
 #[derive(Debug)]
 pub struct BindGroupCache {
-    layouts: HashMap<Vec<wgpu::BindGroupLayoutEntry>, ArcBindGroupLayout>,
+    layouts: HashMap<(Vec<wgpu::BindGroupLayoutEntry>, u64), ArcBindGroupLayout>,
     groups: HashMap<Vec<BindGroupEntryKey>, ArcBindGroup>,
 }
 

--- a/src/graphics/instance.rs
+++ b/src/graphics/instance.rs
@@ -200,22 +200,22 @@ impl InstanceArray {
         }
 
         let len = self.uniforms.len() as u32;
-        if len > self.capacity.load(SeqCst) {
-            let mut resized = InstanceArray::new_wgpu(
-                wgpu,
-                self.bind_layout.clone(),
-                self.image.clone(),
-                len,
-                self.ordered,
-            );
-            *self.buffer.lock().map_err(|_| GameError::LockError)? =
-                resized.buffer.get_mut().unwrap().clone();
-            *self.indices.lock().map_err(|_| GameError::LockError)? =
-                resized.indices.get_mut().unwrap().clone();
-            *self.bind_group.lock().map_err(|_| GameError::LockError)? =
-                resized.bind_group.get_mut().unwrap().clone();
-            self.capacity.store(len, SeqCst);
-        }
+        //if len > self.capacity.load(SeqCst) {
+        let mut resized = InstanceArray::new_wgpu(
+            wgpu,
+            self.bind_layout.clone(),
+            self.image.clone(),
+            len,
+            self.ordered,
+        );
+        *self.buffer.lock().map_err(|_| GameError::LockError)? =
+            resized.buffer.get_mut().unwrap().clone();
+        *self.indices.lock().map_err(|_| GameError::LockError)? =
+            resized.indices.get_mut().unwrap().clone();
+        *self.bind_group.lock().map_err(|_| GameError::LockError)? =
+            resized.bind_group.get_mut().unwrap().clone();
+        self.capacity.store(len, SeqCst);
+        //}
 
         wgpu.queue.write_buffer(
             &self.buffer.lock().unwrap(),

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -1,22 +1,19 @@
 use std::io::Read;
 use std::marker::PhantomData;
 
-use crate::{
-    context::{Has, HasMut},
-    GameError, GameResult,
-};
+use crate::{context::Has, Context, GameError, GameResult};
 
 use super::{
     context::GraphicsContext,
     gpu::{
-        arc::{ArcBindGroup, ArcBindGroupLayout, ArcBuffer, ArcShaderModule},
+        arc::{ArcBindGroup, ArcBindGroupLayout, ArcSampler, ArcShaderModule, ArcTextureView},
         bind_group::BindGroupBuilder,
+        growing::GrowingBufferArena,
     },
     image::Image,
     sampler::Sampler,
 };
 use crevice::std140::Std140;
-use wgpu::util::DeviceExt;
 
 #[derive(Debug, PartialEq, Eq)]
 enum ShaderSource<'a> {
@@ -231,52 +228,41 @@ impl<'a, Uniforms: AsStd140> ShaderParamsBuilder<'a, Uniforms> {
     }
 
     /// Produce a [ShaderParams] from the builder.
-    pub fn build(self, gfx: &mut impl HasMut<GraphicsContext>) -> ShaderParams<Uniforms> {
-        let gfx = gfx.retrieve_mut();
-        let uniforms = ArcBuffer::new(gfx.wgpu.device.create_buffer_init(
-            &wgpu::util::BufferInitDescriptor {
-                label: None,
-                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-                contents: self.uniforms.as_std140().as_bytes(),
-            },
-        ));
-
-        let mut builder = BindGroupBuilder::new();
-        builder = builder.buffer(
-            &uniforms,
-            0,
-            wgpu::ShaderStages::VERTEX_FRAGMENT,
-            wgpu::BufferBindingType::Uniform,
-            false,
-            None,
-        );
-
-        let vis = if self.images_vs_visible {
-            wgpu::ShaderStages::VERTEX_FRAGMENT
-        } else {
-            wgpu::ShaderStages::FRAGMENT
-        };
-        for image in self.images {
-            builder = builder.image(&image.view, vis);
-        }
-
+    pub fn build(self, ctx: &mut Context) -> ShaderParams<Uniforms> {
+        let images = self.images.iter().map(|image| image.view.clone()).collect();
         let samplers = self
             .samplers
             .iter()
-            .map(|&sampler| gfx.sampler_cache.get(&gfx.wgpu.device, sampler))
-            .collect::<Vec<_>>();
-        for sampler in &samplers {
-            builder = builder.sampler(sampler, vis);
-        }
+            .map(|&sampler| ctx.gfx.sampler_cache.get(&ctx.gfx.wgpu.device, sampler))
+            .collect();
 
-        let (bind_group, layout) = builder.create_uncached(&gfx.wgpu.device);
-
-        ShaderParams {
-            uniforms,
-            layout,
-            bind_group,
+        let mut params = ShaderParams {
+            uniform_arena: GrowingBufferArena::new(
+                &ctx.gfx.wgpu.device,
+                ctx.gfx
+                    .wgpu
+                    .device
+                    .limits()
+                    .min_uniform_buffer_offset_alignment as u64,
+                wgpu::BufferDescriptor {
+                    label: None,
+                    size: ShaderParams::<Uniforms>::UPDATES_PER_ARENA
+                        * Uniforms::std140_size_static() as u64,
+                    usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                },
+            ),
+            layout: None,
+            bind_group: None,
+            buffer_offset: 0,
+            images,
+            samplers,
+            images_vs_visible: self.images_vs_visible,
+            last_tick: 0,
             _marker: PhantomData,
-        }
+        };
+        params.set_uniforms(ctx, self.uniforms);
+        params
     }
 }
 
@@ -301,32 +287,73 @@ impl<'a, Uniforms: AsStd140> ShaderParamsBuilder<'a, Uniforms> {
 /// @group(3) @binding(3)
 /// var sampler1: sampler;
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct ShaderParams<Uniforms: AsStd140> {
-    pub(crate) uniforms: ArcBuffer,
-    pub(crate) layout: ArcBindGroupLayout,
-    pub(crate) bind_group: ArcBindGroup,
+    uniform_arena: GrowingBufferArena,
+    // layout and bind_group always Some after construction
+    pub(crate) layout: Option<ArcBindGroupLayout>,
+    pub(crate) bind_group: Option<ArcBindGroup>,
+    pub(crate) buffer_offset: u32,
+    images: Vec<ArcTextureView>,
+    samplers: Vec<ArcSampler>,
+    images_vs_visible: bool,
+    last_tick: usize,
     _marker: PhantomData<Uniforms>,
 }
 
 impl<Uniforms: AsStd140> ShaderParams<Uniforms> {
-    /// Updates the uniform data.
-    pub fn set_uniforms(&self, gfx: &impl Has<GraphicsContext>, uniforms: &Uniforms) {
-        let gfx = gfx.retrieve();
-        gfx.wgpu
-            .queue
-            .write_buffer(&self.uniforms, 0, uniforms.as_std140().as_bytes());
-    }
-}
+    // this is how many times the uniforms can be updated in one frame before a new buffer needs to be allocated.
+    // this is preemptive - if the user never updates then this is a waste, but if the user updates very often in any given frame then we'll have too many buffers + bind groups
+    // therefore, TODO: make this number user customizable?
+    const UPDATES_PER_ARENA: u64 = 16;
 
-impl<Uniforms: AsStd140> Clone for ShaderParams<Uniforms> {
-    fn clone(&self) -> Self {
-        Self {
-            uniforms: self.uniforms.clone(),
-            layout: self.layout.clone(),
-            bind_group: self.bind_group.clone(),
-            _marker: PhantomData,
+    /// Updates the uniform data.
+    ///
+    /// When called, [super::Canvas::set_shader_params] (or [super::Canvas::set_text_shader_params]) **needs to be called again** for the new uniforms to take effect.
+    pub fn set_uniforms(&mut self, ctx: &mut Context, uniforms: &Uniforms) {
+        if ctx.time.ticks() != self.last_tick {
+            self.uniform_arena.free();
+            self.last_tick = ctx.time.ticks();
         }
+        let alloc = self
+            .uniform_arena
+            .allocate(&ctx.gfx.wgpu.device, Uniforms::std140_size_static() as u64);
+        ctx.gfx.wgpu.queue.write_buffer(
+            &alloc.buffer,
+            alloc.offset,
+            uniforms.as_std140().as_bytes(),
+        );
+
+        self.buffer_offset = alloc.offset as u32;
+
+        let mut builder = BindGroupBuilder::new();
+        builder = builder.buffer(
+            &alloc.buffer,
+            0,
+            wgpu::ShaderStages::VERTEX_FRAGMENT,
+            wgpu::BufferBindingType::Uniform,
+            true,
+            None,
+        );
+
+        let vis = if self.images_vs_visible {
+            wgpu::ShaderStages::VERTEX_FRAGMENT
+        } else {
+            wgpu::ShaderStages::FRAGMENT
+        };
+
+        for view in &self.images {
+            builder = builder.image(view, vis);
+        }
+
+        for sampler in &self.samplers {
+            builder = builder.sampler(sampler, vis);
+        }
+
+        let (bind_group, layout) =
+            builder.create(&ctx.gfx.wgpu.device, &mut ctx.gfx.bind_group_cache);
+        self.layout = Some(layout);
+        self.bind_group = Some(bind_group);
     }
 }
 


### PR DESCRIPTION
closes #1129

All instances where wgpu.queue.write_buffer is used now only write to buffers that have been freshly allocated from an arena. Previously, in some instances (such as in ShaderParams), existing buffers regions were overwritten at the start of the queue, causing #1129.

Also fixes #1137 - This had nothing to do with the buffer overwriting issue, we were just missing a dirty_pipeline flag.

The only queued write that isn't reallocated is the queue.write_texture in TextRenderer, but this is fine as we operate under the condition that glyph_brush never tells us to write to a region of the glyph cache texture that's already been written to (which would in itself be problematic :P).

Regarding the original issue of #1129, that is InstanceArray, the fix was very simple; unconditionally executing the statement previously guarded by resizing the buffers when capacity changes. Using an arena here doesn't really make sense as between different mutations an IA can have wildly different buffer sizes and would be a pain to actually implement. I'm only hesitant of the performance effects -- Memory performance should be okay (given what the goal is -- allowing the user to change data between draws within a single pass -- buffers and data need to be duplicated, there's no getting around that, and the excess should be dropped by the end of the frame anyway), but the problem is that this could happen needlessly if the user isn't aware that IAs are effectively duplicated in memory if they're mutated between draws. Attention should be drawn in docs that IA mutations should be done in as large and early chunks as possible.

ShaderParams now have a local arena with a preset buffer size (UPDATES_PER_ARENA -- currently 16). The goal here is to minimize how many new bind groups need to be created by minimizing how many new buffers are encountered in combination with a specific ShaderParams instance - avoiding a sort of combinatorial explosion at the bind group cache. Ideally we would have ShaderParams be sent in two separate bind groups but as I understand this isn't possible due to the need to support lower-end hardware and also possibly for user experience when writing shaders.