### PR TITLE
Attempt at fixing #1232

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -23,8 +23,8 @@ use crate::{
     graphics::gpu::{bind_group::BindGroupLayoutBuilder, pipeline::RenderPipelineInfo},
     GameError,
 };
-use ::image as imgcrate;
 use glyph_brush::FontId;
+use image as imgcrate;
 use std::{collections::HashMap, path::Path, sync::Arc};
 use typed_arena::Arena as TypedArena;
 use winit::{
@@ -557,6 +557,11 @@ impl GraphicsContext {
     pub fn add_font(&mut self, name: &str, font: FontData) {
         let id = self.text.glyph_brush.borrow_mut().add_font(font.font);
         self.fonts.insert(name.to_string(), id);
+    }
+
+    /// Checks if the given font is loaded
+    pub fn has_font(&self, font_name: impl Into<String>) -> bool {
+        self.fonts.contains_key(&font_name.into())
     }
 
     /// Returns the size of the window’s underlying drawable in physical pixels as (width, height).

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -184,6 +184,9 @@ impl Text {
     }
 
     /// Specifies the text's font for fragments that don't specify their own font.
+    ///
+    /// Note: [`Canvas::finish`] will return a [`GameError::FontSelectError`] if the given font is not loaded.
+    /// See [`GraphicsContext::add_font`] and [`GraphicsContext::has_font`]
     pub fn set_font(&mut self, font: impl Into<String>) -> &mut Self {
         self.font = font.into();
         self


### PR DESCRIPTION
In this first commit I've added a `has_font` function to the graphic context, for the user to be able to check if font is loaded.
And modified the doc of `Text::set_font` to add a not warning about the error returned by `Canvas::finish` if the given font is not loaded

This is what the doc change looks like, lmk if that is too much
![image](https://github.com/ggez/ggez/assets/63136904/ff3caeb9-22c3-47c8-976a-c317ae44025a)

