### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,14 +92,15 @@ General examples:
 
 ## Changed
 
-`EventHandler` now takes another generic in form of whatever context implementation you are using whether that be the default one of a custom one
-`Drawable::dimensions` now returns a `Rect` instead of an `Option<Rect>`
+- `EventHandler` now takes another generic in form of whatever context implementation you are using whether that be the default one of a custom one
+- `Drawable::dimensions` now returns a `Rect` instead of an `Option<Rect>`
+- Dependencies updates (including public ones)
 
 ## Removed
 
 ## Fixed
-`Image::to_pixels` no longer crashes and works properly
-`Image` can now be loaded from jpg/jpeg files 
+- `Image::to_pixels` no longer crashes and works properly
+- `Image` can now be loaded from jpg/jpeg files 
 
 # 0.9.3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ toml = "0.5"
 log = "0.4"
 lyon = "1.0"
 smart-default = "0.7"
-glam = { version = "0.24", features = ["mint"] }
+glam = { version = "0.25", features = ["mint"] }
 # Has to be the same version of mint that our math lib uses here.
 mint = "0.5.9"
 gilrs = { version = "0.10", optional = true }
@@ -52,9 +52,9 @@ approx = "0.5"
 bytemuck = { version = "1.12", features = ["derive"] }
 pollster = "0.3"
 memoffset = "0.9"
-crevice = "0.13"
+crevice = "0.14"
 typed-arena = "2.0"
-ordered-float = "3.3"
+ordered-float = "4.2"
 percent-encoding = { version = "2.3.0", optional = true }
 base64 = { version = "0.21.2", optional = true }
 gltf = { version = "1.2.0", optional = true, default-features = false, features = ["utils"] }
@@ -69,7 +69,7 @@ argh = "0.1"
 rand = "0.8"
 keyframe = "1"
 keyframe_derive = "1"
-num-derive = "0.3"
+num-derive = "0.4"
 
 skeptic = "0.13"
 getrandom = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ obj = ["obj-rs", "3d"]
 bitflags = "2.1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 directories = "5.0"
-wgpu = "0.17"
+wgpu = "0.18"
 glyph_brush = "0.7"
 winit = { version = "0.28.3", features = ["serde"] }
 image = { version = "0.24", default-features = false, features = ["gif", "png", "pnm", "tga", "tiff", "webp", "bmp", "dxt", "jpeg"] }

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -297,17 +297,19 @@ impl event::EventHandler for MainState {
                             graphics::LinearColor::from(graphics::Color::new(0.1, 0.1, 0.1, 1.0))
                                 .into(),
                         ),
-                        store: true,
+                        store: wgpu::StoreOp::Store,
                     },
                 })],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
                     view: depth.wgpu().1,
                     depth_ops: Some(wgpu::Operations {
                         load: wgpu::LoadOp::Clear(0.),
-                        store: false,
+                        store: wgpu::StoreOp::Discard,
                     }),
                     stencil_ops: None,
                 }),
+                occlusion_query_set: None,
+                timestamp_writes: None,
             });
 
             pass.set_pipeline(&self.pipeline);

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -115,7 +115,7 @@ impl GraphicsContext {
         let new_instance = |backends| {
             wgpu::Instance::new(wgpu::InstanceDescriptor {
                 backends,
-                dx12_shader_compiler: Default::default(),
+                ..Default::default()
             })
         };
 
@@ -743,10 +743,12 @@ impl GraphicsContext {
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
-                        store: true,
+                        store: wgpu::StoreOp::Store,
                     },
                 })],
                 depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
             });
 
             let sampler = &mut self

--- a/src/graphics/internal_canvas.rs
+++ b/src/graphics/internal_canvas.rs
@@ -77,10 +77,12 @@ impl<'a> InternalCanvas<'a> {
                             None => wgpu::LoadOp::Load,
                             Some(color) => wgpu::LoadOp::Clear(LinearColor::from(color).into()),
                         },
-                        store: true,
+                        store: wgpu::StoreOp::Store,
                     },
                 })],
                 depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
             })
         })
     }
@@ -120,10 +122,12 @@ impl<'a> InternalCanvas<'a> {
                             None => wgpu::LoadOp::Load,
                             Some(color) => wgpu::LoadOp::Clear(LinearColor::from(color).into()),
                         },
-                        store: true,
+                        store: wgpu::StoreOp::Store,
                     },
                 })],
                 depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
             })
         })
     }

--- a/src/graphics/internal_canvas3d.rs
+++ b/src/graphics/internal_canvas3d.rs
@@ -72,17 +72,19 @@ impl<'a> InternalCanvas3d<'a> {
                             None => wgpu::LoadOp::Load,
                             Some(color) => wgpu::LoadOp::Clear(LinearColor::from(color).into()),
                         },
-                        store: true,
+                        store: wgpu::StoreOp::Store,
                     },
                 })],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
                     view: depth.wgpu().1,
                     depth_ops: Some(wgpu::Operations {
                         load: wgpu::LoadOp::Clear(1.0),
-                        store: true,
+                        store: wgpu::StoreOp::Store,
                     }),
                     stencil_ops: None,
                 }),
+                occlusion_query_set: None,
+                timestamp_writes: None,
             })
         })
     }
@@ -123,17 +125,19 @@ impl<'a> InternalCanvas3d<'a> {
                             None => wgpu::LoadOp::Load,
                             Some(color) => wgpu::LoadOp::Clear(LinearColor::from(color).into()),
                         },
-                        store: true,
+                        store: wgpu::StoreOp::Store,
                     },
                 })],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
                     view: depth.wgpu().1,
                     depth_ops: Some(wgpu::Operations {
                         load: wgpu::LoadOp::Clear(1.0),
-                        store: true,
+                        store: wgpu::StoreOp::Store,
                     }),
                     stencil_ops: None,
                 }),
+                occlusion_query_set: None,
+                timestamp_writes: None,
             })
         })
     }


### PR DESCRIPTION
Update dependencies, including `wgpu`.

Winit update requires far more work due to a rework of the keyboard API which will probably require changing our own API too. I started something in https://github.com/a1phyr/ggez/tree/winit_update but this does not even compile yet.