### PR TITLE
Remove `Arc` around `wgpu::ShaderModule`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ obj = ["obj-rs", "3d"]
 bitflags = "2.1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 directories = "5.0"
-wgpu = "24"
+wgpu = "24.0.1"
 glyph_brush = "0.7"
 winit = { version = "0.30", features = ["serde"] }
 image = { version = "0.25", default-features = false, features = ["gif", "png", "pnm", "tga", "tiff", "webp", "bmp", "jpeg"] }

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -686,7 +686,7 @@ impl GraphicsContext {
 
             let (bind, layout) = self.bind_group(fcx.present.view, sampler.clone());
 
-            let layout = self.pipeline_cache.layout(&self.wgpu.device, &[layout]);
+            let layout = self.pipeline_cache.layout(&self.wgpu.device, &[&layout]);
             let copy = self.pipeline_cache.render_pipeline(
                 &self.wgpu.device,
                 RenderPipelineInfo {

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -74,19 +74,19 @@ pub struct GraphicsContext {
     pub(crate) staging_belt: wgpu::util::StagingBelt,
     pub(crate) uniform_arena: GrowingBufferArena,
 
-    pub(crate) draw_shader: Arc<wgpu::ShaderModule>,
+    pub(crate) draw_shader: wgpu::ShaderModule,
 
     #[cfg(feature = "3d")]
-    pub(crate) draw_shader_3d: Arc<wgpu::ShaderModule>,
+    pub(crate) draw_shader_3d: wgpu::ShaderModule,
     #[cfg(feature = "3d")]
-    pub(crate) instance_shader_3d: Arc<wgpu::ShaderModule>,
+    pub(crate) instance_shader_3d: wgpu::ShaderModule,
     #[cfg(feature = "3d")]
-    pub(crate) instance_unordered_shader_3d: Arc<wgpu::ShaderModule>,
+    pub(crate) instance_unordered_shader_3d: wgpu::ShaderModule,
 
-    pub(crate) instance_shader: Arc<wgpu::ShaderModule>,
-    pub(crate) instance_unordered_shader: Arc<wgpu::ShaderModule>,
-    pub(crate) text_shader: Arc<wgpu::ShaderModule>,
-    pub(crate) copy_shader: Arc<wgpu::ShaderModule>,
+    pub(crate) instance_shader: wgpu::ShaderModule,
+    pub(crate) instance_unordered_shader: wgpu::ShaderModule,
+    pub(crate) text_shader: wgpu::ShaderModule,
+    pub(crate) copy_shader: wgpu::ShaderModule,
     pub(crate) rect_mesh: Mesh,
     pub(crate) white_image: Image,
     pub(crate) instance_bind_layout: wgpu::BindGroupLayout,
@@ -334,68 +334,68 @@ impl GraphicsContext {
             },
         );
 
-        let draw_shader = Arc::new(wgpu.device.create_shader_module(
-            wgpu::ShaderModuleDescriptor {
+        let draw_shader = wgpu
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: None,
                 source: wgpu::ShaderSource::Wgsl(include_str!("shader/draw.wgsl").into()),
-            },
-        ));
+            });
 
         #[cfg(feature = "3d")]
-        let draw_shader_3d = Arc::new(wgpu.device.create_shader_module(
-            wgpu::ShaderModuleDescriptor {
+        let draw_shader_3d = wgpu
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: None,
                 source: wgpu::ShaderSource::Wgsl(include_str!("shader/draw3d.wgsl").into()),
-            },
-        ));
+            });
 
         #[cfg(feature = "3d")]
-        let instance_shader_3d = Arc::new(wgpu.device.create_shader_module(
-            wgpu::ShaderModuleDescriptor {
+        let instance_shader_3d = wgpu
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: None,
                 source: wgpu::ShaderSource::Wgsl(include_str!("shader/instance3d.wgsl").into()),
-            },
-        ));
+            });
 
         #[cfg(feature = "3d")]
-        let instance_unordered_shader_3d = Arc::new(wgpu.device.create_shader_module(
-            wgpu::ShaderModuleDescriptor {
-                label: None,
-                source: wgpu::ShaderSource::Wgsl(
-                    include_str!("shader/instance_unordered3d.wgsl").into(),
-                ),
-            },
-        ));
+        let instance_unordered_shader_3d =
+            wgpu.device
+                .create_shader_module(wgpu::ShaderModuleDescriptor {
+                    label: None,
+                    source: wgpu::ShaderSource::Wgsl(
+                        include_str!("shader/instance_unordered3d.wgsl").into(),
+                    ),
+                });
 
-        let instance_shader = Arc::new(wgpu.device.create_shader_module(
-            wgpu::ShaderModuleDescriptor {
+        let instance_shader = wgpu
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: None,
                 source: wgpu::ShaderSource::Wgsl(include_str!("shader/instance.wgsl").into()),
-            },
-        ));
+            });
 
-        let instance_unordered_shader = Arc::new(wgpu.device.create_shader_module(
-            wgpu::ShaderModuleDescriptor {
-                label: None,
-                source: wgpu::ShaderSource::Wgsl(
-                    include_str!("shader/instance_unordered.wgsl").into(),
-                ),
-            },
-        ));
+        let instance_unordered_shader =
+            wgpu.device
+                .create_shader_module(wgpu::ShaderModuleDescriptor {
+                    label: None,
+                    source: wgpu::ShaderSource::Wgsl(
+                        include_str!("shader/instance_unordered.wgsl").into(),
+                    ),
+                });
 
-        let text_shader = Arc::new(wgpu.device.create_shader_module(
-            wgpu::ShaderModuleDescriptor {
+        let text_shader = wgpu
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: None,
                 source: wgpu::ShaderSource::Wgsl(include_str!("shader/text.wgsl").into()),
-            },
-        ));
+            });
 
-        let copy_shader = Arc::new(wgpu.device.create_shader_module(
-            wgpu::ShaderModuleDescriptor {
+        let copy_shader = wgpu
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: None,
                 source: wgpu::ShaderSource::Wgsl(include_str!("shader/copy.wgsl").into()),
-            },
-        ));
+            });
 
         let rect_mesh = Mesh::from_data_wgpu(
             &wgpu,

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -334,68 +334,28 @@ impl GraphicsContext {
             },
         );
 
-        let draw_shader = wgpu
-            .device
-            .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: None,
-                source: wgpu::ShaderSource::Wgsl(include_str!("shader/draw.wgsl").into()),
-            });
+        let load_shader = |source: &str| {
+            wgpu.device
+                .create_shader_module(wgpu::ShaderModuleDescriptor {
+                    label: None,
+                    source: wgpu::ShaderSource::Wgsl(source.into()),
+                })
+        };
+
+        let draw_shader = load_shader(include_str!("shader/draw.wgsl"));
 
         #[cfg(feature = "3d")]
-        let draw_shader_3d = wgpu
-            .device
-            .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: None,
-                source: wgpu::ShaderSource::Wgsl(include_str!("shader/draw3d.wgsl").into()),
-            });
-
+        let draw_shader_3d = load_shader(include_str!("shader/draw3d.wgsl"));
         #[cfg(feature = "3d")]
-        let instance_shader_3d = wgpu
-            .device
-            .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: None,
-                source: wgpu::ShaderSource::Wgsl(include_str!("shader/instance3d.wgsl").into()),
-            });
-
+        let instance_shader_3d = load_shader(include_str!("shader/instance3d.wgsl"));
         #[cfg(feature = "3d")]
         let instance_unordered_shader_3d =
-            wgpu.device
-                .create_shader_module(wgpu::ShaderModuleDescriptor {
-                    label: None,
-                    source: wgpu::ShaderSource::Wgsl(
-                        include_str!("shader/instance_unordered3d.wgsl").into(),
-                    ),
-                });
+            load_shader(include_str!("shader/instance_unordered3d.wgsl"));
 
-        let instance_shader = wgpu
-            .device
-            .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: None,
-                source: wgpu::ShaderSource::Wgsl(include_str!("shader/instance.wgsl").into()),
-            });
-
-        let instance_unordered_shader =
-            wgpu.device
-                .create_shader_module(wgpu::ShaderModuleDescriptor {
-                    label: None,
-                    source: wgpu::ShaderSource::Wgsl(
-                        include_str!("shader/instance_unordered.wgsl").into(),
-                    ),
-                });
-
-        let text_shader = wgpu
-            .device
-            .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: None,
-                source: wgpu::ShaderSource::Wgsl(include_str!("shader/text.wgsl").into()),
-            });
-
-        let copy_shader = wgpu
-            .device
-            .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: None,
-                source: wgpu::ShaderSource::Wgsl(include_str!("shader/copy.wgsl").into()),
-            });
+        let instance_shader = load_shader(include_str!("shader/instance.wgsl"));
+        let instance_unordered_shader = load_shader(include_str!("shader/instance_unordered.wgsl"));
+        let text_shader = load_shader(include_str!("shader/text.wgsl"));
+        let copy_shader = load_shader(include_str!("shader/copy.wgsl"));
 
         let rect_mesh = Mesh::from_data_wgpu(
             &wgpu,

--- a/src/graphics/gpu/pipeline.rs
+++ b/src/graphics/gpu/pipeline.rs
@@ -1,14 +1,11 @@
-use std::{
-    collections::{hash_map::DefaultHasher, HashMap},
-    sync::Arc,
-};
+use std::collections::{hash_map::DefaultHasher, HashMap};
 
 /// Hashable representation of a render pipeline, used as a key in the HashMap cache.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RenderPipelineInfo {
     pub layout: wgpu::PipelineLayout,
-    pub vs: Arc<wgpu::ShaderModule>,
-    pub fs: Arc<wgpu::ShaderModule>,
+    pub vs: wgpu::ShaderModule,
+    pub fs: wgpu::ShaderModule,
     pub vs_entry: String,
     pub fs_entry: String,
     pub samples: u32,

--- a/src/graphics/gpu/pipeline.rs
+++ b/src/graphics/gpu/pipeline.rs
@@ -93,12 +93,12 @@ impl PipelineCache {
     pub fn layout(
         &mut self,
         device: &wgpu::Device,
-        bind_groups: &[wgpu::BindGroupLayout],
+        bind_group_layouts: &[&wgpu::BindGroupLayout],
     ) -> wgpu::PipelineLayout {
         let key = {
             use std::hash::{Hash, Hasher};
             let mut h = DefaultHasher::new();
-            for bg in bind_groups {
+            for bg in bind_group_layouts {
                 bg.hash(&mut h);
             }
             h.finish()
@@ -108,7 +108,7 @@ impl PipelineCache {
             .or_insert_with(|| {
                 device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                     label: None,
-                    bind_group_layouts: &bind_groups.iter().collect::<Vec<_>>(),
+                    bind_group_layouts,
                     push_constant_ranges: &[],
                 })
             })

--- a/src/graphics/internal_canvas.rs
+++ b/src/graphics/internal_canvas.rs
@@ -552,13 +552,13 @@ impl<'a> InternalCanvas<'a> {
             let (dummy_group, dummy_layout) =
                 BindGroupBuilder::new().create(&self.wgpu.device, self.bind_group_cache);
 
-            let mut groups = vec![uniform_layout, texture_layout];
+            let mut groups = vec![&uniform_layout, &texture_layout];
 
             if let ShaderType::Instance { .. } = ty {
-                groups.push(instance_layout);
+                groups.push(&instance_layout);
             } else {
                 // the dummy group ensures the user's bind group is at index 3
-                groups.push(dummy_layout);
+                groups.push(&dummy_layout);
                 self.pass
                     .set_bind_group(2, &*self.arenas.bind_groups.alloc(dummy_group), &[]);
             }
@@ -569,7 +569,7 @@ impl<'a> InternalCanvas<'a> {
                         self.shader_bind_group
                     {
                         self.pass.set_bind_group(3, bind_group, &[offset]);
-                        groups.push(bind_group_layout.clone());
+                        groups.push(bind_group_layout);
                     }
 
                     &self.shader
@@ -579,7 +579,7 @@ impl<'a> InternalCanvas<'a> {
                         self.text_shader_bind_group
                     {
                         self.pass.set_bind_group(3, bind_group, &[offset]);
-                        groups.push(bind_group_layout.clone());
+                        groups.push(bind_group_layout);
                     }
 
                     &self.text_shader

--- a/src/graphics/internal_canvas.rs
+++ b/src/graphics/internal_canvas.rs
@@ -44,10 +44,10 @@ pub struct InternalCanvas<'a> {
     format: wgpu::TextureFormat,
     text_uniforms: ArenaAllocation,
 
-    draw_sm: wgpu::ShaderModule,
-    instance_sm: wgpu::ShaderModule,
-    instance_unordered_sm: wgpu::ShaderModule,
-    text_sm: wgpu::ShaderModule,
+    draw_sm: &'a wgpu::ShaderModule,
+    instance_sm: &'a wgpu::ShaderModule,
+    instance_unordered_sm: &'a wgpu::ShaderModule,
+    text_sm: &'a wgpu::ShaderModule,
 
     transform: glam::Mat4,
     curr_image: Option<wgpu::TextureView>,
@@ -216,10 +216,10 @@ impl<'a> InternalCanvas<'a> {
             format,
             text_uniforms,
 
-            draw_sm: gfx.draw_shader.clone(),
-            instance_sm: gfx.instance_shader.clone(),
-            instance_unordered_sm: gfx.instance_unordered_shader.clone(),
-            text_sm: gfx.text_shader.clone(),
+            draw_sm: &gfx.draw_shader,
+            instance_sm: &gfx.instance_shader,
+            instance_unordered_sm: &gfx.instance_unordered_shader,
+            text_sm: &gfx.text_shader,
 
             transform,
             curr_image: None,

--- a/src/graphics/internal_canvas.rs
+++ b/src/graphics/internal_canvas.rs
@@ -16,7 +16,7 @@ use super::{
 use crate::{GameError, GameResult};
 use crevice::std140::AsStd140;
 use glam::{Mat4, Vec2, Vec4};
-use std::{collections::HashMap, hash::Hash, sync::Arc};
+use std::{collections::HashMap, hash::Hash};
 
 /// A canvas represents a render pass and is how you render primitives such as meshes and text onto images.
 #[allow(missing_debug_implementations)]
@@ -44,10 +44,10 @@ pub struct InternalCanvas<'a> {
     format: wgpu::TextureFormat,
     text_uniforms: ArenaAllocation,
 
-    draw_sm: Arc<wgpu::ShaderModule>,
-    instance_sm: Arc<wgpu::ShaderModule>,
-    instance_unordered_sm: Arc<wgpu::ShaderModule>,
-    text_sm: Arc<wgpu::ShaderModule>,
+    draw_sm: wgpu::ShaderModule,
+    instance_sm: wgpu::ShaderModule,
+    instance_unordered_sm: wgpu::ShaderModule,
+    text_sm: wgpu::ShaderModule,
 
     transform: glam::Mat4,
     curr_image: Option<wgpu::TextureView>,

--- a/src/graphics/internal_canvas3d.rs
+++ b/src/graphics/internal_canvas3d.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{GameError, GameResult};
 use crevice::std140::AsStd140;
 use glam::{Mat4, Vec4};
-use std::{hash::Hash, sync::Arc};
+use std::hash::Hash;
 
 /// A canvas represents a render pass and is how you render meshes .
 #[allow(missing_debug_implementations)]
@@ -38,9 +38,9 @@ pub struct InternalCanvas3d<'a> {
     samples: u32,
     format: wgpu::TextureFormat,
 
-    draw_sm: Arc<wgpu::ShaderModule>,
-    instance_sm: Arc<wgpu::ShaderModule>,
-    instance_unordered_sm: Arc<wgpu::ShaderModule>,
+    draw_sm: wgpu::ShaderModule,
+    instance_sm: wgpu::ShaderModule,
+    instance_unordered_sm: wgpu::ShaderModule,
 
     transform: glam::Mat4,
     curr_image: Option<wgpu::TextureView>,

--- a/src/graphics/internal_canvas3d.rs
+++ b/src/graphics/internal_canvas3d.rs
@@ -38,9 +38,9 @@ pub struct InternalCanvas3d<'a> {
     samples: u32,
     format: wgpu::TextureFormat,
 
-    draw_sm: wgpu::ShaderModule,
-    instance_sm: wgpu::ShaderModule,
-    instance_unordered_sm: wgpu::ShaderModule,
+    draw_sm: &'a wgpu::ShaderModule,
+    instance_sm: &'a wgpu::ShaderModule,
+    instance_unordered_sm: &'a wgpu::ShaderModule,
 
     transform: glam::Mat4,
     curr_image: Option<wgpu::TextureView>,
@@ -204,9 +204,9 @@ impl<'a> InternalCanvas3d<'a> {
             samples,
             format,
 
-            draw_sm: gfx.draw_shader_3d.clone(),
-            instance_sm: gfx.instance_shader_3d.clone(),
-            instance_unordered_sm: gfx.instance_unordered_shader_3d.clone(),
+            draw_sm: &gfx.draw_shader_3d,
+            instance_sm: &gfx.instance_shader_3d,
+            instance_unordered_sm: &gfx.instance_unordered_shader_3d,
 
             transform,
             curr_image: None,

--- a/src/graphics/internal_canvas3d.rs
+++ b/src/graphics/internal_canvas3d.rs
@@ -429,13 +429,13 @@ impl<'a> InternalCanvas3d<'a> {
             let (dummy_group, dummy_layout) =
                 BindGroupBuilder::new().create(&self.wgpu.device, self.bind_group_cache);
 
-            let mut groups = vec![uniform_layout, texture_layout];
+            let mut groups = vec![&uniform_layout, &texture_layout];
 
             if let ShaderType3d::Instance { .. } = ty {
-                groups.push(instance_layout);
+                groups.push(&instance_layout);
             } else {
                 // the dummy group ensures the user's bind group is at index 3
-                groups.push(dummy_layout);
+                groups.push(&dummy_layout);
                 self.pass
                     .set_bind_group(2, &*self.arenas.bind_groups.alloc(dummy_group), &[]);
             }
@@ -446,7 +446,7 @@ impl<'a> InternalCanvas3d<'a> {
                         self.shader_bind_group
                     {
                         self.pass.set_bind_group(3, bind_group, &[offset]);
-                        groups.push(bind_group_layout.clone());
+                        groups.push(bind_group_layout);
                     }
 
                     &self.shader

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -1,5 +1,4 @@
-use std::marker::PhantomData;
-use std::{io::Read, sync::Arc};
+use std::{io::Read, marker::PhantomData};
 
 use crate::{context::Has, Context, GameError, GameResult};
 
@@ -89,21 +88,23 @@ impl<'a> ShaderBuilder<'a> {
     pub fn build(self, gfx: &impl Has<GraphicsContext>) -> GameResult<Shader> {
         let gfx = gfx.retrieve();
         let load = |s: &str| {
-            Some(Arc::new(gfx.wgpu.device.create_shader_module(
-                wgpu::ShaderModuleDescriptor {
-                    label: None,
-                    source: wgpu::ShaderSource::Wgsl(s.into()),
-                },
-            )))
+            Some(
+                gfx.wgpu
+                    .device
+                    .create_shader_module(wgpu::ShaderModuleDescriptor {
+                        label: None,
+                        source: wgpu::ShaderSource::Wgsl(s.into()),
+                    }),
+            )
         };
-        let load_resource = |path: &str| -> GameResult<Option<Arc<wgpu::ShaderModule>>> {
+        let load_resource = |path: &str| -> GameResult<Option<wgpu::ShaderModule>> {
             let mut encoded = Vec::new();
             _ = gfx.fs.open(path)?.read_to_end(&mut encoded)?;
             Ok(load(
                 &String::from_utf8(encoded).map_err(GameError::ShaderEncodingError)?,
             ))
         };
-        let load_any = |source| -> GameResult<Option<Arc<wgpu::ShaderModule>>> {
+        let load_any = |source| -> GameResult<Option<wgpu::ShaderModule>> {
             Ok(match source {
                 ShaderSource::Code(source) => load(source),
                 ShaderSource::Path(source) => load_resource(source)?,
@@ -185,8 +186,8 @@ impl Default for ShaderBuilder<'_> {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Shader {
-    pub(crate) vs_module: Option<Arc<wgpu::ShaderModule>>,
-    pub(crate) fs_module: Option<Arc<wgpu::ShaderModule>>,
+    pub(crate) vs_module: Option<wgpu::ShaderModule>,
+    pub(crate) fs_module: Option<wgpu::ShaderModule>,
 }
 
 impl Shader {


### PR DESCRIPTION
Initial release of `wgpu` 24 didn't include a `Clone` impl for `ShaderModule`. Now that this is fixed, remove trailing `Arc`s from #1304.