### PR TITLE
Set Wayland app-id based on ggez game_id

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -168,6 +168,7 @@ impl Context {
     /// Tries to create a new Context using settings from the given [`Conf`](../conf/struct.Conf.html) object.
     /// Usually called by [`ContextBuilder::build()`](struct.ContextBuilder.html#method.build).
     fn from_conf(
+        game_id: &str,
         conf: conf::Conf,
         fs: Filesystem,
     ) -> GameResult<(Context, winit::event_loop::EventLoop<()>)> {
@@ -175,7 +176,7 @@ impl Context {
         let audio_context = audio::AudioContext::new(&fs)?;
         let events_loop = winit::event_loop::EventLoop::new();
         let timer_context = timer::TimeContext::new();
-        let graphics_context = graphics::context::GraphicsContext::new(&events_loop, &conf, &fs)?;
+        let graphics_context = graphics::context::GraphicsContext::new(game_id, &events_loop, &conf, &fs)?;
 
         let ctx = Context {
             conf,
@@ -340,7 +341,7 @@ impl ContextBuilder {
             self.conf
         };
 
-        Context::from_conf(config, fs)
+        Context::from_conf(self.game_id.as_ref(), config, fs)
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -176,7 +176,8 @@ impl Context {
         let audio_context = audio::AudioContext::new(&fs)?;
         let events_loop = winit::event_loop::EventLoop::new();
         let timer_context = timer::TimeContext::new();
-        let graphics_context = graphics::context::GraphicsContext::new(game_id, &events_loop, &conf, &fs)?;
+        let graphics_context =
+            graphics::context::GraphicsContext::new(game_id, &events_loop, &conf, &fs)?;
 
         let ctx = Context {
             conf,

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -145,8 +145,7 @@ impl GraphicsContext {
 
     #[allow(unsafe_code)]
     pub(crate) fn new_from_instance(
-        #[allow(unused_variables)]
-        game_id: &str,
+        #[allow(unused_variables)] game_id: &str,
         instance: wgpu::Instance,
         event_loop: &winit::event_loop::EventLoop<()>,
         conf: &Conf,

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -95,12 +95,14 @@ pub struct GraphicsContext {
 impl GraphicsContext {
     #[allow(unsafe_code)]
     pub(crate) fn new(
+        game_id: &str,
         event_loop: &winit::event_loop::EventLoop<()>,
         conf: &Conf,
         filesystem: &Filesystem,
     ) -> GameResult<Self> {
         if conf.backend == Backend::All {
             match Self::new_from_instance(
+                game_id,
                 wgpu::Instance::new(wgpu::Backends::PRIMARY),
                 event_loop,
                 conf,
@@ -116,6 +118,7 @@ impl GraphicsContext {
                     );
 
                     Self::new_from_instance(
+                        game_id,
                         wgpu::Instance::new(wgpu::Backends::SECONDARY),
                         event_loop,
                         conf,
@@ -136,12 +139,14 @@ impl GraphicsContext {
                 Backend::BrowserWebGpu => wgpu::Backends::BROWSER_WEBGPU,
             });
 
-            Self::new_from_instance(instance, event_loop, conf, filesystem)
+            Self::new_from_instance(game_id, instance, event_loop, conf, filesystem)
         }
     }
 
     #[allow(unsafe_code)]
     pub(crate) fn new_from_instance(
+        #[allow(unused_variables)]
+        game_id: &str,
         instance: wgpu::Instance,
         event_loop: &winit::event_loop::EventLoop<()>,
         conf: &Conf,
@@ -153,6 +158,18 @@ impl GraphicsContext {
             .with_resizable(conf.window_mode.resizable)
             .with_visible(conf.window_mode.visible)
             .with_transparent(conf.window_mode.transparent);
+
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
+        {
+            use winit::platform::unix::WindowBuilderExtUnix;
+            window_builder = window_builder.with_name(game_id, game_id);
+        }
 
         #[cfg(target_os = "windows")]
         {


### PR DESCRIPTION
This implements the feature described in #1142, it has been tested and confirmed to set the app-id correctly in sway wm, and does not break builds for non-supported platforms by using the same `cfg` directive that winit uses.