### PR TITLE
Upgrade http links to https in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ggez"
 description = "A lightweight game framework for making 2D games with minimum friction, inspired by Love2D."
 version = "0.9.0-rc0"
-homepage = "http://ggez.rs"
+homepage = "https://ggez.rs"
 repository = "https://github.com/ggez/ggez"
 documentation = "https://docs.rs/ggez"
 keywords = ["ggez", "graphics", "2D", "game", "engine"]


### PR DESCRIPTION
This is an automatically-generated PR to update plain HTTP links in Cargo.toml

If there are any issues with this, you can reach out to @/Benjins on Github who is the original author of this automated PR

In file `Cargo.toml`:
 - `http://ggez.rs` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

