### PR TITLE
Adapt WGPU limits to ggez Backend configuration

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -117,6 +117,7 @@ impl GraphicsContext {
             match Self::new_from_instance(
                 game_id,
                 new_instance(wgpu::Backends::PRIMARY),
+                wgpu::Limits::downlevel_webgl2_defaults(),
                 event_loop,
                 conf,
                 filesystem,
@@ -133,6 +134,7 @@ impl GraphicsContext {
                     Self::new_from_instance(
                         game_id,
                         new_instance(wgpu::Backends::SECONDARY),
+                        wgpu::Limits::downlevel_webgl2_defaults(),
                         event_loop,
                         conf,
                         filesystem,
@@ -152,7 +154,12 @@ impl GraphicsContext {
                 Backend::BrowserWebGpu => wgpu::Backends::BROWSER_WEBGPU,
             });
 
-            Self::new_from_instance(game_id, instance, event_loop, conf, filesystem)
+            let base_limits = match conf.backend {
+                Backend::Gl => wgpu::Limits::downlevel_webgl2_defaults(),
+                _ => wgpu::Limits::default(),
+            };
+
+            Self::new_from_instance(game_id, instance, base_limits, event_loop, conf, filesystem)
         }
     }
 
@@ -231,6 +238,7 @@ impl GraphicsContext {
     pub(crate) fn new_from_instance(
         #[allow(unused_variables)] game_id: &str,
         instance: wgpu::Instance,
+        base_limits: wgpu::Limits,
         event_loop: &winit::event_loop::EventLoop<()>,
         conf: &Conf,
         filesystem: &Filesystem,
@@ -303,7 +311,7 @@ impl GraphicsContext {
                     max_storage_buffer_binding_size: INSTANCE_BUFFER_SIZE,
                     max_texture_dimension_1d: 8192,
                     max_texture_dimension_2d: 8192,
-                    ..wgpu::Limits::downlevel_webgl2_defaults()
+                    ..base_limits
                 },
             },
             None,


### PR DESCRIPTION
## Problem

I want to be able to write and use compute shaders in ggez projects, as long as the configured backend allows their usage. Currently this is impossible, because the device limits are always set to `downlevel_webgl2_defaults` which disallows compute shaders.

## Solution

This PR dynamically changes these device limits based on the configured backends. It does this in a way, that is consistent across all possible backends according to configuration. (`Backend:All` disallows compute shaders because it **may** target WebGL2, `Backend::OnlyPrimary` on the other hand always enables them).


