### PR TITLE
fix: use non-rust package in fedora dependency

### DIFF
--- a/docs/BuildingForEveryPlatform.md
+++ b/docs/BuildingForEveryPlatform.md
@@ -71,7 +71,7 @@ yum install alsa-lib-devel
 ### Fedora
 
 ```sh
-dnf install rust-libudev-devel rust-libudev-sys-devel alsa-lib-devel pkgconf-pkg-config
+dnf install systemd-devel alsa-lib-devel pkgconf-pkg-config
 ```
 
 ## Distributing


### PR DESCRIPTION
Using rust-libudev-devel and rust-libudev-sys-devel installs cargo and rust through the package manager, which may not be preferable, if installed through rustup.
