### PR TITLE
Add method to get underlying shader modules from Shader

### DIFF
--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -193,6 +193,18 @@ pub struct Shader {
     pub(crate) fs_module: Option<ArcShaderModule>,
 }
 
+impl Shader {
+    /// Get the underlying vertex shader module for wgpu
+    pub fn vs_module(&self) -> Option<ArcShaderModule> {
+        self.vs_module.clone()
+    }
+
+    /// Get the underlying fragment shader module for wgpu
+    pub fn fs_module(&self) -> Option<ArcShaderModule> {
+        self.fs_module.clone()
+    }
+}
+
 use crevice::std140::AsStd140;
 
 /// A builder for [`ShaderParams`]

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -197,7 +197,7 @@ impl Shader {
     /// Get the underlying vertex shader module for wgpu
     pub fn vs_module(&self) -> Option<&wgpu::ShaderModule> {
         if let Some(vs_module) = &self.vs_module {
-            Some(&*vs_module)
+            Some(vs_module)
         } else {
             None
         }
@@ -206,7 +206,7 @@ impl Shader {
     /// Get the underlying fragment shader module for wgpu
     pub fn fs_module(&self) -> Option<&wgpu::ShaderModule> {
         if let Some(fs_module) = &self.fs_module {
-            Some(&*fs_module)
+            Some(fs_module)
         } else {
             None
         }

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -195,13 +195,21 @@ pub struct Shader {
 
 impl Shader {
     /// Get the underlying vertex shader module for wgpu
-    pub fn vs_module(&self) -> Option<ArcShaderModule> {
-        self.vs_module.clone()
+    pub fn vs_module(&self) -> Option<&wgpu::ShaderModule> {
+        if let Some(vs_module) = &self.vs_module {
+            Some(&*vs_module)
+        } else {
+            None
+        }
     }
 
     /// Get the underlying fragment shader module for wgpu
-    pub fn fs_module(&self) -> Option<ArcShaderModule> {
-        self.fs_module.clone()
+    pub fn fs_module(&self) -> Option<&wgpu::ShaderModule> {
+        if let Some(fs_module) = &self.fs_module {
+            Some(&*fs_module)
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
This will help with people who want to work on lower level rendering things but still use the builtin ggez Shader