### PR TITLE
Update wgpu to 22.1.0, winit to 0.29

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2019, ubuntu-20.04, macos-11]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         toolchain: [stable, beta]
     runs-on: ${{ matrix.os }}
     steps:
@@ -51,7 +51,7 @@ jobs:
       run: cargo test -p doc_tests
 
   rustfmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
     - name: Checkout
@@ -66,7 +66,7 @@ jobs:
       run: cargo fmt --all -- --check
 
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
     - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ obj = ["obj-rs", "3d"]
 bitflags = "2.1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 directories = "5.0"
-wgpu = "0.18"
+wgpu = "22.1.0"
 glyph_brush = "0.7"
-winit = { version = "0.28.3", features = ["serde"] }
+winit = { version = "0.29", features = ["serde"] }
 image = { version = "0.25", default-features = false, features = ["gif", "png", "pnm", "tga", "tiff", "webp", "bmp", "jpeg"] }
 rodio = { version = "0.17", optional = true, default-features = false, features = ["flac", "vorbis", "wav"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -19,7 +19,12 @@ use oorandom::Rand32;
 
 // Next we need to actually `use` the pieces of ggez that we are going
 // to need frequently.
-use ggez::{context::{ContextFields, HasMut}, event, graphics, input::keyboard::KeyInput, Context, GameResult};
+use ggez::{
+    context::{ContextFields, HasMut},
+    event, graphics,
+    input::keyboard::KeyInput,
+    Context, GameResult,
+};
 use winit::keyboard::{Key, NamedKey};
 
 // We'll bring in some things from `std` to help us in the future.

--- a/examples/04_snake.rs
+++ b/examples/04_snake.rs
@@ -19,11 +19,8 @@ use oorandom::Rand32;
 
 // Next we need to actually `use` the pieces of ggez that we are going
 // to need frequently.
-use ggez::{
-    event, graphics,
-    input::keyboard::{KeyCode, KeyInput},
-    Context, GameResult,
-};
+use ggez::{context::{ContextFields, HasMut}, event, graphics, input::keyboard::KeyInput, Context, GameResult};
+use winit::keyboard::{Key, NamedKey};
 
 // We'll bring in some things from `std` to help us in the future.
 use std::collections::VecDeque;
@@ -143,12 +140,12 @@ impl Direction {
     /// `ggez` `Keycode` and the `Direction` that it represents. Of course,
     /// not every keycode represents a direction, so we return `None` if this
     /// is the case.
-    pub fn from_keycode(key: KeyCode) -> Option<Direction> {
+    pub fn from_key(key: &Key) -> Option<Direction> {
         match key {
-            KeyCode::Up => Some(Direction::Up),
-            KeyCode::Down => Some(Direction::Down),
-            KeyCode::Left => Some(Direction::Left),
-            KeyCode::Right => Some(Direction::Right),
+            Key::Named(NamedKey::ArrowUp) => Some(Direction::Up),
+            Key::Named(NamedKey::ArrowDown) => Some(Direction::Down),
+            Key::Named(NamedKey::ArrowLeft) => Some(Direction::Left),
+            Key::Named(NamedKey::ArrowRight) => Some(Direction::Right),
             _ => None,
         }
     }
@@ -436,10 +433,10 @@ impl event::EventHandler for GameState {
     }
 
     /// `key_down_event` gets fired when a key gets pressed.
-    fn key_down_event(&mut self, _ctx: &mut Context, input: KeyInput, _repeat: bool) -> GameResult {
+    fn key_down_event(&mut self, ctx: &mut Context, input: KeyInput, _repeat: bool) -> GameResult {
         // Here we attempt to convert the Keycode into a Direction using the helper
         // we defined earlier.
-        if let Some(dir) = input.keycode.and_then(Direction::from_keycode) {
+        if let Some(dir) = Direction::from_key(&input.event.logical_key) {
             // If it succeeds, we check if a new direction has already been set
             // and make sure the new direction is different then `snake.dir`
             if self.snake.dir != self.snake.last_update_dir && dir.inverse() != self.snake.dir {
@@ -450,6 +447,8 @@ impl event::EventHandler for GameState {
                 // direction the user pressed.
                 self.snake.dir = dir;
             }
+        } else if input.event.logical_key == Key::Named(NamedKey::Escape) {
+            HasMut::<ContextFields>::retrieve_mut(ctx).quit_requested = true;
         }
         Ok(())
     }

--- a/examples/05_astroblasto.rs
+++ b/examples/05_astroblasto.rs
@@ -8,7 +8,6 @@ use ggez::conf;
 use ggez::event::{self, EventHandler};
 use ggez::glam::*;
 use ggez::graphics::{self, Color};
-use ggez::input::keyboard::KeyCode;
 use ggez::timer;
 use ggez::{Context, ContextBuilder, GameResult};
 use oorandom::Rand32;
@@ -16,6 +15,7 @@ use oorandom::Rand32;
 use ggez::input::keyboard::KeyInput;
 use std::env;
 use std::path;
+use winit::keyboard::{Key, NamedKey};
 
 type Point2 = Vec2;
 type Vector2 = Vec2;
@@ -555,41 +555,43 @@ impl EventHandler for MainState {
         input: KeyInput,
         _repeated: bool,
     ) -> GameResult {
-        match input.keycode {
-            Some(KeyCode::Up) => {
+        match input.event.logical_key {
+            Key::Named(NamedKey::ArrowUp) => {
                 self.input.yaxis = 1.0;
             }
-            Some(KeyCode::Left) => {
+            Key::Named(NamedKey::ArrowLeft) => {
                 self.input.xaxis = -1.0;
             }
-            Some(KeyCode::Right) => {
+            Key::Named(NamedKey::ArrowRight) => {
                 self.input.xaxis = 1.0;
             }
-            Some(KeyCode::Space) => {
+            Key::Named(NamedKey::Space) => {
                 self.input.fire = true;
             }
-            Some(KeyCode::P) => {
-                self.screen.image(ctx).encode(
-                    ctx,
-                    graphics::ImageEncodingFormat::Png,
-                    "/screenshot.png",
-                )?;
+            Key::Character(c) => {
+                if c == "p" {
+                    self.screen.image(ctx).encode(
+                        ctx,
+                        graphics::ImageEncodingFormat::Png,
+                        "/screenshot.png",
+                    )?;
+                }
             }
-            Some(KeyCode::Escape) => ctx.request_quit(),
+            Key::Named(NamedKey::Escape) => ctx.request_quit(),
             _ => (), // Do nothing
         }
         Ok(())
     }
 
     fn key_up_event(&mut self, _ctx: &mut Context, input: KeyInput) -> GameResult {
-        match input.keycode {
-            Some(KeyCode::Up) => {
+        match input.event.logical_key {
+            Key::Named(NamedKey::ArrowUp) => {
                 self.input.yaxis = 0.0;
             }
-            Some(KeyCode::Left | KeyCode::Right) => {
+            Key::Named(NamedKey::ArrowLeft | NamedKey::ArrowRight) => {
                 self.input.xaxis = 0.0;
             }
-            Some(KeyCode::Space) => {
+            Key::Named(NamedKey::Space) => {
                 self.input.fire = false;
             }
             _ => (), // Do nothing

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -1,5 +1,6 @@
 use ggez::graphics::{Camera3d, Canvas3d, DrawParam3d, Mesh3d, Mesh3dBuilder, Vertex3d};
 use std::{env, path};
+use winit::keyboard::{Key, NamedKey, PhysicalKey};
 
 use ggez::graphics::Shader;
 use ggez::input::keyboard::KeyCode;
@@ -101,40 +102,40 @@ impl event::EventHandler for MainState {
         let forward = Vec3::new(yaw_cos, 0.0, yaw_sin).normalize();
         let right = Vec3::new(-yaw_sin, 0.0, yaw_cos).normalize();
 
-        if k_ctx.is_key_pressed(KeyCode::Q) {
+        if k_ctx.is_logical_key_pressed(&Key::Character("q".into())) {
             self.meshes[1].1 += 0.1;
         }
-        if k_ctx.is_key_pressed(KeyCode::E) {
+        if k_ctx.is_logical_key_pressed(&Key::Character("e".into())) {
             self.meshes[1].1 -= 0.1;
         }
-        if k_ctx.is_key_pressed(KeyCode::Space) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::Space)) {
             self.camera.transform.position.y += 1.0;
         }
-        if k_ctx.is_key_pressed(KeyCode::C) {
+        if k_ctx.is_logical_key_pressed(&Key::Character("c".into())) {
             self.camera.transform.position.y -= 1.0;
         }
-        if k_ctx.is_key_pressed(KeyCode::W) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyW)) {
             self.camera.transform = self.camera.transform.translate(forward);
         }
-        if k_ctx.is_key_pressed(KeyCode::S) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyS)) {
             self.camera.transform = self.camera.transform.translate(-forward);
         }
-        if k_ctx.is_key_pressed(KeyCode::D) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyD)) {
             self.camera.transform = self.camera.transform.translate(right);
         }
-        if k_ctx.is_key_pressed(KeyCode::A) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyA)) {
             self.camera.transform = self.camera.transform.translate(-right);
         }
-        if k_ctx.is_key_pressed(KeyCode::Right) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowRight)) {
             self.camera.transform.yaw += 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Left) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowLeft)) {
             self.camera.transform.yaw -= 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Up) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowUp)) {
             self.camera.transform.pitch += 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Down) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowDown)) {
             self.camera.transform.pitch -= 1.0_f32.to_radians();
         }
         Ok(())

--- a/examples/3dinstance.rs
+++ b/examples/3dinstance.rs
@@ -1,6 +1,7 @@
 use ggez::graphics::{Camera3d, Canvas3d, InstanceArray3d, Mesh3dBuilder};
 use std::f32::consts::TAU;
 use std::{env, path};
+use winit::keyboard::{Key, NamedKey, PhysicalKey};
 
 use ggez::input::keyboard::KeyCode;
 use ggez::{
@@ -39,34 +40,34 @@ impl event::EventHandler for MainState {
         let forward = Vec3::new(yaw_cos, 0.0, yaw_sin).normalize();
         let right = Vec3::new(-yaw_sin, 0.0, yaw_cos).normalize();
 
-        if k_ctx.is_key_pressed(KeyCode::Space) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::Space)) {
             self.camera.transform.position.y += 1.0;
         }
-        if k_ctx.is_key_pressed(KeyCode::C) {
+        if k_ctx.is_logical_key_pressed(&Key::Character("c".into())) {
             self.camera.transform.position.y -= 1.0;
         }
-        if k_ctx.is_key_pressed(KeyCode::W) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyW)) {
             self.camera.transform = self.camera.transform.translate(forward);
         }
-        if k_ctx.is_key_pressed(KeyCode::S) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyS)) {
             self.camera.transform = self.camera.transform.translate(-forward);
         }
-        if k_ctx.is_key_pressed(KeyCode::D) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyD)) {
             self.camera.transform = self.camera.transform.translate(right);
         }
-        if k_ctx.is_key_pressed(KeyCode::A) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyA)) {
             self.camera.transform = self.camera.transform.translate(-right);
         }
-        if k_ctx.is_key_pressed(KeyCode::Right) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowRight)) {
             self.camera.transform.yaw += 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Left) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowLeft)) {
             self.camera.transform.yaw -= 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Up) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowUp)) {
             self.camera.transform.pitch += 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Down) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowDown)) {
             self.camera.transform.pitch -= 1.0_f32.to_radians();
         }
         Ok(())

--- a/examples/3dshapes.rs
+++ b/examples/3dshapes.rs
@@ -1,5 +1,6 @@
 use ggez::graphics::{Camera3d, Canvas3d, DrawParam3d, Drawable3d, Mesh3d, Mesh3dBuilder};
 use std::{env, path};
+use winit::keyboard::{Key, NamedKey, PhysicalKey};
 
 use ggez::input::keyboard::KeyCode;
 use ggez::{
@@ -74,34 +75,34 @@ impl event::EventHandler for MainState {
         let forward = Vec3::new(yaw_cos, 0.0, yaw_sin).normalize();
         let right = Vec3::new(-yaw_sin, 0.0, yaw_cos).normalize();
 
-        if k_ctx.is_key_pressed(KeyCode::Space) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::Space)) {
             self.camera.transform.position.y += 1.0;
         }
-        if k_ctx.is_key_pressed(KeyCode::C) {
+        if k_ctx.is_logical_key_pressed(&Key::Character("c".into())) {
             self.camera.transform.position.y -= 1.0;
         }
-        if k_ctx.is_key_pressed(KeyCode::W) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyW)) {
             self.camera.transform = self.camera.transform.translate(forward);
         }
-        if k_ctx.is_key_pressed(KeyCode::S) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyS)) {
             self.camera.transform = self.camera.transform.translate(-forward);
         }
-        if k_ctx.is_key_pressed(KeyCode::D) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyD)) {
             self.camera.transform = self.camera.transform.translate(right);
         }
-        if k_ctx.is_key_pressed(KeyCode::A) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyA)) {
             self.camera.transform = self.camera.transform.translate(-right);
         }
-        if k_ctx.is_key_pressed(KeyCode::Right) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowRight)) {
             self.camera.transform.yaw += 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Left) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowLeft)) {
             self.camera.transform.yaw -= 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Up) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowUp)) {
             self.camera.transform.pitch += 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Down) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowDown)) {
             self.camera.transform.pitch -= 1.0_f32.to_radians();
         }
         Ok(())

--- a/examples/3dtexture.rs
+++ b/examples/3dtexture.rs
@@ -9,6 +9,7 @@ use ggez::{
     graphics::{self, Color},
     Context, GameResult,
 };
+use winit::keyboard::{Key, NamedKey, PhysicalKey};
 
 struct MainState {
     camera: Camera3d,
@@ -61,34 +62,34 @@ impl event::EventHandler for MainState {
         self.cube_one.1 *= Quat::from_rotation_y(50.0_f32.to_radians() * dt);
         self.cube_two.1 *= Quat::from_rotation_y(-50.0_f32.to_radians() * dt);
 
-        if k_ctx.is_key_pressed(KeyCode::Space) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::Space)) {
             self.camera.transform.position.y += 1.0;
         }
-        if k_ctx.is_key_pressed(KeyCode::C) {
+        if k_ctx.is_logical_key_pressed(&Key::Character("c".into())) {
             self.camera.transform.position.y -= 1.0;
         }
-        if k_ctx.is_key_pressed(KeyCode::W) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyW)) {
             self.camera.transform = self.camera.transform.translate(forward);
         }
-        if k_ctx.is_key_pressed(KeyCode::S) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyS)) {
             self.camera.transform = self.camera.transform.translate(-forward);
         }
-        if k_ctx.is_key_pressed(KeyCode::D) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyD)) {
             self.camera.transform = self.camera.transform.translate(right);
         }
-        if k_ctx.is_key_pressed(KeyCode::A) {
+        if k_ctx.is_physical_key_pressed(&PhysicalKey::Code(KeyCode::KeyA)) {
             self.camera.transform = self.camera.transform.translate(-right);
         }
-        if k_ctx.is_key_pressed(KeyCode::Right) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowRight)) {
             self.camera.transform.yaw += 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Left) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowLeft)) {
             self.camera.transform.yaw -= 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Up) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowUp)) {
             self.camera.transform.pitch += 1.0_f32.to_radians();
         }
-        if k_ctx.is_key_pressed(KeyCode::Down) {
+        if k_ctx.is_logical_key_pressed(&Key::Named(NamedKey::ArrowDown)) {
             self.camera.transform.pitch -= 1.0_f32.to_radians();
         }
         Ok(())

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -16,6 +16,9 @@ use keyframe_derive::CanTween;
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::env;
 use std::path;
+use winit::keyboard::Key;
+use winit::keyboard::NamedKey;
+use winit::keyboard::PhysicalKey;
 
 struct MainState {
     ball: graphics::Mesh,
@@ -310,44 +313,55 @@ impl event::EventHandler for MainState {
 
     fn key_down_event(&mut self, _ctx: &mut Context, input: KeyInput, _repeat: bool) -> GameResult {
         const DELTA: f32 = 0.2;
-        match input.keycode {
-            Some(KeyCode::Up | KeyCode::Down) => {
-                // easing change
-                let new_easing_enum = new_enum_after_key(
-                    &self.easing_enum,
-                    &EasingEnum::EaseInOut3Point,
-                    KeyCode::Down,
-                    KeyCode::Up,
-                    input.keycode.unwrap(),
-                );
+        match input.event.logical_key {
+            Key::Named(nk) => {
+                match nk {
+                    NamedKey::ArrowUp | NamedKey::ArrowDown => {
+                        // easing change
+                        let new_easing_enum = new_enum_after_key(
+                            &self.easing_enum,
+                            &EasingEnum::EaseInOut3Point,
+                            NamedKey::ArrowDown,
+                            NamedKey::ArrowUp,
+                            &input.event.logical_key,
+                        );
 
-                if self.easing_enum != new_easing_enum {
-                    self.easing_enum = new_easing_enum;
+                        if self.easing_enum != new_easing_enum {
+                            self.easing_enum = new_easing_enum;
+                        }
+                    }
+                    NamedKey::ArrowLeft | NamedKey::ArrowRight => {
+                        // animation change
+                        let new_animation_type = new_enum_after_key(
+                            &self.animation_type,
+                            &AnimationType::Crawl,
+                            NamedKey::ArrowLeft,
+                            NamedKey::ArrowRight,
+                            &input.event.logical_key,
+                        );
+
+                        if self.animation_type != new_animation_type {
+                            self.animation_type = new_animation_type;
+                        }
+                    }
+                    _ => {}
                 }
             }
-            Some(KeyCode::Left | KeyCode::Right) => {
-                // animation change
-                let new_animation_type = new_enum_after_key(
-                    &self.animation_type,
-                    &AnimationType::Crawl,
-                    KeyCode::Left,
-                    KeyCode::Right,
-                    input.keycode.unwrap(),
-                );
-
-                if self.animation_type != new_animation_type {
-                    self.animation_type = new_animation_type;
-                }
-            }
+            _ => {}
+        }
+        match input.event.physical_key {
             // duration change
-            Some(KeyCode::W) => {
-                self.duration += DELTA;
-            }
-            Some(KeyCode::S) => {
-                if self.duration - DELTA > 0.1 {
-                    self.duration -= DELTA;
+            PhysicalKey::Code(kc) => match kc {
+                KeyCode::KeyW => {
+                    self.duration += DELTA;
                 }
-            }
+                KeyCode::KeyS => {
+                    if self.duration - DELTA > 0.1 {
+                        self.duration -= DELTA;
+                    }
+                }
+                _ => {}
+            },
             _ => {}
         }
 
@@ -361,14 +375,14 @@ impl event::EventHandler for MainState {
 fn new_enum_after_key<E: ToPrimitive + FromPrimitive>(
     old_enum: &E,
     max_enum: &E,
-    dec_key: KeyCode,
-    inc_key: KeyCode,
-    key: KeyCode,
+    dec_key: NamedKey,
+    inc_key: NamedKey,
+    key: &Key,
 ) -> E {
     let mut new_val = ToPrimitive::to_i32(old_enum).unwrap();
     new_val += match key {
-        _ if key == dec_key => -1,
-        _ if key == inc_key => 1,
+        _ if *key == dec_key => -1,
+        _ if *key == inc_key => 1,
         _ => 0,
     };
 

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -8,7 +8,7 @@ extern crate num_derive;
 use ggez::event;
 use ggez::glam::*;
 use ggez::graphics::{self, Color};
-use ggez::input::keyboard::{KeyCode, KeyInput};
+use ggez::input::keyboard::KeyInput;
 use ggez::mint::Point2;
 use ggez::{Context, GameResult};
 use keyframe::{ease, functions::*, keyframes, AnimationSequence, EasingFunction};
@@ -18,7 +18,6 @@ use std::env;
 use std::path;
 use winit::keyboard::Key;
 use winit::keyboard::NamedKey;
-use winit::keyboard::PhysicalKey;
 
 struct MainState {
     ball: graphics::Mesh,
@@ -314,48 +313,38 @@ impl event::EventHandler for MainState {
     fn key_down_event(&mut self, _ctx: &mut Context, input: KeyInput, _repeat: bool) -> GameResult {
         const DELTA: f32 = 0.2;
         match input.event.logical_key {
-            Key::Named(nk) => {
-                match nk {
-                    NamedKey::ArrowUp | NamedKey::ArrowDown => {
-                        // easing change
-                        let new_easing_enum = new_enum_after_key(
-                            &self.easing_enum,
-                            &EasingEnum::EaseInOut3Point,
-                            NamedKey::ArrowDown,
-                            NamedKey::ArrowUp,
-                            &input.event.logical_key,
-                        );
+            Key::Named(NamedKey::ArrowUp | NamedKey::ArrowDown) => {
+                // easing change
+                let new_easing_enum = new_enum_after_key(
+                    &self.easing_enum,
+                    &EasingEnum::EaseInOut3Point,
+                    NamedKey::ArrowDown,
+                    NamedKey::ArrowUp,
+                    &input.event.logical_key,
+                );
 
-                        if self.easing_enum != new_easing_enum {
-                            self.easing_enum = new_easing_enum;
-                        }
-                    }
-                    NamedKey::ArrowLeft | NamedKey::ArrowRight => {
-                        // animation change
-                        let new_animation_type = new_enum_after_key(
-                            &self.animation_type,
-                            &AnimationType::Crawl,
-                            NamedKey::ArrowLeft,
-                            NamedKey::ArrowRight,
-                            &input.event.logical_key,
-                        );
-
-                        if self.animation_type != new_animation_type {
-                            self.animation_type = new_animation_type;
-                        }
-                    }
-                    _ => {}
+                if self.easing_enum != new_easing_enum {
+                    self.easing_enum = new_easing_enum;
                 }
             }
-            _ => {}
-        }
-        match input.event.physical_key {
-            // duration change
-            PhysicalKey::Code(kc) => match kc {
-                KeyCode::KeyW => {
-                    self.duration += DELTA;
+            Key::Named(NamedKey::ArrowLeft | NamedKey::ArrowRight) => {
+                // animation change
+                let new_animation_type = new_enum_after_key(
+                    &self.animation_type,
+                    &AnimationType::Crawl,
+                    NamedKey::ArrowLeft,
+                    NamedKey::ArrowRight,
+                    &input.event.logical_key,
+                );
+
+                if self.animation_type != new_animation_type {
+                    self.animation_type = new_animation_type;
                 }
-                KeyCode::KeyS => {
+            }
+            // duration change
+            Key::Character(c) => match &*c {
+                "c" | "C" => self.duration += DELTA,
+                "s" | "S" => {
                     if self.duration - DELTA > 0.1 {
                         self.duration -= DELTA;
                     }

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -4,7 +4,6 @@
 use std::env;
 use std::path;
 
-use ggez::input::keyboard;
 use oorandom::Rand32;
 
 use ggez::graphics::{Color, Image, InstanceArray};
@@ -12,6 +11,8 @@ use ggez::*;
 
 use ggez::glam::*;
 use ggez::input::keyboard::KeyInput;
+use winit::keyboard::Key;
+use winit::keyboard::NamedKey;
 
 // NOTE: Using a high number here yields worse performance than adding more bunnies over
 // time - I think this is due to all of the RNG being run on the same tick...
@@ -147,7 +148,7 @@ impl event::EventHandler for GameState {
     }
 
     fn key_down_event(&mut self, _ctx: &mut Context, input: KeyInput, _repeat: bool) -> GameResult {
-        if input.keycode == Some(keyboard::KeyCode::Space) {
+        if input.event.logical_key == Key::Named(NamedKey::Space) {
             self.batched_drawing = !self.batched_drawing;
         }
         Ok(())

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -146,6 +146,7 @@ impl MainState {
                     vertex: wgpu::VertexState {
                         module: &shader,
                         entry_point: "vs_main",
+                        compilation_options: Default::default(),
                         buffers: &[wgpu::VertexBufferLayout {
                             array_stride: std::mem::size_of::<Vertex>() as _,
                             step_mode: wgpu::VertexStepMode::Vertex,
@@ -189,6 +190,7 @@ impl MainState {
                     fragment: Some(wgpu::FragmentState {
                         module: &shader,
                         entry_point: "fs_main",
+                        compilation_options: Default::default(),
                         targets: &[Some(wgpu::ColorTargetState {
                             format: ctx.gfx.surface_format(),
                             blend: None,
@@ -196,6 +198,7 @@ impl MainState {
                         })],
                     }),
                     multiview: None,
+                    cache: None,
                 });
 
         // Create 1-pixel blue texture.

--- a/examples/custom_context.rs
+++ b/examples/custom_context.rs
@@ -121,7 +121,7 @@ pub fn main() -> GameResult {
     let cb = ggez::ContextBuilder::new("super_simple", "ggez");
     let (mut ctx, event_loop) =
         cb.custom_build::<MyContext>(|game_id: String, conf: Conf, fs: Filesystem| {
-            let events_loop = winit::event_loop::EventLoop::new();
+            let events_loop = winit::event_loop::EventLoop::new()?;
             let timer_context = timer::TimeContext::new();
             let graphics_context =
                 graphics::context::GraphicsContext::new(&game_id, &events_loop, &conf, &fs)?;

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -9,12 +9,13 @@
 //!
 //! It is functionally identical to the `super_simple.rs` example apart from that.
 
-use ggez::event;
-use ggez::event::winit_event::{Event, KeyboardInput, WindowEvent};
 use ggez::graphics::{self, Color, DrawMode};
-use ggez::input::keyboard;
 use ggez::GameResult;
+use ggez::{event, GameError};
+
+use winit::event::{Event, WindowEvent};
 use winit::event_loop::ControlFlow;
+use winit::keyboard::{Key, NamedKey};
 
 pub fn main() -> GameResult {
     let cb = ggez::ContextBuilder::new("eventloop", "ggez");
@@ -23,84 +24,81 @@ pub fn main() -> GameResult {
     let mut position: f32 = 1.0;
 
     // Handle events. Refer to `winit` docs for more information.
-    events_loop.run(move |mut event, _window_target, control_flow| {
-        let ctx = &mut ctx;
+    events_loop
+        .run(move |mut event, window_target| {
+            let ctx = &mut ctx;
 
-        if ctx.fields.quit_requested {
-            ctx.fields.continuing = false;
-        }
-        if !ctx.fields.continuing {
-            *control_flow = ControlFlow::Exit;
-            return;
-        }
-
-        *control_flow = ControlFlow::Poll;
-
-        // This tells `ggez` to update it's internal states, should the event require that.
-        // These include cursor position, view updating on resize, etc.
-        event::process_event(ctx, &mut event);
-        match event {
-            Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => ctx.request_quit(),
-                WindowEvent::KeyboardInput {
-                    input:
-                        KeyboardInput {
-                            virtual_keycode: Some(keycode),
-                            ..
-                        },
-                    ..
-                } => {
-                    if let keyboard::KeyCode::Escape = keycode {
-                        ctx.request_quit();
-                    }
-                }
-                // `CloseRequested` and `KeyboardInput` events won't appear here.
-                x => println!("Other window event fired: {x:?}"),
-            },
-            Event::MainEventsCleared => {
-                // Tell the timer stuff a frame has happened.
-                // Without this the FPS timer functions and such won't work.
-                ctx.time.tick();
-
-                // Update
-                position += 1.0;
-
-                // Draw
-                ctx.gfx.begin_frame().unwrap();
-
-                let mut canvas =
-                    graphics::Canvas::from_frame(ctx, graphics::Color::from([0.1, 0.2, 0.3, 1.0]));
-
-                let circle = graphics::Mesh::new_circle(
-                    ctx,
-                    DrawMode::fill(),
-                    ggez::glam::Vec2::new(0.0, 0.0),
-                    100.0,
-                    2.0,
-                    Color::WHITE,
-                )
-                .unwrap();
-                canvas.draw(&circle, ggez::glam::Vec2::new(position, 380.0));
-
-                canvas.finish(ctx).unwrap();
-                ctx.gfx.end_frame().unwrap();
-
-                // reset the mouse delta for the next frame
-                // necessary because it's calculated cumulatively each cycle
-                ctx.mouse.reset_delta();
-
-                // Copy the state of the keyboard into the KeyboardContext and
-                // the mouse into the MouseContext.
-                // Not required for this example but important if you want to
-                // use the functions keyboard::is_key_just_pressed/released and
-                // mouse::is_button_just_pressed/released.
-                ctx.keyboard.save_keyboard_state();
-                ctx.mouse.save_mouse_state();
-
-                ggez::timer::yield_now();
+            if ctx.fields.quit_requested {
+                ctx.fields.continuing = false;
+            }
+            if !ctx.fields.continuing {
+                window_target.exit();
+                return;
             }
 
-            x => println!("Device event fired: {x:?}"),
-        }
-    });
+            window_target.set_control_flow(ControlFlow::Poll);
+
+            // This tells `ggez` to update it's internal states, should the event require that.
+            // These include cursor position, view updating on resize, etc.
+            event::process_event(ctx, &mut event);
+            match event {
+                Event::WindowEvent { event, .. } => match event {
+                    WindowEvent::CloseRequested => ctx.request_quit(),
+                    WindowEvent::KeyboardInput { event, .. } => {
+                        if Key::Named(NamedKey::Escape) == event.logical_key {
+                            ctx.request_quit();
+                        }
+                    }
+                    // `CloseRequested` and `KeyboardInput` events won't appear here.
+                    x => println!("Other window event fired: {x:?}"),
+                },
+                Event::AboutToWait => {
+                    // Tell the timer stuff a frame has happened.
+                    // Without this the FPS timer functions and such won't work.
+                    ctx.time.tick();
+
+                    // Update
+                    position += 1.0;
+
+                    // Draw
+                    ctx.gfx.begin_frame().unwrap();
+
+                    let mut canvas = graphics::Canvas::from_frame(
+                        ctx,
+                        graphics::Color::from([0.1, 0.2, 0.3, 1.0]),
+                    );
+
+                    let circle = graphics::Mesh::new_circle(
+                        ctx,
+                        DrawMode::fill(),
+                        ggez::glam::Vec2::new(0.0, 0.0),
+                        100.0,
+                        2.0,
+                        Color::WHITE,
+                    )
+                    .unwrap();
+                    canvas.draw(&circle, ggez::glam::Vec2::new(position, 380.0));
+
+                    canvas.finish(ctx).unwrap();
+                    ctx.gfx.end_frame().unwrap();
+
+                    // reset the mouse delta for the next frame
+                    // necessary because it's calculated cumulatively each cycle
+                    ctx.mouse.reset_delta();
+
+                    // Copy the state of the keyboard into the KeyboardContext and
+                    // the mouse into the MouseContext.
+                    // Not required for this example but important if you want to
+                    // use the functions keyboard::is_key_just_pressed/released and
+                    // mouse::is_button_just_pressed/released.
+                    ctx.keyboard.save_keyboard_state();
+                    ctx.mouse.save_mouse_state();
+
+                    ggez::timer::yield_now();
+                }
+
+                x => println!("Device event fired: {x:?}"),
+            }
+        })
+        .map_err(GameError::EventLoopError)
 }

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -7,7 +7,6 @@ use ggez::conf;
 use ggez::event;
 use ggez::graphics::Rect;
 use ggez::graphics::{self, Color, DrawMode, DrawParam};
-use ggez::input::keyboard::KeyCode;
 use ggez::{Context, GameResult};
 
 use argh::FromArgs;
@@ -15,6 +14,8 @@ use argh::FromArgs;
 use ggez::input::keyboard::KeyInput;
 use std::env;
 use std::path;
+use winit::keyboard::Key;
+use winit::keyboard::NamedKey;
 
 type Point2 = ggez::glam::Vec2;
 
@@ -138,7 +139,7 @@ impl event::EventHandler for MainState {
     fn mouse_button_down_event(
         &mut self,
         _ctx: &mut Context,
-        _btn: event::MouseButton,
+        _btn: winit::event::MouseButton,
         x: f32,
         y: f32,
     ) -> GameResult {
@@ -147,26 +148,28 @@ impl event::EventHandler for MainState {
     }
 
     fn key_up_event(&mut self, ctx: &mut Context, input: KeyInput) -> GameResult {
-        match input.keycode {
-            Some(KeyCode::F) => {
-                self.window_settings.toggle_fullscreen = true;
-                self.window_settings.is_fullscreen = !self.window_settings.is_fullscreen;
+        match input.event.logical_key {
+            Key::Character(c) => {
+                if c == "f" {
+                    self.window_settings.toggle_fullscreen = true;
+                    self.window_settings.is_fullscreen = !self.window_settings.is_fullscreen;
+                }
             }
-            Some(KeyCode::Up) => {
+            Key::Named(NamedKey::ArrowUp) => {
                 self.zoom += 0.1;
                 println!("Zoom is now {}", self.zoom);
                 let (w, h) = ctx.gfx.drawable_size();
                 let new_rect = graphics::Rect::new(0.0, 0.0, w * self.zoom, h * self.zoom);
                 self.screen_coords = new_rect;
             }
-            Some(KeyCode::Down) => {
+            Key::Named(NamedKey::ArrowDown) => {
                 self.zoom -= 0.1;
                 println!("Zoom is now {}", self.zoom);
                 let (w, h) = ctx.gfx.drawable_size();
                 let new_rect = graphics::Rect::new(0.0, 0.0, w * self.zoom, h * self.zoom);
                 self.screen_coords = new_rect;
             }
-            Some(KeyCode::Space) => {
+            Key::Named(NamedKey::Space) => {
                 self.window_settings.resize_projection = !self.window_settings.resize_projection;
                 println!(
                     "Resizing the projection on window resize is now: {}",

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -1,11 +1,12 @@
 //! Example that just prints out all the input events.
 
 use ggez::conf;
-use ggez::event::{self, Axis, Button, GamepadId, MouseButton};
+use ggez::event::{self, Axis, Button, GamepadId};
 use ggez::glam::*;
 use ggez::graphics::{self, Color, DrawMode};
-use ggez::input::keyboard::{KeyCode, KeyInput};
+use ggez::input::keyboard::KeyInput;
 use ggez::{Context, GameResult};
+use winit::keyboard::Key;
 
 struct MainState {
     pos_x: f32,
@@ -25,17 +26,21 @@ impl MainState {
 
 impl event::EventHandler for MainState {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        if ctx.keyboard.is_key_pressed(KeyCode::A) {
+        if ctx
+            .keyboard
+            .is_logical_key_pressed(&Key::Character("a".into()))
+        {
             println!("The A key is pressed");
             if ctx
                 .keyboard
-                .is_mod_active(ggez::input::keyboard::KeyMods::SHIFT)
+                .active_modifiers
+                .contains(winit::keyboard::ModifiersState::SHIFT)
             {
                 println!("The shift key is held too.");
             }
             println!(
                 "Full list of pressed keys: {:?}",
-                ctx.keyboard.pressed_keys()
+                ctx.keyboard.pressed_logical_keys
             );
         }
         Ok(())
@@ -62,7 +67,7 @@ impl event::EventHandler for MainState {
     fn mouse_button_down_event(
         &mut self,
         _ctx: &mut Context,
-        button: MouseButton,
+        button: winit::event::MouseButton,
         x: f32,
         y: f32,
     ) -> GameResult {
@@ -74,7 +79,7 @@ impl event::EventHandler for MainState {
     fn mouse_button_up_event(
         &mut self,
         _ctx: &mut Context,
-        button: MouseButton,
+        button: winit::event::MouseButton,
         x: f32,
         y: f32,
     ) -> GameResult {
@@ -119,16 +124,16 @@ impl event::EventHandler for MainState {
 
     fn key_down_event(&mut self, _ctx: &mut Context, input: KeyInput, repeat: bool) -> GameResult {
         println!(
-            "Key pressed: scancode {}, keycode {:?}, modifier {:?}, repeat: {}",
-            input.scancode, input.keycode, input.mods, repeat
+            "Key pressed: physical key {:?}, logical key {:?}, modifier {:?}, repeat: {}",
+            input.event.physical_key, input.event.logical_key, input.mods, repeat
         );
         Ok(())
     }
 
     fn key_up_event(&mut self, _ctx: &mut Context, input: KeyInput) -> GameResult {
         println!(
-            "Key released: scancode {}, keycode {:?}, modifier {:?}",
-            input.scancode, input.keycode, input.mods
+            "Key released: physical key {:?}, logical key {:?}, modifier {:?}",
+            input.event.physical_key, input.event.logical_key, input.mods
         );
         Ok(())
     }

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -12,11 +12,12 @@ use ggez::conf::{WindowMode, WindowSetup};
 use ggez::event::EventHandler;
 use ggez::filesystem::File;
 use ggez::graphics;
-use ggez::input::keyboard::{KeyCode, KeyInput};
+use ggez::input::keyboard::KeyInput;
 use ggez::timer;
 use ggez::{Context, ContextBuilder, GameResult};
 use std::io::Write;
 use std::sync::mpsc;
+use winit::keyboard::{Key, NamedKey};
 
 /// A basic file writer.
 /// Hogs it's log file until dropped, writes to it whenever `update()` is called.
@@ -101,9 +102,9 @@ impl EventHandler for App {
         // Log the keypress to info channel!
         info!(
             "Key down event: {:?}, modifiers: {:?}, repeat: {}",
-            input.keycode, input.mods, repeated
+            input.event.logical_key, input.mods, repeated
         );
-        if input.keycode == Some(KeyCode::Escape) {
+        if input.event.logical_key == Key::Named(NamedKey::Escape) {
             // Escape key closes the app.
             ctx.request_quit();
         }
@@ -171,7 +172,9 @@ pub fn main() -> GameResult {
         Err(e) => {
             error!("Could not initialize: {}", e);
         }
-        Ok(app) => ggez::event::run(ctx, events_loop, app),
+        Ok(app) => {
+            let _ = ggez::event::run(ctx, events_loop, app);
+        }
     }
 
     trace!("Since file logger is dropped with App, this line will cause an error in fern!");

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -10,9 +10,7 @@ use ggez::input::keyboard::KeyInput;
 use std::env;
 use std::path;
 use std::time::Duration;
-use winit::keyboard::Key;
 use winit::keyboard::KeyCode;
-use winit::keyboard::NamedKey;
 use winit::keyboard::PhysicalKey;
 
 struct MainState {
@@ -92,10 +90,7 @@ impl event::EventHandler for MainState {
             PhysicalKey::Code(KeyCode::Digit4) => self.play_highpitch(ctx),
             PhysicalKey::Code(KeyCode::Digit5) => self.play_lowpitch(ctx),
             PhysicalKey::Code(KeyCode::Digit6) => self.play_stats(ctx),
-            _ => (),
-        }
-        match input.event.logical_key {
-            Key::Named(NamedKey::Escape) => ctx.request_quit(),
+            PhysicalKey::Code(KeyCode::Escape) => ctx.request_quit(),
             _ => (),
         }
         Ok(())

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -2,7 +2,6 @@ use ggez::audio;
 use ggez::audio::SoundSource;
 use ggez::event;
 use ggez::graphics;
-use ggez::input;
 use ggez::{Context, GameResult};
 
 use ggez::glam::*;
@@ -11,6 +10,10 @@ use ggez::input::keyboard::KeyInput;
 use std::env;
 use std::path;
 use std::time::Duration;
+use winit::keyboard::Key;
+use winit::keyboard::KeyCode;
+use winit::keyboard::NamedKey;
+use winit::keyboard::PhysicalKey;
 
 struct MainState {
     sound: audio::Source,
@@ -82,14 +85,17 @@ impl event::EventHandler for MainState {
     }
 
     fn key_down_event(&mut self, ctx: &mut Context, input: KeyInput, _repeat: bool) -> GameResult {
-        match input.keycode {
-            Some(input::keyboard::KeyCode::Key1) => self.play_detached(ctx),
-            Some(input::keyboard::KeyCode::Key2) => self.play_later(ctx),
-            Some(input::keyboard::KeyCode::Key3) => self.play_fadein(ctx),
-            Some(input::keyboard::KeyCode::Key4) => self.play_highpitch(ctx),
-            Some(input::keyboard::KeyCode::Key5) => self.play_lowpitch(ctx),
-            Some(input::keyboard::KeyCode::Key6) => self.play_stats(ctx),
-            Some(input::keyboard::KeyCode::Escape) => ctx.request_quit(),
+        match input.event.physical_key {
+            PhysicalKey::Code(KeyCode::Digit1) => self.play_detached(ctx),
+            PhysicalKey::Code(KeyCode::Digit2) => self.play_later(ctx),
+            PhysicalKey::Code(KeyCode::Digit3) => self.play_fadein(ctx),
+            PhysicalKey::Code(KeyCode::Digit4) => self.play_highpitch(ctx),
+            PhysicalKey::Code(KeyCode::Digit5) => self.play_lowpitch(ctx),
+            PhysicalKey::Code(KeyCode::Digit6) => self.play_stats(ctx),
+            _ => (),
+        }
+        match input.event.logical_key {
+            Key::Named(NamedKey::Escape) => ctx.request_quit(),
             _ => (),
         }
         Ok(())

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -6,6 +6,8 @@ use ggez::input::keyboard;
 use ggez::{Context, GameResult};
 use std::env;
 use std::path;
+use winit::keyboard::Key;
+use winit::keyboard::NamedKey;
 
 const GRID_INTERVAL: f32 = 100.0;
 const GRID_SIZE: usize = 10;
@@ -104,7 +106,7 @@ impl event::EventHandler for MainState {
         input: keyboard::KeyInput,
         _repeat: bool,
     ) -> GameResult {
-        if let Some(keyboard::KeyCode::Space) = input.keycode {
+        if Key::Named(NamedKey::Space) == input.event.logical_key {
             self.screen_bounds_idx = (self.screen_bounds_idx + 1) % self.screen_bounds.len();
             self.screen_coords = self.screen_bounds[self.screen_bounds_idx];
         }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -328,8 +328,6 @@ pub enum Backend {
     Metal,
     /// Use the Microsoft DirectX 12 API.
     Dx12,
-    /// Use the Microsoft DirectX 11 API. This is not a recommended backend.
-    Dx11,
     /// Use the Khronos OpenGL API. This is not a recommended backend.
     Gl,
     /// Use the WebGPU API. Targets the web.

--- a/src/context.rs
+++ b/src/context.rs
@@ -228,7 +228,7 @@ impl Context {
     ) -> GameResult<(Context, winit::event_loop::EventLoop<()>)> {
         #[cfg(feature = "audio")]
         let audio_context = audio::AudioContext::new(&fs)?;
-        let events_loop = winit::event_loop::EventLoop::new();
+        let events_loop = winit::event_loop::EventLoop::new()?;
         let timer_context = timer::TimeContext::new();
         let graphics_context =
             graphics::context::GraphicsContext::new(game_id, &events_loop, &conf, &fs)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ pub enum GameError {
     ConfigError(String),
     /// Happens when an `winit::event_loop::EventLoopProxy` attempts to
     /// wake up an `winit::event_loop::EventLoop` that no longer exists.
-    EventLoopError(String),
+    EventLoopError(winit::error::EventLoopError),
     /// An error trying to load a resource, such as getting an invalid image file.
     ResourceLoadError(String),
     /// Unable to find a resource; the `Vec` is the paths it searched for and associated errors
@@ -31,7 +31,7 @@ pub enum GameError {
     /// Something went wrong trying to set or get window properties.
     WindowError(String),
     /// Something went wrong trying to create a window
-    WindowCreationError(Arc<winit::error::OsError>),
+    WindowCreationError(winit::error::OsError),
     /// Something went wrong trying to read from a file
     #[allow(clippy::upper_case_acronyms)]
     IOError(Arc<std::io::Error>),
@@ -86,11 +86,12 @@ impl Error for GameError {
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
             GameError::RequestDeviceError(ref e) => Some(e),
-            GameError::WindowCreationError(ref e) => Some(&**e),
+            GameError::WindowCreationError(ref e) => Some(e),
             GameError::IOError(ref e) => Some(&**e),
             GameError::FontError(ref e) => Some(e),
             GameError::GlyphBrushError(ref e) => Some(e),
             GameError::BufferAsyncError(ref e) => Some(e),
+            GameError::EventLoopError(ref e) => Some(e),
             _ => None,
         }
     }
@@ -150,8 +151,8 @@ impl From<image::ImageError> for GameError {
     }
 }
 impl From<winit::error::OsError> for GameError {
-    fn from(s: winit::error::OsError) -> GameError {
-        GameError::WindowCreationError(Arc::new(s))
+    fn from(e: winit::error::OsError) -> GameError {
+        GameError::WindowCreationError(e)
     }
 }
 
@@ -185,9 +186,9 @@ impl From<wgpu::RequestDeviceError> for GameError {
     }
 }
 
-impl From<Arc<winit::error::OsError>> for GameError {
-    fn from(s: Arc<winit::error::OsError>) -> GameError {
-        GameError::WindowCreationError(s)
+impl From<winit::error::EventLoopError> for GameError {
+    fn from(e: winit::error::EventLoopError) -> GameError {
+        GameError::EventLoopError(e)
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,44 +10,27 @@
 //! source code for this module, or the [`eventloop`
 //! example](https://github.com/ggez/ggez/blob/master/examples/eventloop.rs).
 
-use winit::{self, dpi};
+use winit::{
+    dpi,
+    event::{ElementState, Event, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent},
+    event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+    keyboard::{Key, NamedKey},
+};
 
-/// A mouse button.
-pub use winit::event::{MouseButton, ScanCode};
-
-/// An analog axis of some device (gamepad thumbstick, joystick...).
-#[cfg(feature = "gamepad")]
-pub use gilrs::Axis;
-/// A button of some device (gamepad, joystick...).
-#[cfg(feature = "gamepad")]
-pub use gilrs::Button;
-
-/// `winit` events; nested in a module for re-export neatness.
-pub mod winit_event {
-    pub use super::winit::event::{
-        DeviceEvent, ElementState, Event, KeyboardInput, ModifiersState, MouseScrollDelta,
-        TouchPhase, WindowEvent,
-    };
-}
-use crate::context::ContextFields;
-#[cfg(not(feature = "gamepad"))]
-use crate::context::GamepadContext;
-use crate::context::HasMut;
 use crate::graphics::GraphicsContext;
-use crate::input;
+use crate::input::{self, keyboard::KeyInput};
+use crate::{
+    context::{ContextFields, HasMut},
+    GameResult,
+};
+use crate::{Context, GameError};
+
 #[cfg(feature = "gamepad")]
 use crate::input::gamepad::GamepadContext;
 #[cfg(feature = "gamepad")]
 pub use crate::input::gamepad::GamepadId;
-use crate::input::keyboard::{KeyCode, KeyInput, KeyMods};
-use crate::Context;
-use crate::GameError;
-
-use self::winit_event::{
-    ElementState, Event, KeyboardInput, MouseScrollDelta, TouchPhase, WindowEvent,
-};
-/// `winit` event loop.
-pub use winit::event_loop::{ControlFlow, EventLoop};
+#[cfg(feature = "gamepad")]
+pub use gilrs::{Axis, Button};
 
 /// Used in [`EventHandler::on_error()`](trait.EventHandler.html#method.on_error)
 /// to specify where an error originated
@@ -176,7 +159,7 @@ where
     /// when the escape key is pressed. If you override this with your own
     /// event handler you have to re-implement that functionality yourself.
     fn key_down_event(&mut self, ctx: &mut C, input: KeyInput, _repeated: bool) -> Result<(), E> {
-        if input.keycode == Some(KeyCode::Escape) {
+        if input.event.logical_key == Key::Named(NamedKey::Escape) {
             HasMut::<ContextFields>::retrieve_mut(ctx).quit_requested = true;
         }
         Ok(())
@@ -283,7 +266,7 @@ where
 /// It does not try to do any type of framerate limiting.  See the
 /// documentation for the [`timer`](../timer/index.html) module for more info.
 #[allow(clippy::needless_return)] // necessary as the returns used here are actually necessary to break early from the event loop
-pub fn run<S, C, E>(mut ctx: C, event_loop: EventLoop<()>, mut state: S) -> !
+pub fn run<S, C, E>(mut ctx: C, event_loop: EventLoop<()>, mut state: S) -> GameResult
 where
     S: EventHandler<C, E> + 'static,
     E: std::fmt::Debug,
@@ -295,340 +278,314 @@ where
         + HasMut<GamepadContext>
         + HasMut<crate::timer::TimeContext>,
 {
-    event_loop.run(move |mut event, _, control_flow| {
-        let ctx = &mut ctx;
-        let state = &mut state;
+    event_loop
+        .run(move |mut event, window_target| {
+            let ctx = &mut ctx;
+            let state = &mut state;
 
-        // let mut fields = HasMut::<ContextFields>::retrieve_mut(ctx).clone();
-        // let mut mouse =
-        //     HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx)
-        // let mut keyboard = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx).clone();
-
-        if HasMut::<ContextFields>::retrieve_mut(ctx).quit_requested {
-            let res = state.quit_event(ctx);
-            HasMut::<ContextFields>::retrieve_mut(ctx).quit_requested = false;
-            if let Ok(false) = res {
-                HasMut::<ContextFields>::retrieve_mut(ctx).continuing = false;
-            } else if catch_error(ctx, res, state, control_flow, ErrorOrigin::QuitEvent) {
+            if HasMut::<ContextFields>::retrieve_mut(ctx).quit_requested {
+                let res = state.quit_event(ctx);
+                HasMut::<ContextFields>::retrieve_mut(ctx).quit_requested = false;
+                if let Ok(false) = res {
+                    HasMut::<ContextFields>::retrieve_mut(ctx).continuing = false;
+                } else if catch_error(ctx, res, state, window_target, ErrorOrigin::QuitEvent) {
+                    return;
+                }
+            }
+            if !HasMut::<ContextFields>::retrieve_mut(ctx).continuing {
+                window_target.exit();
                 return;
             }
-        }
-        if !HasMut::<ContextFields>::retrieve_mut(ctx).continuing {
-            *control_flow = ControlFlow::Exit;
-            return;
-        }
 
-        *control_flow = ControlFlow::Poll;
+            window_target.set_control_flow(ControlFlow::Poll);
 
-        process_event(ctx, &mut event);
-        match event {
-            Event::WindowEvent { event, .. } => match event {
-                WindowEvent::Resized(logical_size) => {
-                    // let actual_size = logical_size;
-                    let res = state.resize_event(
-                        ctx,
-                        logical_size.width as f32,
-                        logical_size.height as f32,
-                    );
-                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::ResizeEvent) {
-                        return;
-                    };
-                }
-                WindowEvent::CloseRequested => {
-                    let res = state.quit_event(ctx);
-                    if let Ok(false) = res {
-                        HasMut::<ContextFields>::retrieve_mut(ctx).continuing = false;
-                    } else if catch_error(ctx, res, state, control_flow, ErrorOrigin::QuitEvent) {
-                        return;
+            process_event(ctx, &mut event);
+            match event {
+                Event::WindowEvent { event, .. } => match event {
+                    WindowEvent::Resized(logical_size) => {
+                        let res = state.resize_event(
+                            ctx,
+                            logical_size.width as f32,
+                            logical_size.height as f32,
+                        );
+                        if catch_error(ctx, res, state, window_target, ErrorOrigin::ResizeEvent) {
+                            return;
+                        };
+                    }
+                    WindowEvent::CloseRequested => {
+                        let res = state.quit_event(ctx);
+                        if let Ok(false) = res {
+                            HasMut::<ContextFields>::retrieve_mut(ctx).continuing = false;
+                        } else if catch_error(
+                            ctx,
+                            res,
+                            state,
+                            window_target,
+                            ErrorOrigin::QuitEvent,
+                        ) {
+                            return;
+                        }
+                    }
+                    WindowEvent::Focused(gained) => {
+                        let res = state.focus_event(ctx, gained);
+                        if catch_error(ctx, res, state, window_target, ErrorOrigin::FocusEvent) {
+                            return;
+                        };
+                    }
+                    WindowEvent::ModifiersChanged(mods) => {
+                        HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx)
+                            .active_modifiers = mods.state()
+                    }
+                    WindowEvent::KeyboardInput { event, .. } => {
+                        let mods = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx)
+                            .active_modifiers;
+
+                        let repeat = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx)
+                            .is_key_repeated();
+                        let key_state = event.state;
+                        let input = KeyInput { event, mods };
+                        let (res, origin) = match key_state {
+                            ElementState::Pressed => (
+                                state.key_down_event(ctx, input, repeat),
+                                ErrorOrigin::KeyDownEvent,
+                            ),
+                            ElementState::Released => {
+                                (state.key_up_event(ctx, input), ErrorOrigin::KeyUpEvent)
+                            }
+                        };
+                        if catch_error(ctx, res, state, window_target, origin) {
+                            return;
+                        };
+                    }
+                    WindowEvent::MouseWheel { delta, .. } => {
+                        let gfx = HasMut::<GraphicsContext>::retrieve_mut(ctx);
+                        let (x, y) = match delta {
+                            MouseScrollDelta::LineDelta(x, y) => (x, y),
+                            MouseScrollDelta::PixelDelta(pos) => {
+                                let scale_factor = gfx.window.scale_factor();
+                                let dpi::LogicalPosition { x, y } =
+                                    pos.to_logical::<f32>(scale_factor);
+                                (x, y)
+                            }
+                        };
+                        let res = state.mouse_wheel_event(ctx, x, y);
+                        if catch_error(ctx, res, state, window_target, ErrorOrigin::MouseWheelEvent)
+                        {
+                            return;
+                        };
+                    }
+                    WindowEvent::MouseInput {
+                        state: element_state,
+                        button,
+                        ..
+                    } => {
+                        let position =
+                            HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).position();
+                        match element_state {
+                            ElementState::Pressed => {
+                                let res = state
+                                    .mouse_button_down_event(ctx, button, position.x, position.y);
+                                if catch_error(
+                                    ctx,
+                                    res,
+                                    state,
+                                    window_target,
+                                    ErrorOrigin::MouseButtonDownEvent,
+                                ) {
+                                    return;
+                                };
+                            }
+                            ElementState::Released => {
+                                let res = state
+                                    .mouse_button_up_event(ctx, button, position.x, position.y);
+                                if catch_error(
+                                    ctx,
+                                    res,
+                                    state,
+                                    window_target,
+                                    ErrorOrigin::MouseButtonUpEvent,
+                                ) {
+                                    return;
+                                };
+                            }
+                        }
+                    }
+                    WindowEvent::CursorMoved { .. } => {
+                        let position =
+                            HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).position();
+                        let delta =
+                            HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).last_delta();
+                        let res =
+                            state.mouse_motion_event(ctx, position.x, position.y, delta.x, delta.y);
+                        if catch_error(
+                            ctx,
+                            res,
+                            state,
+                            window_target,
+                            ErrorOrigin::MouseMotionEvent,
+                        ) {
+                            return;
+                        };
+                    }
+                    WindowEvent::Touch(touch) => {
+                        let res =
+                            state.touch_event(ctx, touch.phase, touch.location.x, touch.location.y);
+                        if catch_error(ctx, res, state, window_target, ErrorOrigin::TouchEvent) {
+                            return;
+                        };
+                    }
+                    WindowEvent::CursorEntered { device_id: _ } => {
+                        let res = state.mouse_enter_or_leave(ctx, true);
+                        if catch_error(
+                            ctx,
+                            res,
+                            state,
+                            window_target,
+                            ErrorOrigin::MouseEnterOrLeave,
+                        ) {
+                            return;
+                        }
+                    }
+                    WindowEvent::CursorLeft { device_id: _ } => {
+                        let res = state.mouse_enter_or_leave(ctx, false);
+                        if catch_error(
+                            ctx,
+                            res,
+                            state,
+                            window_target,
+                            ErrorOrigin::MouseEnterOrLeave,
+                        ) {
+                            return;
+                        }
+                    }
+                    _x => {
+                        // trace!("ignoring window event {:?}", x);
+                    }
+                },
+                Event::DeviceEvent {
+                    device_id: _,
+                    event,
+                } => {
+                    if let winit::event::DeviceEvent::MouseMotion { delta } = event {
+                        let res = state.raw_mouse_motion_event(ctx, delta.0, delta.0);
+                        if catch_error(
+                            ctx,
+                            res,
+                            state,
+                            window_target,
+                            ErrorOrigin::RawMouseMotionEvent,
+                        ) {
+                            return;
+                        }
                     }
                 }
-                WindowEvent::Focused(gained) => {
-                    let res = state.focus_event(ctx, gained);
-                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::FocusEvent) {
+                Event::Resumed => (),
+                Event::Suspended => (),
+                Event::NewEvents(_) => (),
+                Event::UserEvent(_) => (),
+                Event::AboutToWait => {
+                    // If you are writing your own event loop, make sure
+                    // you include `timer_context.tick()` and
+                    // `ctx.process_event()` calls.  These update ggez's
+                    // internal state however necessary.
+                    let time = HasMut::<crate::timer::TimeContext>::retrieve_mut(ctx);
+                    time.tick();
+
+                    // Handle gamepad events if necessary.
+                    #[cfg(feature = "gamepad")]
+                    while let Some(gilrs::Event { id, event, .. }) =
+                        HasMut::<input::gamepad::GamepadContext>::retrieve_mut(ctx).next_event()
+                    {
+                        match event {
+                            gilrs::EventType::ButtonPressed(button, _) => {
+                                let res =
+                                    state.gamepad_button_down_event(ctx, button, GamepadId(id));
+                                if catch_error(
+                                    ctx,
+                                    res,
+                                    state,
+                                    window_target,
+                                    ErrorOrigin::GamepadButtonDownEvent,
+                                ) {
+                                    return;
+                                };
+                            }
+                            gilrs::EventType::ButtonReleased(button, _) => {
+                                let res = state.gamepad_button_up_event(ctx, button, GamepadId(id));
+                                if catch_error(
+                                    ctx,
+                                    res,
+                                    state,
+                                    window_target,
+                                    ErrorOrigin::GamepadButtonUpEvent,
+                                ) {
+                                    return;
+                                };
+                            }
+                            gilrs::EventType::AxisChanged(axis, value, _) => {
+                                let res = state.gamepad_axis_event(ctx, axis, value, GamepadId(id));
+                                if catch_error(
+                                    ctx,
+                                    res,
+                                    state,
+                                    window_target,
+                                    ErrorOrigin::GamepadAxisEvent,
+                                ) {
+                                    return;
+                                };
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    let res = state.update(ctx);
+                    if catch_error(ctx, res, state, window_target, ErrorOrigin::Update) {
                         return;
                     };
-                }
-                WindowEvent::ReceivedCharacter(ch) => {
-                    let res = state.text_input_event(ctx, ch);
-                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::TextInputEvent) {
-                        return;
-                    };
-                }
-                WindowEvent::ModifiersChanged(mods) => {
+
+                    if let Err(e) = HasMut::<GraphicsContext>::retrieve_mut(ctx).begin_frame() {
+                        error!("Error on GraphicsContext::begin_frame(): {e:?}");
+                        eprintln!("Error on GraphicsContext::begin_frame(): {e:?}");
+                        window_target.exit();
+                    }
+
+                    if let Err(e) = state.draw(ctx) {
+                        error!("Error on EventHandler::draw(): {e:?}");
+                        eprintln!("Error on EventHandler::draw(): {e:?}");
+                        if state.on_error(ctx, ErrorOrigin::Draw, e) {
+                            window_target.exit();
+                            return;
+                        }
+                    }
+
+                    if let Err(e) = HasMut::<GraphicsContext>::retrieve_mut(ctx).end_frame() {
+                        error!("Error on GraphicsContext::end_frame(): {e:?}");
+                        eprintln!("Error on GraphicsContext::end_frame(): {e:?}");
+                        window_target.exit();
+                    }
+
+                    // reset the mouse delta for the next frame
+                    // necessary because it's calculated cumulatively each cycle
+                    HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).reset_delta();
+
+                    // Copy the state of the keyboard into the KeyboardContext
+                    // and the mouse into the MouseContext
                     HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx)
-                        .set_modifiers(KeyMods::from(mods))
+                        .save_keyboard_state();
+                    HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).save_mouse_state();
                 }
-                WindowEvent::KeyboardInput {
-                    input:
-                        KeyboardInput {
-                            state: ElementState::Pressed,
-                            virtual_keycode: keycode,
-                            scancode,
-                            ..
-                        },
-                    ..
-                } => {
-                    let active_mods =
-                        HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx).active_mods();
-
-                    let repeat = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx)
-                        .is_key_repeated();
-                    let res = state.key_down_event(
-                        ctx,
-                        KeyInput {
-                            scancode,
-                            keycode,
-                            mods: active_mods,
-                        },
-                        repeat,
-                    );
-                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::KeyDownEvent) {
-                        return;
-                    };
-                }
-                WindowEvent::KeyboardInput {
-                    input:
-                        KeyboardInput {
-                            state: ElementState::Released,
-                            virtual_keycode: keycode,
-                            scancode,
-                            ..
-                        },
-                    ..
-                } => {
-                    let active_mods =
-                        HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx).active_mods();
-                    let res = state.key_up_event(
-                        ctx,
-                        KeyInput {
-                            scancode,
-                            keycode,
-                            mods: active_mods,
-                        },
-                    );
-                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::KeyUpEvent) {
-                        return;
-                    };
-                }
-                WindowEvent::MouseWheel { delta, .. } => {
-                    let gfx = HasMut::<GraphicsContext>::retrieve_mut(ctx);
-                    let (x, y) = match delta {
-                        MouseScrollDelta::LineDelta(x, y) => (x, y),
-                        MouseScrollDelta::PixelDelta(pos) => {
-                            let scale_factor = gfx.window.scale_factor();
-                            let dpi::LogicalPosition { x, y } = pos.to_logical::<f32>(scale_factor);
-                            (x, y)
-                        }
-                    };
-                    let res = state.mouse_wheel_event(ctx, x, y);
-                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::MouseWheelEvent) {
-                        return;
-                    };
-                }
-                WindowEvent::MouseInput {
-                    state: element_state,
-                    button,
-                    ..
-                } => {
-                    let position =
-                        HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).position();
-                    match element_state {
-                        ElementState::Pressed => {
-                            let res =
-                                state.mouse_button_down_event(ctx, button, position.x, position.y);
-                            if catch_error(
-                                ctx,
-                                res,
-                                state,
-                                control_flow,
-                                ErrorOrigin::MouseButtonDownEvent,
-                            ) {
-                                return;
-                            };
-                        }
-                        ElementState::Released => {
-                            let res =
-                                state.mouse_button_up_event(ctx, button, position.x, position.y);
-                            if catch_error(
-                                ctx,
-                                res,
-                                state,
-                                control_flow,
-                                ErrorOrigin::MouseButtonUpEvent,
-                            ) {
-                                return;
-                            };
-                        }
-                    }
-                }
-                WindowEvent::CursorMoved { .. } => {
-                    let position =
-                        HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).position();
-                    let delta =
-                        HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).last_delta();
-                    let res =
-                        state.mouse_motion_event(ctx, position.x, position.y, delta.x, delta.y);
-                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::MouseMotionEvent) {
-                        return;
-                    };
-                }
-                WindowEvent::Touch(touch) => {
-                    let res =
-                        state.touch_event(ctx, touch.phase, touch.location.x, touch.location.y);
-                    if catch_error(ctx, res, state, control_flow, ErrorOrigin::TouchEvent) {
-                        return;
-                    };
-                }
-                WindowEvent::CursorEntered { device_id: _ } => {
-                    let res = state.mouse_enter_or_leave(ctx, true);
-                    if catch_error(
-                        ctx,
-                        res,
-                        state,
-                        control_flow,
-                        ErrorOrigin::MouseEnterOrLeave,
-                    ) {
-                        return;
-                    }
-                }
-                WindowEvent::CursorLeft { device_id: _ } => {
-                    let res = state.mouse_enter_or_leave(ctx, false);
-                    if catch_error(
-                        ctx,
-                        res,
-                        state,
-                        control_flow,
-                        ErrorOrigin::MouseEnterOrLeave,
-                    ) {
-                        return;
-                    }
-                }
-                _x => {
-                    // trace!("ignoring window event {:?}", x);
-                }
-            },
-            Event::DeviceEvent {
-                device_id: _,
-                event,
-            } => {
-                if let winit::event::DeviceEvent::MouseMotion { delta } = event {
-                    let res = state.raw_mouse_motion_event(ctx, delta.0, delta.0);
-                    if catch_error(
-                        ctx,
-                        res,
-                        state,
-                        control_flow,
-                        ErrorOrigin::RawMouseMotionEvent,
-                    ) {
-                        return;
-                    }
-                }
+                Event::LoopExiting => (),
+                Event::MemoryWarning => (),
             }
-            Event::Resumed => (),
-            Event::Suspended => (),
-            Event::NewEvents(_) => (),
-            Event::UserEvent(_) => (),
-            Event::MainEventsCleared => {
-                // If you are writing your own event loop, make sure
-                // you include `timer_context.tick()` and
-                // `ctx.process_event()` calls.  These update ggez's
-                // internal state however necessary.
-                let time = HasMut::<crate::timer::TimeContext>::retrieve_mut(ctx);
-                time.tick();
-
-                // Handle gamepad events if necessary.
-                #[cfg(feature = "gamepad")]
-                while let Some(gilrs::Event { id, event, .. }) =
-                    HasMut::<input::gamepad::GamepadContext>::retrieve_mut(ctx).next_event()
-                {
-                    match event {
-                        gilrs::EventType::ButtonPressed(button, _) => {
-                            let res = state.gamepad_button_down_event(ctx, button, GamepadId(id));
-                            if catch_error(
-                                ctx,
-                                res,
-                                state,
-                                control_flow,
-                                ErrorOrigin::GamepadButtonDownEvent,
-                            ) {
-                                return;
-                            };
-                        }
-                        gilrs::EventType::ButtonReleased(button, _) => {
-                            let res = state.gamepad_button_up_event(ctx, button, GamepadId(id));
-                            if catch_error(
-                                ctx,
-                                res,
-                                state,
-                                control_flow,
-                                ErrorOrigin::GamepadButtonUpEvent,
-                            ) {
-                                return;
-                            };
-                        }
-                        gilrs::EventType::AxisChanged(axis, value, _) => {
-                            let res = state.gamepad_axis_event(ctx, axis, value, GamepadId(id));
-                            if catch_error(
-                                ctx,
-                                res,
-                                state,
-                                control_flow,
-                                ErrorOrigin::GamepadAxisEvent,
-                            ) {
-                                return;
-                            };
-                        }
-                        _ => {}
-                    }
-                }
-
-                let res = state.update(ctx);
-                if catch_error(ctx, res, state, control_flow, ErrorOrigin::Update) {
-                    return;
-                };
-
-                if let Err(e) = HasMut::<GraphicsContext>::retrieve_mut(ctx).begin_frame() {
-                    error!("Error on GraphicsContext::begin_frame(): {e:?}");
-                    eprintln!("Error on GraphicsContext::begin_frame(): {e:?}");
-                    *control_flow = ControlFlow::Exit;
-                }
-
-                if let Err(e) = state.draw(ctx) {
-                    error!("Error on EventHandler::draw(): {e:?}");
-                    eprintln!("Error on EventHandler::draw(): {e:?}");
-                    if state.on_error(ctx, ErrorOrigin::Draw, e) {
-                        *control_flow = ControlFlow::Exit;
-                        return;
-                    }
-                }
-
-                if let Err(e) = HasMut::<GraphicsContext>::retrieve_mut(ctx).end_frame() {
-                    error!("Error on GraphicsContext::end_frame(): {e:?}");
-                    eprintln!("Error on GraphicsContext::end_frame(): {e:?}");
-                    *control_flow = ControlFlow::Exit;
-                }
-
-                // reset the mouse delta for the next frame
-                // necessary because it's calculated cumulatively each cycle
-                HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).reset_delta();
-
-                // Copy the state of the keyboard into the KeyboardContext
-                // and the mouse into the MouseContext
-                HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx).save_keyboard_state();
-                HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).save_mouse_state();
-            }
-            Event::RedrawRequested(_) => (),
-            Event::RedrawEventsCleared => (),
-            Event::LoopDestroyed => (),
-        }
-    })
+        })
+        .map_err(GameError::EventLoopError)
 }
 
 fn catch_error<T, C, E, S>(
     ctx: &mut C,
     event_result: Result<T, E>,
     state: &mut S,
-    control_flow: &mut ControlFlow,
+    window_target: &EventLoopWindowTarget<()>,
     origin: ErrorOrigin,
 ) -> bool
 where
@@ -640,7 +597,7 @@ where
         error!("Error on EventHandler {origin:?}: {e:?}");
         eprintln!("Error on EventHandler {origin:?}: {e:?}");
         if state.on_error(ctx, origin, e) {
-            *control_flow = ControlFlow::Exit;
+            window_target.exit();
             return true;
         }
     }
@@ -651,14 +608,14 @@ where
 /// state it needs to, such as detecting window resizes.  If you are
 /// rolling your own event loop, you should call this on the events
 /// you receive before processing them yourself.
-pub fn process_event<C>(ctx: &mut C, event: &mut winit::event::Event<()>)
+pub fn process_event<C>(ctx: &mut C, event: &mut Event<()>)
 where
     C: HasMut<ContextFields>
         + HasMut<GraphicsContext>
         + HasMut<input::keyboard::KeyboardContext>
         + HasMut<input::mouse::MouseContext>,
 {
-    if let winit_event::Event::DeviceEvent {
+    if let Event::DeviceEvent {
         event: winit::event::DeviceEvent::MouseMotion { delta },
         ..
     } = event
@@ -666,60 +623,50 @@ where
         let mouse = HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx);
         mouse.handle_motion(delta.0, delta.1);
     }
-    if let winit_event::Event::WindowEvent { event, .. } = event {
+    if let Event::WindowEvent { event, .. } = event {
         match event {
-            winit_event::WindowEvent::Resized(physical_size) => {
+            WindowEvent::Resized(physical_size) => {
                 let gfx = HasMut::<GraphicsContext>::retrieve_mut(ctx);
                 gfx.resize(*physical_size);
             }
-            winit_event::WindowEvent::CursorMoved {
+            WindowEvent::CursorMoved {
                 position: physical_position,
                 ..
             } => {
                 let mouse = HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx);
                 mouse.handle_move(physical_position.x as f32, physical_position.y as f32);
             }
-            winit_event::WindowEvent::MouseInput { button, state, .. } => {
+            WindowEvent::MouseInput { button, state, .. } => {
                 let mouse = HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx);
                 let pressed = match state {
-                    winit_event::ElementState::Pressed => true,
-                    winit_event::ElementState::Released => false,
+                    ElementState::Pressed => true,
+                    ElementState::Released => false,
                 };
                 mouse.set_button(*button, pressed);
             }
-            winit_event::WindowEvent::ModifiersChanged(mods) => {
+            WindowEvent::ModifiersChanged(mods) => {
                 let keyboard = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx);
-                keyboard.set_modifiers(KeyMods::from(*mods))
+                keyboard.active_modifiers = mods.state();
             }
-            winit_event::WindowEvent::KeyboardInput {
-                input:
-                    winit::event::KeyboardInput {
-                        state,
-                        scancode,
-                        virtual_keycode: keycode,
-                        ..
-                    },
-                ..
+            WindowEvent::KeyboardInput { event, .. } => {
+                let keyboard = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx);
+                let pressed = event.state == ElementState::Pressed;
+                keyboard.set_logical_key(&event.logical_key, pressed);
+                keyboard.set_physical_key(&event.physical_key, pressed);
+            }
+            WindowEvent::ScaleFactorChanged {
+                inner_size_writer, ..
             } => {
-                let keyboard = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx);
-                let pressed = match state {
-                    winit_event::ElementState::Pressed => true,
-                    winit_event::ElementState::Released => false,
-                };
-                keyboard.set_scancode(*scancode, pressed);
-                if let Some(key) = keycode {
-                    keyboard.set_key(*key, pressed);
-                }
-            }
-            winit_event::WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
                 let fields = HasMut::<ContextFields>::retrieve_mut(ctx);
                 if !fields.conf.window_mode.resize_on_scale_factor_change {
                     // actively set the new_inner_size to be the desired size
                     // to stop winit from resizing our window
-                    **new_inner_size = winit::dpi::PhysicalSize::<u32>::from([
-                        fields.conf.window_mode.width,
-                        fields.conf.window_mode.height,
-                    ]);
+                    let _ = inner_size_writer.request_inner_size(
+                        winit::dpi::PhysicalSize::<u32>::from([
+                            fields.conf.window_mode.width,
+                            fields.conf.window_mode.height,
+                        ]),
+                    );
                 }
             }
             _ => (),

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -3,16 +3,16 @@
 //! This module provides access to files in specific places:
 //!
 //! * The `resources/` subdirectory in the same directory as the
-//! program executable, if any,
+//!   program executable, if any,
 //! * The `resources.zip` file in the same
-//! directory as the program executable, if any,
+//!   directory as the program executable, if any,
 //! * The root folder of the  game's "save" directory which is in a
-//! platform-dependent location,
-//! such as `~/.local/share/<gameid>/` on Linux.  The `gameid`
-//! is the the string passed to
-//! [`ContextBuilder::new()`](../struct.ContextBuilder.html#method.new).
-//! Some platforms such as Windows also incorporate the `author` string into
-//! the path.
+//!   platform-dependent location,
+//!   such as `~/.local/share/<gameid>/` on Linux.  The `gameid`
+//!   is the the string passed to
+//!   [`ContextBuilder::new()`](../struct.ContextBuilder.html#method.new).
+//!   Some platforms such as Windows also incorporate the `author` string into
+//!   the path.
 //!
 //! These locations will be searched for files in the order listed, and the first file
 //! found used.  That allows game assets to be easily distributed as an archive

--- a/src/graphics/draw.rs
+++ b/src/graphics/draw.rs
@@ -21,7 +21,7 @@ pub enum Transform {
         /// For most objects this works as a relative offset (meaning `[0.5,0.5]` is an offset which
         /// centers the object on the destination). These objects are:
         /// * `Image`, `Canvas`, `Text` and the sprites inside an `InstanceArray` (as long as you're
-        /// not making an instanced mesh-draw)
+        ///   not making an instanced mesh-draw)
         offset: mint::Point2<f32>,
     },
     /// Transform made of an arbitrary matrix.

--- a/src/graphics/gpu/pipeline.rs
+++ b/src/graphics/gpu/pipeline.rs
@@ -52,6 +52,7 @@ impl PipelineCache {
                         vertex: wgpu::VertexState {
                             module: &info.vs,
                             entry_point: &info.vs_entry,
+                            compilation_options: wgpu::PipelineCompilationOptions::default(),
                             buffers: if info.vertices { &vertex_buffers } else { &[] },
                         },
                         primitive: wgpu::PrimitiveState {
@@ -78,6 +79,7 @@ impl PipelineCache {
                         fragment: Some(wgpu::FragmentState {
                             module: &info.fs,
                             entry_point: &info.fs_entry,
+                            compilation_options: wgpu::PipelineCompilationOptions::default(),
                             targets: &[Some(wgpu::ColorTargetState {
                                 format: info.format,
                                 blend: info.blend,
@@ -85,6 +87,7 @@ impl PipelineCache {
                             })],
                         }),
                         multiview: None,
+                        cache: None,
                     },
                 ))
             })

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -140,7 +140,7 @@ impl Image {
             pixels,
             wgpu::ImageDataLayout {
                 offset: 0,
-                bytes_per_row: Some(format.block_size(None).unwrap() * width), // Unwrap since it only fails with depth formats.
+                bytes_per_row: Some(format.block_copy_size(None).unwrap() * width), // Unwrap since it only fails with depth formats.
                 rows_per_image: None,
             },
             wgpu::Extent3d {
@@ -249,7 +249,7 @@ impl Image {
             )));
         }
 
-        let block_size = u64::from(self.format.block_size(None).unwrap()); // Unwrap since it only fails with depth formats.
+        let block_size = u64::from(self.format.block_copy_size(None).unwrap()); // Unwrap since it only fails with depth formats.
 
         let bytes_per_pixel = block_size;
         let unpadded_bytes_per_row = self.width as usize * bytes_per_pixel as usize;

--- a/src/graphics/mesh3d.rs
+++ b/src/graphics/mesh3d.rs
@@ -785,8 +785,9 @@ impl<I: FromPrimitive> obj::FromRawVertex<I> for Vertex3d {
             let mut map = |pi: usize| -> obj::ObjResult<()> {
                 inds.push(match I::from_usize(pi) {
                     Some(val) => val,
+                    #[allow(deprecated)]
                     None => {
-                        return obj::ObjResult::Err(obj::ObjError::Load(obj::LoadError::new(
+                        return Err(obj::ObjError::Load(obj::LoadError::new(
                             obj::LoadErrorKind::IndexOutOfRange,
                             "Unable to convert the index from usize",
                         )));
@@ -815,6 +816,7 @@ impl<I: FromPrimitive> obj::FromRawVertex<I> for Vertex3d {
                             map(pi)?
                         }
                     }
+                    #[allow(deprecated)]
                     _ => {
                         return Err(obj::ObjError::Load(obj::LoadError::new(
                             obj::LoadErrorKind::UntriangulatedModel,

--- a/src/graphics/mesh3d.rs
+++ b/src/graphics/mesh3d.rs
@@ -687,12 +687,12 @@ impl Mesh3d {
             minimum = minimum.min(Vec3::from_array(p.pos));
             maximum = maximum.max(Vec3::from_array(p.pos));
         }
-        if minimum.x != std::f32::MAX
-            && minimum.y != std::f32::MAX
-            && minimum.z != std::f32::MAX
-            && maximum.x != std::f32::MIN
-            && maximum.y != std::f32::MIN
-            && maximum.z != std::f32::MIN
+        if minimum.x != f32::MAX
+            && minimum.y != f32::MAX
+            && minimum.z != f32::MAX
+            && maximum.x != f32::MIN
+            && maximum.y != f32::MIN
+            && maximum.z != f32::MIN
         {
             self.aabb = Some(Aabb::from_min_max(minimum, maximum))
         } else {
@@ -1175,12 +1175,12 @@ impl Model {
                 maximum = maximum.max(Vec3::from_array(p.pos));
             }
         }
-        if minimum.x != std::f32::MAX
-            && minimum.y != std::f32::MAX
-            && minimum.z != std::f32::MAX
-            && maximum.x != std::f32::MIN
-            && maximum.y != std::f32::MIN
-            && maximum.z != std::f32::MIN
+        if minimum.x != f32::MAX
+            && minimum.y != f32::MAX
+            && minimum.z != f32::MAX
+            && maximum.x != f32::MIN
+            && maximum.y != f32::MIN
+            && maximum.z != f32::MIN
         {
             self.aabb = Some(Aabb::from_min_max(minimum, maximum))
         } else {

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -17,7 +17,7 @@
 //! characters to their physical location on the keyboard.
 //!
 //! In general, logical keys should be used when the meaning of the typed
-//! character is important (e.g. "I" to open the inventory), and physical keys 
+//! character is important (e.g. "I" to open the inventory), and physical keys
 //! for when the location is important (e.g. the WASD key block).
 //!
 //! -----

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,7 @@ extern crate log;
 
 pub use glam;
 pub use mint;
+pub use winit;
 
 pub mod audio;
 pub mod conf;
@@ -208,5 +209,5 @@ mod vfs;
 pub mod coroutine;
 pub use crate::coroutine::Coroutine;
 
-pub use crate::context::{winit, Context, ContextBuilder};
+pub use crate::context::{Context, ContextBuilder};
 pub use crate::error::*;


### PR DESCRIPTION
In 0.29, `winit` overhauled their keyboard API, upon which `ggez` relies. Rather than try to hide these changes from the `ggez` end user, this commit refactors `ggez::keyboard` to use the `winit` types.

`wgpu` 22.1.0 contains fewer changes relevant to the `ggez` end user, but the most important is that the `Window` in `GraphicsContext` is now wrapped in an `Arc` to take advantage of the new safe `create_surface`.
