### PR TITLE
from_color

### DIFF
--- a/examples/colorspace.rs
+++ b/examples/colorspace.rs
@@ -99,7 +99,7 @@ impl MainState {
             graphics::Rect::new(0.0, 0.0, 400.0, 400.0),
             Color::WHITE,
         )?;
-        let demo_image = graphics::Image::from_solid(ctx, 200, AQUA);
+        let demo_image = graphics::Image::from_color(ctx, 200, 200, Some(AQUA));
 
         let mut demo_instances = graphics::InstanceArray::new(ctx, demo_image.clone());
         demo_instances.push(

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -198,8 +198,12 @@ impl MainState {
                 });
 
         // Create 1-pixel blue texture.
-        let image =
-            graphics::Image::from_solid(ctx, 1, graphics::Color::from_rgb(0x20, 0xA0, 0xC0));
+        let image = graphics::Image::from_color(
+            ctx,
+            1,
+            1,
+            Some(graphics::Color::from_rgb(0x20, 0xA0, 0xC0)),
+        );
 
         let sampler = ctx
             .gfx

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -52,7 +52,7 @@ impl Image {
     ///
     /// The default color is [`Color::WHITE`].
     /// Mainly useful for debugging.
-    pub fn new_blank_canvas_image(
+    pub fn from_color(
         gfx: &impl Has<GraphicsContext>,
         width: u32,
         height: u32,
@@ -119,23 +119,6 @@ impl Image {
         );
 
         image
-    }
-
-    /// A little helper function that creates a new `Image` that is just a solid square of the given size and color. Mainly useful for debugging.
-    pub fn from_solid(gfx: &impl Has<GraphicsContext>, size: u32, color: Color) -> Self {
-        let pixels = (0..(size * size))
-            .flat_map(|_| {
-                let (r, g, b, a) = color.to_rgba();
-                [r, g, b, a]
-            })
-            .collect::<Vec<_>>();
-        Self::from_pixels(
-            gfx,
-            &pixels,
-            wgpu::TextureFormat::Rgba8UnormSrgb,
-            size,
-            size,
-        )
     }
 
     /// Creates a new image initialized with pixel data loaded from a given path as an


### PR DESCRIPTION
renamed `new_blank_canvas_image` to `from_color` and removed `from_solid`, as `from_color` is just a more properly named replacement with the ability to specify width and height.