### PR TITLE
canvas/instancearray: custom sorting functions

### DIFF
--- a/src/graphics/instance3d.rs
+++ b/src/graphics/instance3d.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crevice::std140::AsStd140;
 use std::{
-    collections::BTreeMap,
+    cmp::Ordering,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst},
         Mutex,
@@ -32,6 +32,7 @@ pub struct InstanceArray3d {
     capacity: AtomicUsize,
     uniforms: Vec<Std140DrawUniforms3d>,
     params: Vec<DrawParam3d>,
+    sort_by: fn(&DrawParam3d, &DrawParam3d) -> Ordering,
 }
 
 impl InstanceArray3d {
@@ -147,6 +148,7 @@ impl InstanceArray3d {
             uniforms,
             params,
             mesh,
+            sort_by: |a, b| a.z.cmp(&b.z),
         }
     }
 
@@ -236,11 +238,9 @@ impl InstanceArray3d {
         );
 
         if self.ordered {
-            let mut layers = BTreeMap::<_, Vec<_>>::new();
-            for (i, param) in self.params.iter().enumerate() {
-                layers.entry(param.z).or_default().push(i as u32);
-            }
-            let indices = layers.into_values().flatten().collect::<Vec<_>>();
+            let mut sorted: Vec<_> = self.params.iter().enumerate().collect();
+            sorted.sort_by(|(_, a), (_, b)| (self.sort_by)(a, b));
+            let indices: Vec<_> = sorted.iter().map(|(i, _)| *i as u32).collect();
             wgpu.queue.write_buffer(
                 &self.indices.lock().unwrap(),
                 0,
@@ -299,6 +299,15 @@ impl InstanceArray3d {
     #[inline]
     pub fn capacity(&self) -> usize {
         self.capacity.load(SeqCst)
+    }
+
+    /// Sets the sorting function for the final draw order of the instance array.
+    /// This is used upon the instance array being drawn to a canvas.
+    ///
+    /// By default, draws will be sorted by the Z index of [`DrawParam3d`].
+    #[inline]
+    pub fn set_sort_by(&mut self, sort_by: fn(&DrawParam3d, &DrawParam3d) -> Ordering) {
+        self.sort_by = sort_by;
     }
 }
 


### PR DESCRIPTION
It was brought to my attention that GGEZ lacks any ability to support custom sorting, which would be helpful in, e.g., top-down games, where draws should be sorted by the Y coordinate. Currently the only way to sort is by using Z indices, which does not apply well to this scenario.

This PR changes two things:

1. The internal `BTreeMap` structures are replaced with a plain `Vec`.
2. The draw list (or indices) are stable sorted by a function which can be set by the user.

These changes apply to both `Canvas` and `InstanceArray`.

The default behavior remains identical to current, with draws ordered by Z and then by insertion (hence why a stable sort was chosen).

From my limited testing, average frame delta is essentially identical to the current `BTreeMap`-based sorting.