### PR TITLE
Mark the input::keyboard doctest as no_run

### DIFF
--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -24,7 +24,7 @@
 //!
 //! Example:
 //!
-//! ```rust, compile
+//! ```rust,no_run
 //! use winit::keyboard::{Key, ModifiersState, NamedKey};
 //! use ggez::event::{self, EventHandler};
 //! use ggez::input::keyboard::KeyInput;


### PR DESCRIPTION
Without this, `cargo test --doc` would open up a window...