### PR TITLE
doc: Added dependencies for fedora into build guide

### DIFF
--- a/docs/BuildingForEveryPlatform.md
+++ b/docs/BuildingForEveryPlatform.md
@@ -68,6 +68,12 @@ least you can install them with:
 yum install alsa-lib-devel
 ```
 
+### Fedora
+
+```sh
+dnf install rust-libudev-devel rust-libudev-sys-devel alsa-lib-devel pkgconf-pkg-config
+```
+
 ## Distributing
 
 You should be able to just copy-paste the executable file and the `resources` directory to wherever you want.


### PR DESCRIPTION
Some fedora packages are called quite differently than in Debian based distributions. Therefore the corresponding package names were added.

**Please only open PRs that are based on and aimed towards the `devel` branch**

**For more information take a look at [the contribution guide](./CONTRIBUTING.md)**
