### PR TITLE
fix non-instanced draw calls - use as_std140 instead of bytemuck for uniforms

### DIFF
--- a/src/graphics/internal_canvas.rs
+++ b/src/graphics/internal_canvas.rs
@@ -342,7 +342,7 @@ impl<'a> InternalCanvas<'a> {
         self.wgpu.queue.write_buffer(
             &uniform_alloc.buffer,
             uniform_alloc.offset,
-            bytemuck::bytes_of(&uniforms),
+            uniforms.as_std140().as_bytes(),
         );
 
         self.pass.set_bind_group(


### PR DESCRIPTION
Fixes the issues as discussed on Reddit and Discord:
https://www.reddit.com/r/rust_gamedev/comments/z5xhi9/ggez_081_only_text_is_rendering_help_needed_please/