### PR TITLE
fix(canvas): Reset shader params when setting default shader

### DIFF
--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -213,6 +213,9 @@ impl Canvas {
     }
 
     /// Resets the active mesh shader to the default.
+    ///
+    /// If any shader parameters were previously set with `set_shader_params`, these will also be
+    /// reset to the default of `None`.
     #[inline]
     pub fn set_default_shader(&mut self) {
         self.state.shader = default_shader();
@@ -220,6 +223,9 @@ impl Canvas {
     }
 
     /// Resets the active text shader to the default.
+    ///
+    /// If any text shader parameters were previously set with `set_text_shader_params`, these will
+    /// also be reset to the default of `None`.
     #[inline]
     pub fn set_default_text_shader(&mut self) {
         self.state.text_shader = default_text_shader();

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -216,12 +216,14 @@ impl Canvas {
     #[inline]
     pub fn set_default_shader(&mut self) {
         self.state.shader = default_shader();
+        self.state.params = None;
     }
 
     /// Resets the active text shader to the default.
     #[inline]
     pub fn set_default_text_shader(&mut self) {
         self.state.text_shader = default_text_shader();
+        self.state.text_params = None;
     }
 
     /// Sets the active sampler used to sample images.


### PR DESCRIPTION
Previous behaviour when using the `set_default_shader` function was to keep the old shader params under `self.state.params` around. This was conditionally giving me a panic with the following message:
```
The pipeline layout, associated with the current render pipeline, contains a bind group layout at index 3 which is incompatible with the bind group layout associated with the bind group at 3
```

Presumably the sensible fix is to simply also reset the shader parameters when we reset the shader. After discussion in Discord, I was told the same would apply to the text shader/params. I haven't used these at all, but the fix there looks trivially similar. If I'm at all wrong just let me know, thanks :smile: 