### PR TITLE
Update winit to 0.30 (take 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 directories = "5.0"
 wgpu = "23"
 glyph_brush = "0.7"
-winit = { version = "0.29", features = ["serde"] }
+winit = { version = "0.30", features = ["serde"] }
 image = { version = "0.25", default-features = false, features = ["gif", "png", "pnm", "tga", "tiff", "webp", "bmp", "jpeg"] }
 rodio = { version = "0.20", optional = true, default-features = false, features = ["flac", "vorbis", "wav"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -10,95 +10,125 @@
 //! It is functionally identical to the `super_simple.rs` example apart from that.
 
 use ggez::graphics::{self, Color, DrawMode};
+use ggez::Context;
 use ggez::GameResult;
 use ggez::{event, GameError};
 
-use winit::event::{Event, WindowEvent};
-use winit::event_loop::ControlFlow;
+use winit::application::ApplicationHandler;
+use winit::event::{DeviceEvent, DeviceId, StartCause, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, ControlFlow};
 use winit::keyboard::{Key, NamedKey};
+use winit::window::WindowId;
+
+struct CustomApplicationHandler {
+    ctx: Context,
+    position: f32,
+}
+
+impl ApplicationHandler<()> for CustomApplicationHandler {
+    fn new_events(&mut self, event_loop: &ActiveEventLoop, _: StartCause) {
+        if self.ctx.fields.quit_requested {
+            self.ctx.fields.continuing = false;
+        }
+        if !self.ctx.fields.continuing {
+            event_loop.exit();
+            return;
+        }
+
+        event_loop.set_control_flow(ControlFlow::Poll);
+    }
+
+    fn resumed(&mut self, _event_loop: &ActiveEventLoop) {}
+
+    fn window_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        mut window_id: WindowId,
+        mut event: WindowEvent,
+    ) {
+        // This tells `ggez` to update it's internal states, should the event require that.
+        // These include cursor position, view updating on resize, etc.
+        event::process_window_event(&mut self.ctx, &mut window_id, &mut event);
+
+        match event {
+            WindowEvent::CloseRequested => {
+                self.ctx.request_quit();
+            }
+            WindowEvent::KeyboardInput { event, .. } => {
+                if Key::Named(NamedKey::Escape) == event.logical_key {
+                    self.ctx.request_quit();
+                }
+            }
+            // `CloseRequested` and `KeyboardInput` events won't appear here.
+            x => println!("Other window event fired: {x:?}"),
+        }
+    }
+
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        mut device_id: DeviceId,
+        mut event: DeviceEvent,
+    ) {
+        // This tells `ggez` to update it's internal states, should the event require that.
+        // These include cursor position, view updating on resize, etc.
+        event::process_device_event(&mut self.ctx, &mut device_id, &mut event);
+
+        println!("Device event fired: {event:?}");
+    }
+
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        // Tell the timer stuff a frame has happened.
+        // Without this the FPS timer functions and such won't work.
+        self.ctx.time.tick();
+
+        // Update
+        self.position += 1.0;
+
+        // Draw
+        self.ctx.gfx.begin_frame().unwrap();
+
+        let mut canvas =
+            graphics::Canvas::from_frame(&self.ctx, graphics::Color::from([0.1, 0.2, 0.3, 1.0]));
+
+        let circle = graphics::Mesh::new_circle(
+            &self.ctx,
+            DrawMode::fill(),
+            ggez::glam::Vec2::new(0.0, 0.0),
+            100.0,
+            2.0,
+            Color::WHITE,
+        )
+        .unwrap();
+        canvas.draw(&circle, ggez::glam::Vec2::new(self.position, 380.0));
+
+        canvas.finish(&mut self.ctx).unwrap();
+        self.ctx.gfx.end_frame().unwrap();
+
+        // reset the mouse delta for the next frame
+        // necessary because it's calculated cumulatively each cycle
+        self.ctx.mouse.reset_delta();
+
+        // Copy the state of the keyboard into the KeyboardContext and
+        // the mouse into the MouseContext.
+        // Not required for this example but important if you want to
+        // use the functions keyboard::is_key_just_pressed/released and
+        // mouse::is_button_just_pressed/released.
+        self.ctx.keyboard.save_keyboard_state();
+        self.ctx.mouse.save_mouse_state();
+
+        ggez::timer::yield_now();
+    }
+}
 
 pub fn main() -> GameResult {
     let cb = ggez::ContextBuilder::new("eventloop", "ggez");
-    let (mut ctx, events_loop) = cb.build()?;
+    let (ctx, events_loop) = cb.build()?;
 
-    let mut position: f32 = 1.0;
+    let mut app = CustomApplicationHandler { ctx, position: 1.0 };
 
     // Handle events. Refer to `winit` docs for more information.
     events_loop
-        .run(move |mut event, window_target| {
-            let ctx = &mut ctx;
-
-            if ctx.fields.quit_requested {
-                ctx.fields.continuing = false;
-            }
-            if !ctx.fields.continuing {
-                window_target.exit();
-                return;
-            }
-
-            window_target.set_control_flow(ControlFlow::Poll);
-
-            // This tells `ggez` to update it's internal states, should the event require that.
-            // These include cursor position, view updating on resize, etc.
-            event::process_event(ctx, &mut event);
-            match event {
-                Event::WindowEvent { event, .. } => match event {
-                    WindowEvent::CloseRequested => ctx.request_quit(),
-                    WindowEvent::KeyboardInput { event, .. } => {
-                        if Key::Named(NamedKey::Escape) == event.logical_key {
-                            ctx.request_quit();
-                        }
-                    }
-                    // `CloseRequested` and `KeyboardInput` events won't appear here.
-                    x => println!("Other window event fired: {x:?}"),
-                },
-                Event::AboutToWait => {
-                    // Tell the timer stuff a frame has happened.
-                    // Without this the FPS timer functions and such won't work.
-                    ctx.time.tick();
-
-                    // Update
-                    position += 1.0;
-
-                    // Draw
-                    ctx.gfx.begin_frame().unwrap();
-
-                    let mut canvas = graphics::Canvas::from_frame(
-                        ctx,
-                        graphics::Color::from([0.1, 0.2, 0.3, 1.0]),
-                    );
-
-                    let circle = graphics::Mesh::new_circle(
-                        ctx,
-                        DrawMode::fill(),
-                        ggez::glam::Vec2::new(0.0, 0.0),
-                        100.0,
-                        2.0,
-                        Color::WHITE,
-                    )
-                    .unwrap();
-                    canvas.draw(&circle, ggez::glam::Vec2::new(position, 380.0));
-
-                    canvas.finish(ctx).unwrap();
-                    ctx.gfx.end_frame().unwrap();
-
-                    // reset the mouse delta for the next frame
-                    // necessary because it's calculated cumulatively each cycle
-                    ctx.mouse.reset_delta();
-
-                    // Copy the state of the keyboard into the KeyboardContext and
-                    // the mouse into the MouseContext.
-                    // Not required for this example but important if you want to
-                    // use the functions keyboard::is_key_just_pressed/released and
-                    // mouse::is_button_just_pressed/released.
-                    ctx.keyboard.save_keyboard_state();
-                    ctx.mouse.save_mouse_state();
-
-                    ggez::timer::yield_now();
-                }
-
-                x => println!("Device event fired: {x:?}"),
-            }
-        })
+        .run_app(&mut app)
         .map_err(GameError::EventLoopError)
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -709,7 +709,11 @@ where
     };
 }
 
-pub(crate) fn process_device_event<C>(ctx: &mut C, _: &mut DeviceId, event: &mut DeviceEvent)
+/// Feeds a `DeviceEvent` into the `Context` so it can update any internal
+/// state it needs to, such as detecting mouse movements.  If you are
+/// rolling your own event loop, you should call this on the events you
+/// receive before processing them yourself.
+pub fn process_device_event<C>(ctx: &mut C, _: &mut DeviceId, event: &mut DeviceEvent)
 where
     C: HasMut<ContextFields>
         + HasMut<GraphicsContext>
@@ -722,7 +726,11 @@ where
     }
 }
 
-pub(crate) fn process_window_event<C>(ctx: &mut C, _: &mut WindowId, event: &mut WindowEvent)
+/// Feeds a `WindowEvent` into the `Context` so it can update any internal
+/// state it needs to, such as detecting window resizes.  If you are
+/// rolling your own event loop, you should call this on the events you
+/// receive before processing them yourself.
+pub fn process_window_event<C>(ctx: &mut C, _: &mut WindowId, event: &mut WindowEvent)
 where
     C: HasMut<ContextFields>
         + HasMut<GraphicsContext>

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,10 +10,11 @@
 //! source code for this module, or the [`eventloop`
 //! example](https://github.com/ggez/ggez/blob/master/examples/eventloop.rs).
 
+use std::marker::PhantomData;
 use winit::{
     dpi,
     event::{ElementState, Event, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent},
-    event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+    event_loop::{ControlFlow, EventLoop},
     keyboard::{Key, NamedKey},
 };
 
@@ -31,6 +32,10 @@ use crate::input::gamepad::GamepadContext;
 pub use crate::input::gamepad::GamepadId;
 #[cfg(feature = "gamepad")]
 pub use gilrs::{Axis, Button};
+use winit::application::ApplicationHandler;
+use winit::event::{DeviceEvent, DeviceId, StartCause};
+use winit::event_loop::ActiveEventLoop;
+use winit::window::WindowId;
 
 /// Used in [`EventHandler::on_error()`](trait.EventHandler.html#method.on_error)
 /// to specify where an error originated
@@ -265,8 +270,30 @@ where
 ///
 /// It does not try to do any type of framerate limiting.  See the
 /// documentation for the [`timer`](../timer/index.html) module for more info.
-#[allow(clippy::needless_return)] // necessary as the returns used here are actually necessary to break early from the event loop
-pub fn run<S, C, E>(mut ctx: C, event_loop: EventLoop<()>, mut state: S) -> GameResult
+pub fn run<S, C, E>(ctx: C, event_loop: EventLoop<()>, state: S) -> GameResult
+where
+    S: EventHandler<C, E> + 'static,
+    E: 'static + std::fmt::Debug,
+    C: 'static
+        + HasMut<ContextFields>
+        + HasMut<GraphicsContext>
+        + HasMut<input::keyboard::KeyboardContext>
+        + HasMut<input::mouse::MouseContext>
+        + HasMut<GamepadContext>
+        + HasMut<crate::timer::TimeContext>,
+{
+    let mut app = GgezApplicationHandler {
+        ctx,
+        state,
+        _p: PhantomData,
+    };
+
+    event_loop
+        .run_app(&mut app)
+        .map_err(GameError::EventLoopError)
+}
+
+struct GgezApplicationHandler<S, C, E>
 where
     S: EventHandler<C, E> + 'static,
     E: std::fmt::Debug,
@@ -278,314 +305,372 @@ where
         + HasMut<GamepadContext>
         + HasMut<crate::timer::TimeContext>,
 {
-    event_loop
-        .run(move |mut event, window_target| {
-            let ctx = &mut ctx;
-            let state = &mut state;
+    ctx: C,
+    state: S,
+    _p: PhantomData<E>,
+}
 
-            if HasMut::<ContextFields>::retrieve_mut(ctx).quit_requested {
-                let res = state.quit_event(ctx);
-                HasMut::<ContextFields>::retrieve_mut(ctx).quit_requested = false;
+impl<S, C, E> ApplicationHandler<()> for GgezApplicationHandler<S, C, E>
+where
+    S: EventHandler<C, E> + 'static,
+    E: std::fmt::Debug,
+    C: 'static
+        + HasMut<ContextFields>
+        + HasMut<GraphicsContext>
+        + HasMut<input::keyboard::KeyboardContext>
+        + HasMut<input::mouse::MouseContext>
+        + HasMut<GamepadContext>
+        + HasMut<crate::timer::TimeContext>,
+{
+    fn new_events(&mut self, event_loop: &ActiveEventLoop, _: StartCause) {
+        if HasMut::<ContextFields>::retrieve_mut(&mut self.ctx).quit_requested {
+            let res = self.state.quit_event(&mut self.ctx);
+            HasMut::<ContextFields>::retrieve_mut(&mut self.ctx).quit_requested = false;
+            if let Ok(false) = res {
+                HasMut::<ContextFields>::retrieve_mut(&mut self.ctx).continuing = false;
+            } else if catch_error(
+                &mut self.ctx,
+                res,
+                &mut self.state,
+                event_loop,
+                ErrorOrigin::QuitEvent,
+            ) {
+                event_loop.exit();
+            }
+        }
+        if !HasMut::<ContextFields>::retrieve_mut(&mut self.ctx).continuing {
+            event_loop.exit();
+            return;
+        }
+
+        event_loop.set_control_flow(ControlFlow::Poll);
+    }
+    fn resumed(&mut self, _event_loop: &ActiveEventLoop) {
+        // TODO create window
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        mut window_id: WindowId,
+        mut event: WindowEvent,
+    ) {
+        process_window_event(&mut self.ctx, &mut window_id, &mut event);
+
+        match event {
+            WindowEvent::Resized(logical_size) => {
+                let res = self.state.resize_event(
+                    &mut self.ctx,
+                    logical_size.width as f32,
+                    logical_size.height as f32,
+                );
+                if catch_error(
+                    &mut self.ctx,
+                    res,
+                    &mut self.state,
+                    event_loop,
+                    ErrorOrigin::ResizeEvent,
+                ) {}
+            }
+            WindowEvent::CloseRequested => {
+                let res = self.state.quit_event(&mut self.ctx);
                 if let Ok(false) = res {
-                    HasMut::<ContextFields>::retrieve_mut(ctx).continuing = false;
-                } else if catch_error(ctx, res, state, window_target, ErrorOrigin::QuitEvent) {
-                    return;
+                    HasMut::<ContextFields>::retrieve_mut(&mut self.ctx).continuing = false;
+                } else if catch_error(
+                    &mut self.ctx,
+                    res,
+                    &mut self.state,
+                    event_loop,
+                    ErrorOrigin::QuitEvent,
+                ) {
                 }
             }
-            if !HasMut::<ContextFields>::retrieve_mut(ctx).continuing {
-                window_target.exit();
-                return;
+            WindowEvent::Focused(gained) => {
+                let res = self.state.focus_event(&mut self.ctx, gained);
+                if catch_error(
+                    &mut self.ctx,
+                    res,
+                    &mut self.state,
+                    event_loop,
+                    ErrorOrigin::FocusEvent,
+                ) {}
             }
+            WindowEvent::ModifiersChanged(modifiers) => {
+                HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(&mut self.ctx)
+                    .active_modifiers = modifiers.state()
+            }
+            WindowEvent::KeyboardInput { event, .. } => {
+                let mods = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(&mut self.ctx)
+                    .active_modifiers;
 
-            window_target.set_control_flow(ControlFlow::Poll);
-
-            process_event(ctx, &mut event);
-            match event {
-                Event::WindowEvent { event, .. } => match event {
-                    WindowEvent::Resized(logical_size) => {
-                        let res = state.resize_event(
-                            ctx,
-                            logical_size.width as f32,
-                            logical_size.height as f32,
+                let repeat =
+                    HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(&mut self.ctx)
+                        .is_key_repeated();
+                let key_state = event.state;
+                let input = KeyInput { event, mods };
+                let (res, origin) = match key_state {
+                    ElementState::Pressed => (
+                        self.state.key_down_event(&mut self.ctx, input, repeat),
+                        ErrorOrigin::KeyDownEvent,
+                    ),
+                    ElementState::Released => (
+                        self.state.key_up_event(&mut self.ctx, input),
+                        ErrorOrigin::KeyUpEvent,
+                    ),
+                };
+                if catch_error(&mut self.ctx, res, &mut self.state, event_loop, origin) {}
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                let gfx = HasMut::<GraphicsContext>::retrieve_mut(&mut self.ctx);
+                let (x, y) = match delta {
+                    MouseScrollDelta::LineDelta(x, y) => (x, y),
+                    MouseScrollDelta::PixelDelta(pos) => {
+                        let scale_factor = gfx.window.scale_factor();
+                        let dpi::LogicalPosition { x, y } = pos.to_logical::<f32>(scale_factor);
+                        (x, y)
+                    }
+                };
+                let res = self.state.mouse_wheel_event(&mut self.ctx, x, y);
+                if catch_error(
+                    &mut self.ctx,
+                    res,
+                    &mut self.state,
+                    event_loop,
+                    ErrorOrigin::MouseWheelEvent,
+                ) {}
+            }
+            WindowEvent::MouseInput {
+                state: element_state,
+                button,
+                ..
+            } => {
+                let position =
+                    HasMut::<input::mouse::MouseContext>::retrieve_mut(&mut self.ctx).position();
+                match element_state {
+                    ElementState::Pressed => {
+                        let res = self.state.mouse_button_down_event(
+                            &mut self.ctx,
+                            button,
+                            position.x,
+                            position.y,
                         );
-                        if catch_error(ctx, res, state, window_target, ErrorOrigin::ResizeEvent) {
-                            return;
-                        };
-                    }
-                    WindowEvent::CloseRequested => {
-                        let res = state.quit_event(ctx);
-                        if let Ok(false) = res {
-                            HasMut::<ContextFields>::retrieve_mut(ctx).continuing = false;
-                        } else if catch_error(
-                            ctx,
-                            res,
-                            state,
-                            window_target,
-                            ErrorOrigin::QuitEvent,
-                        ) {
-                            return;
-                        }
-                    }
-                    WindowEvent::Focused(gained) => {
-                        let res = state.focus_event(ctx, gained);
-                        if catch_error(ctx, res, state, window_target, ErrorOrigin::FocusEvent) {
-                            return;
-                        };
-                    }
-                    WindowEvent::ModifiersChanged(mods) => {
-                        HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx)
-                            .active_modifiers = mods.state()
-                    }
-                    WindowEvent::KeyboardInput { event, .. } => {
-                        let mods = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx)
-                            .active_modifiers;
-
-                        let repeat = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx)
-                            .is_key_repeated();
-                        let key_state = event.state;
-                        let input = KeyInput { event, mods };
-                        let (res, origin) = match key_state {
-                            ElementState::Pressed => (
-                                state.key_down_event(ctx, input, repeat),
-                                ErrorOrigin::KeyDownEvent,
-                            ),
-                            ElementState::Released => {
-                                (state.key_up_event(ctx, input), ErrorOrigin::KeyUpEvent)
-                            }
-                        };
-                        if catch_error(ctx, res, state, window_target, origin) {
-                            return;
-                        };
-                    }
-                    WindowEvent::MouseWheel { delta, .. } => {
-                        let gfx = HasMut::<GraphicsContext>::retrieve_mut(ctx);
-                        let (x, y) = match delta {
-                            MouseScrollDelta::LineDelta(x, y) => (x, y),
-                            MouseScrollDelta::PixelDelta(pos) => {
-                                let scale_factor = gfx.window.scale_factor();
-                                let dpi::LogicalPosition { x, y } =
-                                    pos.to_logical::<f32>(scale_factor);
-                                (x, y)
-                            }
-                        };
-                        let res = state.mouse_wheel_event(ctx, x, y);
-                        if catch_error(ctx, res, state, window_target, ErrorOrigin::MouseWheelEvent)
-                        {
-                            return;
-                        };
-                    }
-                    WindowEvent::MouseInput {
-                        state: element_state,
-                        button,
-                        ..
-                    } => {
-                        let position =
-                            HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).position();
-                        match element_state {
-                            ElementState::Pressed => {
-                                let res = state
-                                    .mouse_button_down_event(ctx, button, position.x, position.y);
-                                if catch_error(
-                                    ctx,
-                                    res,
-                                    state,
-                                    window_target,
-                                    ErrorOrigin::MouseButtonDownEvent,
-                                ) {
-                                    return;
-                                };
-                            }
-                            ElementState::Released => {
-                                let res = state
-                                    .mouse_button_up_event(ctx, button, position.x, position.y);
-                                if catch_error(
-                                    ctx,
-                                    res,
-                                    state,
-                                    window_target,
-                                    ErrorOrigin::MouseButtonUpEvent,
-                                ) {
-                                    return;
-                                };
-                            }
-                        }
-                    }
-                    WindowEvent::CursorMoved { .. } => {
-                        let position =
-                            HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).position();
-                        let delta =
-                            HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).last_delta();
-                        let res =
-                            state.mouse_motion_event(ctx, position.x, position.y, delta.x, delta.y);
                         if catch_error(
-                            ctx,
+                            &mut self.ctx,
                             res,
-                            state,
-                            window_target,
-                            ErrorOrigin::MouseMotionEvent,
-                        ) {
-                            return;
-                        };
+                            &mut self.state,
+                            event_loop,
+                            ErrorOrigin::MouseButtonDownEvent,
+                        ) {}
                     }
-                    WindowEvent::Touch(touch) => {
-                        let res =
-                            state.touch_event(ctx, touch.phase, touch.location.x, touch.location.y);
-                        if catch_error(ctx, res, state, window_target, ErrorOrigin::TouchEvent) {
-                            return;
-                        };
-                    }
-                    WindowEvent::CursorEntered { device_id: _ } => {
-                        let res = state.mouse_enter_or_leave(ctx, true);
+                    ElementState::Released => {
+                        let res = self.state.mouse_button_up_event(
+                            &mut self.ctx,
+                            button,
+                            position.x,
+                            position.y,
+                        );
                         if catch_error(
-                            ctx,
+                            &mut self.ctx,
                             res,
-                            state,
-                            window_target,
-                            ErrorOrigin::MouseEnterOrLeave,
-                        ) {
-                            return;
-                        }
-                    }
-                    WindowEvent::CursorLeft { device_id: _ } => {
-                        let res = state.mouse_enter_or_leave(ctx, false);
-                        if catch_error(
-                            ctx,
-                            res,
-                            state,
-                            window_target,
-                            ErrorOrigin::MouseEnterOrLeave,
-                        ) {
-                            return;
-                        }
-                    }
-                    _x => {
-                        // trace!("ignoring window event {:?}", x);
-                    }
-                },
-                Event::DeviceEvent {
-                    device_id: _,
-                    event,
-                } => {
-                    if let winit::event::DeviceEvent::MouseMotion { delta } = event {
-                        let res = state.raw_mouse_motion_event(ctx, delta.0, delta.0);
-                        if catch_error(
-                            ctx,
-                            res,
-                            state,
-                            window_target,
-                            ErrorOrigin::RawMouseMotionEvent,
-                        ) {
-                            return;
-                        }
+                            &mut self.state,
+                            event_loop,
+                            ErrorOrigin::MouseButtonUpEvent,
+                        ) {}
                     }
                 }
-                Event::Resumed => (),
-                Event::Suspended => (),
-                Event::NewEvents(_) => (),
-                Event::UserEvent(_) => (),
-                Event::AboutToWait => {
-                    // If you are writing your own event loop, make sure
-                    // you include `timer_context.tick()` and
-                    // `ctx.process_event()` calls.  These update ggez's
-                    // internal state however necessary.
-                    let time = HasMut::<crate::timer::TimeContext>::retrieve_mut(ctx);
-                    time.tick();
+            }
+            WindowEvent::CursorMoved { .. } => {
+                let position =
+                    HasMut::<input::mouse::MouseContext>::retrieve_mut(&mut self.ctx).position();
+                let delta =
+                    HasMut::<input::mouse::MouseContext>::retrieve_mut(&mut self.ctx).last_delta();
+                let res = self.state.mouse_motion_event(
+                    &mut self.ctx,
+                    position.x,
+                    position.y,
+                    delta.x,
+                    delta.y,
+                );
+                if catch_error(
+                    &mut self.ctx,
+                    res,
+                    &mut self.state,
+                    event_loop,
+                    ErrorOrigin::MouseMotionEvent,
+                ) {}
+            }
+            WindowEvent::Touch(touch) => {
+                let res = self.state.touch_event(
+                    &mut self.ctx,
+                    touch.phase,
+                    touch.location.x,
+                    touch.location.y,
+                );
+                if catch_error(
+                    &mut self.ctx,
+                    res,
+                    &mut self.state,
+                    event_loop,
+                    ErrorOrigin::TouchEvent,
+                ) {}
+            }
+            WindowEvent::CursorEntered { device_id: _ } => {
+                let res = self.state.mouse_enter_or_leave(&mut self.ctx, true);
+                if catch_error(
+                    &mut self.ctx,
+                    res,
+                    &mut self.state,
+                    event_loop,
+                    ErrorOrigin::MouseEnterOrLeave,
+                ) {}
+            }
+            WindowEvent::CursorLeft { device_id: _ } => {
+                let res = self.state.mouse_enter_or_leave(&mut self.ctx, false);
+                if catch_error(
+                    &mut self.ctx,
+                    res,
+                    &mut self.state,
+                    event_loop,
+                    ErrorOrigin::MouseEnterOrLeave,
+                ) {}
+            }
+            _x => {
+                // trace!("ignoring window event {:?}", x);
+            }
+        }
+    }
 
-                    // Handle gamepad events if necessary.
-                    #[cfg(feature = "gamepad")]
-                    while let Some(gilrs::Event { id, event, .. }) =
-                        HasMut::<input::gamepad::GamepadContext>::retrieve_mut(ctx).next_event()
-                    {
-                        match event {
-                            gilrs::EventType::ButtonPressed(button, _) => {
-                                let res =
-                                    state.gamepad_button_down_event(ctx, button, GamepadId(id));
-                                if catch_error(
-                                    ctx,
-                                    res,
-                                    state,
-                                    window_target,
-                                    ErrorOrigin::GamepadButtonDownEvent,
-                                ) {
-                                    return;
-                                };
-                            }
-                            gilrs::EventType::ButtonReleased(button, _) => {
-                                let res = state.gamepad_button_up_event(ctx, button, GamepadId(id));
-                                if catch_error(
-                                    ctx,
-                                    res,
-                                    state,
-                                    window_target,
-                                    ErrorOrigin::GamepadButtonUpEvent,
-                                ) {
-                                    return;
-                                };
-                            }
-                            gilrs::EventType::AxisChanged(axis, value, _) => {
-                                let res = state.gamepad_axis_event(ctx, axis, value, GamepadId(id));
-                                if catch_error(
-                                    ctx,
-                                    res,
-                                    state,
-                                    window_target,
-                                    ErrorOrigin::GamepadAxisEvent,
-                                ) {
-                                    return;
-                                };
-                            }
-                            _ => {}
-                        }
-                    }
+    fn device_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        mut device_id: DeviceId,
+        mut event: DeviceEvent,
+    ) {
+        process_device_event(&mut self.ctx, &mut device_id, &mut event);
 
-                    let res = state.update(ctx);
-                    if catch_error(ctx, res, state, window_target, ErrorOrigin::Update) {
+        if let DeviceEvent::MouseMotion { delta } = event {
+            let res = self
+                .state
+                .raw_mouse_motion_event(&mut self.ctx, delta.0, delta.0);
+            if catch_error(
+                &mut self.ctx,
+                res,
+                &mut self.state,
+                event_loop,
+                ErrorOrigin::RawMouseMotionEvent,
+            ) {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        // If you are writing your own event loop, make sure
+        // you include `timer_context.tick()` and
+        // `ctx.process_event()` calls.  These update ggez's
+        // internal state however necessary.
+        let time = HasMut::<crate::timer::TimeContext>::retrieve_mut(&mut self.ctx);
+        time.tick();
+
+        // Handle gamepad events if necessary.
+        #[cfg(feature = "gamepad")]
+        while let Some(gilrs::Event { id, event, .. }) =
+            HasMut::<input::gamepad::GamepadContext>::retrieve_mut(&mut self.ctx).next_event()
+        {
+            match event {
+                gilrs::EventType::ButtonPressed(button, _) => {
+                    let res =
+                        self.state
+                            .gamepad_button_down_event(&mut self.ctx, button, GamepadId(id));
+                    if catch_error(
+                        &mut self.ctx,
+                        res,
+                        &mut self.state,
+                        event_loop,
+                        ErrorOrigin::GamepadButtonDownEvent,
+                    ) {
                         return;
                     };
-
-                    if let Err(e) = HasMut::<GraphicsContext>::retrieve_mut(ctx).begin_frame() {
-                        error!("Error on GraphicsContext::begin_frame(): {e:?}");
-                        eprintln!("Error on GraphicsContext::begin_frame(): {e:?}");
-                        window_target.exit();
-                    }
-
-                    if let Err(e) = state.draw(ctx) {
-                        error!("Error on EventHandler::draw(): {e:?}");
-                        eprintln!("Error on EventHandler::draw(): {e:?}");
-                        if state.on_error(ctx, ErrorOrigin::Draw, e) {
-                            window_target.exit();
-                            return;
-                        }
-                    }
-
-                    if let Err(e) = HasMut::<GraphicsContext>::retrieve_mut(ctx).end_frame() {
-                        error!("Error on GraphicsContext::end_frame(): {e:?}");
-                        eprintln!("Error on GraphicsContext::end_frame(): {e:?}");
-                        window_target.exit();
-                    }
-
-                    // reset the mouse delta for the next frame
-                    // necessary because it's calculated cumulatively each cycle
-                    HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).reset_delta();
-
-                    // Copy the state of the keyboard into the KeyboardContext
-                    // and the mouse into the MouseContext
-                    HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx)
-                        .save_keyboard_state();
-                    HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx).save_mouse_state();
                 }
-                Event::LoopExiting => (),
-                Event::MemoryWarning => (),
+                gilrs::EventType::ButtonReleased(button, _) => {
+                    let res =
+                        self.state
+                            .gamepad_button_up_event(&mut self.ctx, button, GamepadId(id));
+                    if catch_error(
+                        &mut self.ctx,
+                        res,
+                        &mut self.state,
+                        event_loop,
+                        ErrorOrigin::GamepadButtonUpEvent,
+                    ) {
+                        return;
+                    };
+                }
+                gilrs::EventType::AxisChanged(axis, value, _) => {
+                    let res =
+                        self.state
+                            .gamepad_axis_event(&mut self.ctx, axis, value, GamepadId(id));
+                    if catch_error(
+                        &mut self.ctx,
+                        res,
+                        &mut self.state,
+                        event_loop,
+                        ErrorOrigin::GamepadAxisEvent,
+                    ) {
+                        return;
+                    };
+                }
+                _ => {}
             }
-        })
-        .map_err(GameError::EventLoopError)
+        }
+
+        let res = self.state.update(&mut self.ctx);
+        if catch_error(
+            &mut self.ctx,
+            res,
+            &mut self.state,
+            event_loop,
+            ErrorOrigin::Update,
+        ) {
+            return;
+        };
+
+        if let Err(e) = HasMut::<GraphicsContext>::retrieve_mut(&mut self.ctx).begin_frame() {
+            error!("Error on GraphicsContext::begin_frame(): {e:?}");
+            eprintln!("Error on GraphicsContext::begin_frame(): {e:?}");
+            event_loop.exit();
+        }
+
+        if let Err(e) = self.state.draw(&mut self.ctx) {
+            error!("Error on EventHandler::draw(): {e:?}");
+            eprintln!("Error on EventHandler::draw(): {e:?}");
+            if self.state.on_error(&mut self.ctx, ErrorOrigin::Draw, e) {
+                event_loop.exit();
+                return;
+            }
+        }
+
+        if let Err(e) = HasMut::<GraphicsContext>::retrieve_mut(&mut self.ctx).end_frame() {
+            error!("Error on GraphicsContext::end_frame(): {e:?}");
+            eprintln!("Error on GraphicsContext::end_frame(): {e:?}");
+            event_loop.exit();
+        }
+
+        // reset the mouse delta for the next frame
+        // necessary because it's calculated cumulatively each cycle
+        HasMut::<input::mouse::MouseContext>::retrieve_mut(&mut self.ctx).reset_delta();
+
+        // Copy the state of the keyboard into the KeyboardContext
+        // and the mouse into the MouseContext
+        HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(&mut self.ctx)
+            .save_keyboard_state();
+        HasMut::<input::mouse::MouseContext>::retrieve_mut(&mut self.ctx).save_mouse_state();
+    }
 }
 
 fn catch_error<T, C, E, S>(
     ctx: &mut C,
     event_result: Result<T, E>,
     state: &mut S,
-    window_target: &EventLoopWindowTarget<()>,
+    event_loop: &ActiveEventLoop,
     origin: ErrorOrigin,
 ) -> bool
 where
@@ -597,7 +682,7 @@ where
         error!("Error on EventHandler {origin:?}: {e:?}");
         eprintln!("Error on EventHandler {origin:?}: {e:?}");
         if state.on_error(ctx, origin, e) {
-            window_target.exit();
+            event_loop.exit();
             return true;
         }
     }
@@ -615,61 +700,79 @@ where
         + HasMut<input::keyboard::KeyboardContext>
         + HasMut<input::mouse::MouseContext>,
 {
-    if let Event::DeviceEvent {
-        event: winit::event::DeviceEvent::MouseMotion { delta },
-        ..
-    } = event
-    {
+    if let Event::DeviceEvent { device_id, event } = event {
+        process_device_event(ctx, device_id, event);
+    }
+
+    if let Event::WindowEvent { window_id, event } = event {
+        process_window_event(ctx, window_id, event);
+    };
+}
+
+pub(crate) fn process_device_event<C>(ctx: &mut C, _: &mut DeviceId, event: &mut DeviceEvent)
+where
+    C: HasMut<ContextFields>
+        + HasMut<GraphicsContext>
+        + HasMut<input::keyboard::KeyboardContext>
+        + HasMut<input::mouse::MouseContext>,
+{
+    if let DeviceEvent::MouseMotion { delta } = event {
         let mouse = HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx);
         mouse.handle_motion(delta.0, delta.1);
     }
-    if let Event::WindowEvent { event, .. } = event {
-        match event {
-            WindowEvent::Resized(physical_size) => {
-                let gfx = HasMut::<GraphicsContext>::retrieve_mut(ctx);
-                gfx.resize(*physical_size);
-            }
-            WindowEvent::CursorMoved {
-                position: physical_position,
-                ..
-            } => {
-                let mouse = HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx);
-                mouse.handle_move(physical_position.x as f32, physical_position.y as f32);
-            }
-            WindowEvent::MouseInput { button, state, .. } => {
-                let mouse = HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx);
-                let pressed = match state {
-                    ElementState::Pressed => true,
-                    ElementState::Released => false,
-                };
-                mouse.set_button(*button, pressed);
-            }
-            WindowEvent::ModifiersChanged(mods) => {
-                let keyboard = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx);
-                keyboard.active_modifiers = mods.state();
-            }
-            WindowEvent::KeyboardInput { event, .. } => {
-                let keyboard = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx);
-                let pressed = event.state == ElementState::Pressed;
-                keyboard.set_logical_key(&event.logical_key, pressed);
-                keyboard.set_physical_key(&event.physical_key, pressed);
-            }
-            WindowEvent::ScaleFactorChanged {
-                inner_size_writer, ..
-            } => {
-                let fields = HasMut::<ContextFields>::retrieve_mut(ctx);
-                if !fields.conf.window_mode.resize_on_scale_factor_change {
-                    // actively set the new_inner_size to be the desired size
-                    // to stop winit from resizing our window
-                    let _ = inner_size_writer.request_inner_size(
-                        winit::dpi::PhysicalSize::<u32>::from([
-                            fields.conf.window_mode.width,
-                            fields.conf.window_mode.height,
-                        ]),
-                    );
-                }
-            }
-            _ => (),
+}
+
+pub(crate) fn process_window_event<C>(ctx: &mut C, _: &mut WindowId, event: &mut WindowEvent)
+where
+    C: HasMut<ContextFields>
+        + HasMut<GraphicsContext>
+        + HasMut<input::keyboard::KeyboardContext>
+        + HasMut<input::mouse::MouseContext>,
+{
+    match event {
+        WindowEvent::Resized(physical_size) => {
+            let gfx = HasMut::<GraphicsContext>::retrieve_mut(ctx);
+            gfx.resize(*physical_size);
         }
-    };
+        WindowEvent::CursorMoved {
+            position: physical_position,
+            ..
+        } => {
+            let mouse = HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx);
+            mouse.handle_move(physical_position.x as f32, physical_position.y as f32);
+        }
+        WindowEvent::MouseInput { button, state, .. } => {
+            let mouse = HasMut::<input::mouse::MouseContext>::retrieve_mut(ctx);
+            let pressed = match state {
+                ElementState::Pressed => true,
+                ElementState::Released => false,
+            };
+            mouse.set_button(*button, pressed);
+        }
+        WindowEvent::ModifiersChanged(mods) => {
+            let keyboard = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx);
+            keyboard.active_modifiers = mods.state();
+        }
+        WindowEvent::KeyboardInput { event, .. } => {
+            let keyboard = HasMut::<input::keyboard::KeyboardContext>::retrieve_mut(ctx);
+            let pressed = event.state == ElementState::Pressed;
+            keyboard.set_logical_key(&event.logical_key, pressed);
+            keyboard.set_physical_key(&event.physical_key, pressed);
+        }
+        WindowEvent::ScaleFactorChanged {
+            inner_size_writer, ..
+        } => {
+            let fields = HasMut::<ContextFields>::retrieve_mut(ctx);
+            if !fields.conf.window_mode.resize_on_scale_factor_change {
+                // actively set the new_inner_size to be the desired size
+                // to stop winit from resizing our window
+                let _ =
+                    inner_size_writer.request_inner_size(winit::dpi::PhysicalSize::<u32>::from([
+                        fields.conf.window_mode.width,
+                        fields.conf.window_mode.height,
+                    ]));
+            }
+        }
+        _ => (),
+    }
 }

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -236,7 +236,7 @@ pub fn set_cursor_hidden(ctx: &mut Context, hidden: bool) {
 // TODO: Move to graphics context (This isn't input)
 pub fn set_cursor_type(ctx: &mut Context, cursor_type: CursorIcon) {
     ctx.mouse.cursor_type = cursor_type;
-    ctx.gfx.window.set_cursor_icon(cursor_type);
+    ctx.gfx.window.set_cursor(cursor_type);
 }
 
 /// Get whether or not the mouse is grabbed.


### PR DESCRIPTION
I took the liberty to rebase #1294 onto `devel`. Considerations mentioned there still apply here.

- There should be no warnings anymore
- The custom event-loop example has been updated as well

---

> This code still uses the (now deprecated but not yet removed in 0.30) [EventLoop::create_window](https://docs.rs/winit/latest/x86_64-pc-windows-msvc/winit/event_loop/struct.EventLoop.html#method.create_window) function rather than creating the window inside the new application handler, as is the new winit approach going forward. Removing this deprecated usage will require more structural changes in the wider ggez codebase that I do not feel qualified enough to decide on or implement.

This is still the case. If I understand the design rationale behind winit correctly, creation of the window and initialization of the wgpu context should be done in the application handler (under control by the native event loop) after notified by the system (i.e. in the [`ApplicationHandler::resumed()`](https://docs.rs/winit/latest/winit/application/trait.ApplicationHandler.html#tymethod.resumed) callback).

In case of ggez, it appears to imply that the initialization of the `GraphicsContext` must happen after the event loop is started. This isn't a trivial change right now, as the `GraphicsContext` is tightly coupled to the general ggez `Context`. Possible solutions include:

1. Split creation of the `event_loop` and context initialization, i.e., create the event loop separately from calling `ContextBuilder::build()` and call `::build()` in winit's `resumed()` callback. This has the drawback that the final `ctx` cannot be passed to the user's state initialization (that implements `EventHandler`). This might be tackled by extending the `EventHandler` with a new `init()` function similar to [here](https://github.com/rust-windowing/softbuffer/blob/master/examples/utils/winit_app.rs).
2. Split initialization of `GraphicsContext` from `Context` and allow late initialization in the `resumed()` callback. This brings the ugliness of `Option<GraphicsContext>` and `.unwrap()`.

If there is a clear preference for any approach, I am open to create a PR for it (for further discussion).

---

Furthermore, winit suggests rendering in response to the [WindowEvent::RedrawRequested](https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.RedrawRequested) event instead of in `about_to_wait()`:
> This is not an ideal event to drive application rendering from and instead applications should render in response to [WindowEvent::RedrawRequested](https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.RedrawRequested) events.

This has not changed in this PR, but should be more straight forward than the initialization issue.