### PR TITLE
Fix typo in Text::set_scale doc

### DIFF
--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -195,7 +195,7 @@ impl Text {
         self
     }
 
-    /// Specifies the text's font scael for fragments that don't specify their own scale.
+    /// Specifies the text's font scale for fragments that don't specify their own scale.
     pub fn set_scale(&mut self, scale: impl Into<PxScale>) -> &mut Self {
         self.scale = scale.into();
         self


### PR DESCRIPTION
Fix typo in `Text::set_scale` doc.