### PR TITLE
Removed FAQ reference to no-longer-existing function

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -48,9 +48,8 @@ filesystem lookup path by pulling it from the environment variable, see
 the examples for how.  Sorry, there's no especially good way of doing it
 automatically; we've tried.
 
-If that doesn't help, call `Context::print_resource_stats()`.  That
-should print out all the files it can find, and where it is finding
-them.
+If that doesn't help, call `Filesystem::print_all()`.  That should print
+print out all the files it can find, and where it is finding them.
 
 If you want to add a non-standard location to the resources lookup
 path, you can use `Filesystem::mount()` or

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -48,7 +48,7 @@ filesystem lookup path by pulling it from the environment variable, see
 the examples for how.  Sorry, there's no especially good way of doing it
 automatically; we've tried.
 
-If that doesn't help, call `Filesystem::print_all()`.  That should print
+If that doesn't help, call `Filesystem::print_all()`.  That should
 print out all the files it can find, and where it is finding them.
 
 If you want to add a non-standard location to the resources lookup


### PR DESCRIPTION
The FAQ references `Context::print_resource_stats`, which no longer exists; it was superceded by `Filesystem::print_all` and `Filesystem::log_all` in commit 3e07581.

I am very out of practice with GitHub and accidentally only cloned the `master` branch, but it looks like the pull request still works when applied to the `devel` branch because I'm only changing one file which hasn't been changed between the two. I hope that's okay.