### PR TITLE
Fix/instances-empty-guard

### DIFF
--- a/src/graphics/instance.rs
+++ b/src/graphics/instance.rs
@@ -306,6 +306,11 @@ impl InstanceArray {
 
 impl Drawable for InstanceArray {
     fn draw(&self, canvas: &mut Canvas, param: impl Into<DrawParam>) {
+        // Only flush (and then push a draw) if there are any instances to draw.
+        // This guards against attempts to create empty buffers in `new_wgpu`, see #1168.
+        if self.instances().is_empty() {
+            return;
+        }
         self.flush_wgpu(&canvas.wgpu).unwrap();
         canvas.push_draw(
             Draw::MeshInstances {


### PR DESCRIPTION
added safeguard to InstanceArray::draw for the case of no instances to draw, based on https://github.com/ggez/ggez/issues/1168#issuecomment-1419178721