### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2019, ubuntu-20.04, macos-10.15]
+        os: [windows-2019, ubuntu-20.04, macos-11]
         toolchain: [stable, beta]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ gamepad = ["gilrs"]
 [dependencies]
 bitflags = "1.3"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
-directories = "4.0"
+directories = "5.0"
 wgpu = "0.15"
 glyph_brush = "0.7"
-winit = { version = "0.27.3", features = ["serde"] }
+winit = { version = "0.28.3", features = ["serde"] }
 image = { version = "0.24", default-features = false, features = [
    "gif",
    "png",
@@ -49,7 +49,7 @@ image = { version = "0.24", default-features = false, features = [
    "bmp",
    "dxt",
 ] }
-rodio = { version = "0.16", optional = true, default-features = false, features = [
+rodio = { version = "0.17", optional = true, default-features = false, features = [
    "flac",
    "vorbis",
    "wav",
@@ -59,15 +59,15 @@ toml = "0.5"
 log = "0.4"
 lyon = "1.0"
 smart-default = "0.6"
-glam = { version = "0.22", features = ["mint"] }
+glam = { version = "0.23", features = ["mint"] }
 # Has to be the same version of mint that our math lib uses here.
 mint = "0.5.9"
 gilrs = { version = "0.10", optional = true }
 approx = "0.5"
 bytemuck = { version = "1.12", features = ["derive"] }
-pollster = "0.2"
+pollster = "0.3"
 memoffset = "0.8"
-crevice = "0.12"
+crevice = "0.13"
 typed-arena = "2.0"
 ordered-float = "3.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 log = "0.4"
 lyon = "1.0"
-smart-default = "0.6"
+smart-default = "0.7"
 glam = { version = "0.24", features = ["mint"] }
 # Has to be the same version of mint that our math lib uses here.
 mint = "0.5.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ toml = "0.5"
 log = "0.4"
 lyon = "1.0"
 smart-default = "0.6"
-glam = { version = "0.23", features = ["mint"] }
+glam = { version = "0.24", features = ["mint"] }
 # Has to be the same version of mint that our math lib uses here.
 mint = "0.5.9"
 gilrs = { version = "0.10", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ audio = ["rodio"]
 gamepad = ["gilrs"]
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "2.1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 directories = "5.0"
 wgpu = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ gamepad = ["gilrs"]
 bitflags = "1.3"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 directories = "5.0"
-wgpu = "0.15"
+wgpu = "0.16"
 glyph_brush = "0.7"
 winit = { version = "0.28.3", features = ["serde"] }
 image = { version = "0.24", default-features = false, features = [

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -173,8 +173,14 @@ impl GraphicsContext {
             target_os = "openbsd"
         ))]
         {
-            use winit::platform::unix::WindowBuilderExtUnix;
-            window_builder = window_builder.with_name(game_id, game_id);
+            {
+                use winit::platform::x11::WindowBuilderExtX11;
+                window_builder = window_builder.with_name(game_id, game_id);
+            }
+            {
+                use winit::platform::wayland::WindowBuilderExtWayland;
+                window_builder = window_builder.with_name(game_id, game_id);
+            }
         }
 
         #[cfg(target_os = "windows")]

--- a/src/graphics/gpu/text.rs
+++ b/src/graphics/gpu/text.rs
@@ -211,7 +211,7 @@ pub(crate) struct Extra {
 }
 
 // hash is impl'd via OrderedFloat, but we still want to preserve the types
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl std::hash::Hash for Extra {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/src/graphics/gpu/text.rs
+++ b/src/graphics/gpu/text.rs
@@ -6,7 +6,7 @@ use crate::graphics::{context::FrameArenas, LinearColor};
 use crevice::std140::AsStd140;
 use glyph_brush::{GlyphBrush, GlyphBrushBuilder};
 use ordered_float::OrderedFloat;
-use std::{cell::RefCell, num::NonZeroU32};
+use std::cell::RefCell;
 
 pub(crate) struct TextRenderer {
     // RefCell to make various getter not take &mut.
@@ -108,7 +108,7 @@ impl TextRenderer {
                     pixels,
                     wgpu::ImageDataLayout {
                         offset: 0,
-                        bytes_per_row: Some(NonZeroU32::new(rect.width()).unwrap()),
+                        bytes_per_row: Some(rect.width()),
                         rows_per_image: None,
                     },
                     wgpu::Extent3d {

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -5,8 +5,7 @@ use super::{
 };
 use crate::{context::Has, Context, GameError, GameResult};
 use image::ImageEncoder;
-use std::path::Path;
-use std::{io::Read, num::NonZeroU32};
+use std::{io::Read, path::Path};
 
 // maintaing a massive enum of all possible texture formats?
 // screw that.
@@ -84,9 +83,7 @@ impl Image {
             pixels,
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: Some(
-                    NonZeroU32::new(u32::from(format.describe().block_size) * width).unwrap(),
-                ),
+                bytes_per_row: Some(format.block_size(None).unwrap() * width),
                 rows_per_image: None,
             },
             wgpu::Extent3d {
@@ -178,9 +175,9 @@ impl Image {
                 dimension: Some(wgpu::TextureViewDimension::D2),
                 aspect: wgpu::TextureAspect::All,
                 base_mip_level: 0,
-                mip_level_count: Some(NonZeroU32::new(1).unwrap()),
+                mip_level_count: Some(1),
                 base_array_layer: 0,
-                array_layer_count: Some(NonZeroU32::new(1).unwrap()),
+                array_layer_count: Some(1),
             }));
 
         Image {
@@ -211,7 +208,7 @@ impl Image {
             )));
         }
 
-        let block_size = u64::from(self.format.describe().block_size);
+        let block_size = u64::from(self.format.block_size(None).unwrap());
 
         let buffer = gfx.wgpu.device.create_buffer(&wgpu::BufferDescriptor {
             label: None,
@@ -231,9 +228,7 @@ impl Image {
                     buffer: &buffer,
                     layout: wgpu::ImageDataLayout {
                         offset: 0,
-                        bytes_per_row: Some(
-                            NonZeroU32::new(block_size as u32 * self.width).unwrap(),
-                        ),
+                        bytes_per_row: Some(block_size as u32 * self.width),
                         rows_per_image: None,
                     },
                 },

--- a/src/graphics/sampler.rs
+++ b/src/graphics/sampler.rs
@@ -59,7 +59,7 @@ impl<'a> From<Sampler> for wgpu::SamplerDescriptor<'a> {
             lod_min_clamp: 0.0,
             lod_max_clamp: 1.0,
             compare: None,
-            anisotropy_clamp: None,
+            anisotropy_clamp: 1,
             border_color: None,
         }
     }

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -172,10 +172,10 @@ impl Default for ShaderBuilder<'_> {
 ///         let dim = Dim { rate: 0.5 };
 ///         // NOTE: This is for simplicity; do not recreate your shader every frame like this!
 ///         //       For more info look at the full example.
-///         let shader = ShaderBuilder::new_wgsl()
+///         let shader = ShaderBuilder::new()
 ///             .fragment_code(include_str!("../../resources/dimmer.wgsl"))
 ///             .build(&mut ctx.gfx)?;
-///         let params = ShaderParamsBuilder::new(&dim).build(&mut ctx);
+///         let mut params = ShaderParamsBuilder::new(&dim).build(ctx);
 ///         params.set_uniforms(ctx, &dim);
 ///
 ///         canvas.set_shader(&shader);

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -117,7 +117,7 @@ pub use winit::event::VirtualKeyCode as KeyCode;
 
 bitflags::bitflags! {
     /// Bitflags describing the state of keyboard modifiers, such as `Control` or `Shift`.
-    #[derive(Default)]
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
     pub struct KeyMods: u8 {
         /// No modifiers; equivalent to `KeyMods::default()` and
         /// [`KeyMods::empty()`](struct.KeyMods.html#method.empty).


### PR DESCRIPTION
Update multiple dependencies:
- `bitflags` to `2.1`
- `wgpu` to `0.16`
- `directories` to `5.0`
- `winit` to `0.28`
- `rodio` to `0.17`
- `glam` to `0.24`
- `pollster` to `0.3`
- `crevice` to `0.13`
- `smart-default` to `0.7`

Also fix CI failures from clippy and update deprecatd MacOS version in CI