### PR TITLE
Drop SurfaceTexture before reconfiguring surface (fix #1273)

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -607,8 +607,14 @@ impl GraphicsContext {
         let frame = loop {
             match self.surface.get_current_texture() {
                 wgpu::CurrentSurfaceTexture::Success(frame) => break frame,
-                wgpu::CurrentSurfaceTexture::Suboptimal(_)
-                | wgpu::CurrentSurfaceTexture::Outdated => self.reconfigure_surface(),
+                wgpu::CurrentSurfaceTexture::Suboptimal(tex) => {
+                    // Drop the SurfaceTexture before reconfiguring the surface,
+                    // otherwise wgpu panics with "SurfaceOutput must be dropped
+                    // before a new Surface is made" (issue ggez/ggez#1273).
+                    drop(tex);
+                    self.reconfigure_surface();
+                }
+                wgpu::CurrentSurfaceTexture::Outdated => self.reconfigure_surface(),
                 wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded => {
                     // TODO: Add proper way to skip frame
                     continue;


### PR DESCRIPTION
## Summary

Fixes the wgpu validation panic that occurs in `GraphicsContext::begin_frame` when the surface returns `Suboptimal` — most notably on the very first rendered frame under Wayland.

## The bug

`begin_frame` matches:

```rust
wgpu::CurrentSurfaceTexture::Suboptimal(_)
| wgpu::CurrentSurfaceTexture::Outdated => self.reconfigure_surface(),
```

The underscore-bound `SurfaceTexture` is only dropped at the end of the match arm — *after* `reconfigure_surface()` runs. wgpu, however, requires the texture to be dropped *before* `Surface::configure`, so it panics:

```
wgpu error: Validation Error
In Surface::configure
  `SurfaceOutput` must be dropped before a new `Surface` is made
```

## The fix

Split the variants so `Suboptimal(tex)` explicitly `drop(tex)`s before calling `reconfigure_surface()`. `Outdated` carries no payload so it's fine.

The diff is intentionally tiny — no logic change, just an explicit drop ordering that matches wgpu's contract.

## Why we hit it (and why it matters)

We're upgrading [TBE — a turn-based game engine](https://gitlab.com/game-development1584802/turn-based-engine/engine) and its consumer game from ggez 0.9 to 0.10 (master) primarily to pick up the winit 0.30 Wayland support. Under Wayland the compositor signals `Suboptimal` on the first frame of every newly-shown window, so this panic fires **100% of the time** before any user code runs — making 0.10 effectively unusable on Wayland without this fix.

For X11 it's harder to hit reliably, but the underlying contract violation is the same and would manifest under any compositor / driver that returns `Suboptimal` ahead of the user's first draw.

Tested locally on Ubuntu 24.04 / GNOME / Wayland with a 3440×1440 ultrawide display in both windowed and fullscreen (`FullscreenType::Desktop`) modes — game starts and renders correctly with the patch applied; panics deterministically without it.

Closes #1273