### PR TITLE
canvas: fix shader param pipeline hashing

### DIFF
--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -483,6 +483,8 @@ impl Canvas {
             if draw.state.params != state.params {
                 if let Some((bind_group, layout, offset)) = &draw.state.params {
                     canvas.set_shader_params(bind_group.clone(), layout.clone(), *offset);
+                } else {
+                    canvas.reset_shader_params();
                 }
             }
 
@@ -493,6 +495,8 @@ impl Canvas {
             if draw.state.text_params != state.text_params {
                 if let Some((bind_group, layout, offset)) = &draw.state.text_params {
                     canvas.set_text_shader_params(bind_group.clone(), layout.clone(), *offset);
+                } else {
+                    canvas.reset_text_shader_params();
                 }
             }
 

--- a/src/graphics/canvas3d.rs
+++ b/src/graphics/canvas3d.rs
@@ -415,6 +415,8 @@ impl Canvas3d {
             if draw.state.params != state.params {
                 if let Some((bind_group, layout, offset)) = &draw.state.params {
                     canvas.set_shader_params(bind_group.clone(), layout.clone(), *offset);
+                } else {
+                    canvas.reset_shader_params();
                 }
             }
 

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -760,6 +760,7 @@ impl GraphicsContext {
                 &self.wgpu.device,
                 &layout,
                 RenderPipelineInfo {
+                    layout_id: layout.id(),
                     vs: self.copy_shader.clone(),
                     fs: self.copy_shader.clone(),
                     vs_entry: "vs_main".into(),

--- a/src/graphics/gpu/pipeline.rs
+++ b/src/graphics/gpu/pipeline.rs
@@ -4,6 +4,7 @@ use std::collections::{hash_map::DefaultHasher, HashMap};
 /// Hashable representation of a render pipeline, used as a key in the HashMap cache.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RenderPipelineInfo {
+    pub layout_id: u64,
     pub vs: ArcShaderModule,
     pub fs: ArcShaderModule,
     pub vs_entry: String,

--- a/src/graphics/internal_canvas.rs
+++ b/src/graphics/internal_canvas.rs
@@ -240,6 +240,12 @@ impl<'a> InternalCanvas<'a> {
         self.shader_bind_group = Some((self.arenas.bind_groups.alloc(bind_group), layout, offset));
     }
 
+    pub fn reset_shader_params(&mut self) {
+        self.flush_text();
+        self.dirty_pipeline = true;
+        self.shader_bind_group = None;
+    }
+
     pub fn set_shader(&mut self, shader: Shader) {
         self.flush_text();
         self.dirty_pipeline = true;
@@ -256,6 +262,12 @@ impl<'a> InternalCanvas<'a> {
         self.dirty_pipeline = true;
         self.text_shader_bind_group =
             Some((self.arenas.bind_groups.alloc(bind_group), layout, offset));
+    }
+
+    pub fn reset_text_shader_params(&mut self) {
+        self.flush_text();
+        self.dirty_pipeline = true;
+        self.text_shader_bind_group = None;
     }
 
     pub fn set_text_shader(&mut self, shader: Shader) {
@@ -585,6 +597,7 @@ impl<'a> InternalCanvas<'a> {
                     &self.wgpu.device,
                     layout.as_ref(),
                     RenderPipelineInfo {
+                        layout_id: layout.id(),
                         vs: if let Some(vs_module) = &shader.vs_module {
                             vs_module.clone()
                         } else {

--- a/src/graphics/internal_canvas3d.rs
+++ b/src/graphics/internal_canvas3d.rs
@@ -224,6 +224,11 @@ impl<'a> InternalCanvas3d<'a> {
         self.shader_bind_group = Some((self.arenas.bind_groups.alloc(bind_group), layout, offset));
     }
 
+    pub fn reset_shader_params(&mut self) {
+        self.dirty_pipeline = true;
+        self.shader_bind_group = None;
+    }
+
     pub fn set_shader(&mut self, shader: Shader) {
         self.dirty_pipeline = true;
         self.shader = shader;
@@ -455,6 +460,7 @@ impl<'a> InternalCanvas3d<'a> {
                     &self.wgpu.device,
                     layout.as_ref(),
                     RenderPipelineInfo {
+                        layout_id: layout.id(),
                         vs: if let Some(vs_module) = &shader.vs_module {
                             vs_module.clone()
                         } else {


### PR DESCRIPTION
Fixes an issue that occurred in an extremely specific circumstance wherein the pipeline cache was poisoned with a pipeline that was created with a pipeline layout containing an additional unneeded bind group (bind group 3, for the user's shader params), which would only affect subsequent canvases.

Fix does two things:
1. explicitly resets internal shader params to `None` so that the pipeline layout is correct - this fixes this specific scenario
2. includes the pipeline layout ID in the pipeline hash to prevent any other bug like this from occurring