### PR TITLE
Remove `Drawable::dimensions()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,10 +93,11 @@ General examples:
 ## Changed
 
 - `EventHandler` now takes another generic in form of whatever context implementation you are using whether that be the default one of a custom one
-- `Drawable::dimensions` now returns a `Rect` instead of an `Option<Rect>`
 - Dependencies updates (including public ones)
+- `InstanceArray::dimensions_meshed` has been renamed to `bounding_box` and no longer requires a context as parameter
 
 ## Removed
+- `Drawable::dimensions`, as its usage wasn't clear enough and it was not used internally either. For meshes, use `Mesh::bounding_box()` instead, and for texts use `Text::measure()`.
 
 ## Fixed
 - `Image::to_pixels` no longer crashes and works properly

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,12 +1,9 @@
 //! This example demonstrates how to use `Text` to draw TrueType font texts efficiently.
 
+use ggez::conf::{WindowMode, WindowSetup};
 use ggez::glam::Vec2;
 use ggez::graphics::{self, Color, PxScale, Text, TextAlign, TextFragment};
 use ggez::timer;
-use ggez::{
-    conf::{WindowMode, WindowSetup},
-    graphics::Drawable,
-};
 use ggez::{event, graphics::TextLayout};
 use ggez::{Context, ContextBuilder, GameResult};
 use std::collections::BTreeMap;
@@ -157,7 +154,7 @@ impl event::EventHandler for App {
             };
             canvas.draw(text, Vec2::new(x, 20.0 + height));
             //height += 20.0 + text.height(ctx) as f32;
-            height += 20.0 + text.dimensions(ctx).h
+            height += 20.0 + text.measure(ctx)?.y
         }
 
         // Individual fragments within the `Text` can be replaced;
@@ -176,7 +173,7 @@ impl event::EventHandler for App {
                 TextFragment::new(ch).scale(PxScale::from(10.0 + 6.0 * self.rng.rand_float())),
             );
         }
-        let wobble_rect = wobble.dimensions(ctx);
+        let wobble_bounds = wobble.measure(ctx)?;
         canvas.draw(
             &wobble,
             graphics::DrawParam::new()
@@ -186,7 +183,7 @@ impl event::EventHandler for App {
         );
         let t = Text::new(format!(
             "width: {}\nheight: {}",
-            wobble_rect.w, wobble_rect.h
+            wobble_bounds.x, wobble_bounds.y
         ));
         canvas.draw(&t, graphics::DrawParam::from([500.0, 320.0]).rotation(-0.5));
 

--- a/src/graphics/draw.rs
+++ b/src/graphics/draw.rs
@@ -312,12 +312,6 @@ where
 pub trait Drawable {
     /// Draws the drawable onto the canvas.
     fn draw(&self, canvas: &mut Canvas, param: impl Into<DrawParam>);
-
-    /// Returns a bounding box in the form of a `Rect`.
-    ///
-    /// It returns `Option` because some `Drawable`s may have no bounding box,
-    /// namely `InstanceArray` (as there is no true bounds for the instances given the instanced mesh can differ).
-    fn dimensions(&self, gfx: &impl Has<GraphicsContext>) -> Rect;
 }
 
 #[derive(Debug, Copy, Clone, crevice::std140::AsStd140)]

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -423,15 +423,6 @@ impl Drawable for Image {
             param.into(),
         );
     }
-
-    fn dimensions(&self, _gfx: &impl Has<GraphicsContext>) -> Rect {
-        Rect {
-            x: 0.,
-            y: 0.,
-            w: self.width() as _,
-            h: self.height() as _,
-        }
-    }
 }
 
 /// An image which is sized relative to the screen.

--- a/src/graphics/instance.rs
+++ b/src/graphics/instance.rs
@@ -291,15 +291,12 @@ impl InstanceArray {
         self.sort_by = sort_by;
     }
 
-    /// This is equivalent to `<InstanceArray as Drawable>::dimensions()` (see [`Drawable::dimensions()`]), but with a mesh taken into account.
-    ///
-    /// Essentially, consider `<InstanceArray as Drawable>::dimensions()` to be the bounds when the [`InstanceArray`] is drawn with `canvas.draw()`,
-    /// and consider [`InstanceArray::dimensions_meshed()`] to be the bounds when the [`InstanceArray`] is drawn with `canvas.draw_instanced_mesh()`.
-    pub fn dimensions_meshed(&self, gfx: &impl Has<GraphicsContext>, mesh: &Mesh) -> Rect {
+    /// Calculates the bounding box of the set of instances already pushed into the array, using the mesh given as reference.
+    pub fn bounding_box(&self, mesh: &Mesh) -> Rect {
         if self.params.is_empty() {
             return Rect::new(0.0, 0.0, 1.0, 1.0);
         }
-        let dimensions = mesh.dimensions(gfx);
+        let dimensions = mesh.bounds;
         self.params
             .iter()
             .map(|&param| transform_rect(dimensions, param))
@@ -323,17 +320,5 @@ impl Drawable for InstanceArray {
             },
             param.into(),
         );
-    }
-
-    fn dimensions(&self, gfx: &impl Has<GraphicsContext>) -> Rect {
-        let gfx = gfx.retrieve();
-        if self.params.is_empty() {
-            return Rect::new(0.0, 0.0, 1.0, 1.0);
-        }
-        let dimensions = self.image.dimensions(gfx);
-        self.params
-            .iter()
-            .map(|&param| transform_rect(dimensions, param))
-            .fold(Rect::zero(), |acc: Rect, rect| acc.combine_with(rect))
     }
 }

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -246,6 +246,11 @@ impl Mesh {
                 }),
         )
     }
+
+    /// Returns the bounding box of the vertices of this mesh.
+    pub fn bounding_box(&self) -> Rect {
+        self.bounds
+    }
 }
 
 impl Drawable for Mesh {
@@ -258,10 +263,6 @@ impl Drawable for Mesh {
             },
             param.into(),
         );
-    }
-
-    fn dimensions(&self, _gfx: &impl Has<GraphicsContext>) -> Rect {
-        self.bounds
     }
 }
 
@@ -282,10 +283,6 @@ pub struct Quad;
 impl Drawable for Quad {
     fn draw(&self, canvas: &mut Canvas, param: impl Into<DrawParam>) {
         canvas.default_resources().mesh.clone().draw(canvas, param);
-    }
-
-    fn dimensions(&self, _gfx: &impl Has<GraphicsContext>) -> Rect {
-        Rect::one()
     }
 }
 

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -287,16 +287,6 @@ impl Drawable for Text {
     fn draw(&self, canvas: &mut Canvas, param: impl Into<DrawParam>) {
         canvas.push_draw(Draw::BoundedText { text: self.clone() }, param.into());
     }
-
-    fn dimensions(&self, gfx: &impl Has<GraphicsContext>) -> Rect {
-        let bounds = self.measure(gfx).unwrap_or(glam::Vec2::splat(1.0).into());
-        Rect {
-            x: 0.,
-            y: 0.,
-            w: bounds.x,
-            h: bounds.y,
-        }
-    }
 }
 
 /// Describes text alignment along a single axis.


### PR DESCRIPTION
Removes `Drawable::dimensions()`.

As an user, I have never really understood the need for it. The documentation on it wasn't clear enough to be 100% sure what it was returning (No units are specified, so asking just for "dimensions" never truly clicked with me), so I never used it. Thankfully it wasn't very annoying since its return value was completely optional.

However, [this `devel` commit](https://github.com/ggez/ggez/commit/3bb2eb8be3dc854576faae8d14c61b8a0a872f78) changed this fact, forcing the user to having to return a dimension value, even if the docs (which remained unaffected by the change) weren't very clear on what it truly was. What perplexed me most were that the cases that previously couldn't calculate this dimensions value and returned `None` now suddenly returned an unit rect, which seemed really unintuitive.

 After thinking about it for a while and searching for references for this function along the repo, I found out that the `dimensions` function is not actually used anywhere outside of `InstanceArray` (for another function returning dimensions) and the text example, which used `dimensions` instead of the more fitting `Text::measure()`.
 
Seeing how this function isn't used internally and now seems to be more of a burden for users, I propose with this PR to remove it. In fact, if I had noticed these flaws earlier, I probably would've removed it earlier in the [massive refactor I did along with jazzfool a while back for 0.8.0.](https://github.com/ggez/ggez/pull/1020)

Places where `dimensions` did make _some_ sense, like in `Mesh`, have been replaced by a function called `bounding_box` which just returns the min & max positions of the vertices forming it as a Rect. Previous `dimensions` implementations can just be done from user code, so if an user needed to calculate bounding boxes in their own coordinate system, they could do so easily with the available public library functions.