### PR TITLE
Update docs with new crevice version

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -214,7 +214,7 @@ If you want to create your own structs to send as uniforms to your shaders, simi
 then those structs need to implement `AsStd140`, which can luckily be easily derived using crevice.
 
 So far, so good. But now I have to tell you that you also need to **depend on the version of crevice that we are using
-yourself, directly**, which at the time of writing (ggez 0.8.1) is `0.11` currently. So add `crevice = "0.11"` to your Cargo.toml .
+yourself, directly**, which at the time of writing (ggez 0.9.3) is `0.14` currently. So add `crevice = "0.14"` to your Cargo.toml .
 
 There may or may not be ways around this via writing our own wrapper macro using `Span::mixed_site` and re-exporting `crevice`,
 but we lowly mortals haven't yet found a way to actually do this. If you manage to solve this problem, please let us know! :)

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -4,6 +4,7 @@
 //! the underlying `gfx-rs` data types, so you can bypass ggez's
 //! drawing code entirely and write your own.
 
+// You must depend on the same version of `crevice` that ggez uses
 use crevice::std140::AsStd140;
 use ggez::event;
 use ggez::glam::*;

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -1,5 +1,6 @@
 //! A very simple shader example.
 
+// You must depend on the same version of `crevice` that ggez uses
 use crevice::std140::AsStd140;
 use ggez::event;
 use ggez::glam::Vec2;

--- a/examples/shadows.rs
+++ b/examples/shadows.rs
@@ -1,6 +1,7 @@
 //! A more sophisticated example of how to use shaders
 //! and canvas's to do 2D GPU shadows.
 
+// You must depend on the same version of `crevice` that ggez uses
 use crevice::std140::AsStd140;
 use ggez::glam::Vec2;
 use ggez::graphics::{

--- a/examples/vertex_shader.rs
+++ b/examples/vertex_shader.rs
@@ -1,5 +1,6 @@
 //! An example demonstrating vertex shaders.
 
+// You must depend on the same version of `crevice` that ggez uses
 use crevice::std140::AsStd140;
 use ggez::event;
 use ggez::glam::*;


### PR DESCRIPTION
Related #1084

@nobbele I've been getting back into rust/ggez dev and looking through a few issues for low hanging fruit.

I could be mistaken, but don't think this is possible to solve without significant changes to `crevice`, since they hard code crate references in the proc macros.

This PR just updates the docs with the latest `crevice` version and adds a few notes in the examples. The issue can probably be closed.