### PR TITLE
Call pre_present_notify before presenting frames

### DIFF
--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -711,6 +711,7 @@ impl GraphicsContext {
             std::mem::drop(present_pass);
 
             let _ = self.wgpu.queue.submit([fcx.cmd.finish()]);
+            self.window.pre_present_notify();
             fcx.frame.present();
 
             Ok(())


### PR DESCRIPTION
## Summary
- call `Window::pre_present_notify()` before presenting the wgpu surface frame
- lets winit schedule/align Wayland frame callbacks before the buffer is committed

## Rationale
The winit docs for `Window::pre_present_notify()` say it should be called after drawing operations but before submitting the buffer to the display or committing drawings. They also document that on Wayland this schedules a frame callback to throttle `RedrawRequested`.

Docs: https://docs.rs/winit/0.30.13/winit/window/struct.Window.html#method.pre_present_notify

The related `Window::request_redraw()` docs say Wayland redraw events are aligned with frame callbacks when `Window::pre_present_notify()` is used.

Docs: https://docs.rs/winit/0.30.13/winit/window/struct.Window.html#method.request_redraw

## Verification
- `cargo check --no-default-features`
- `cargo fmt --check`

Full default `cargo check` was not run in my local Nix shell because the shell was missing `alsa.pc` for the optional default audio feature; the no-default-features check covers this graphics-path change.

## Disclosure
This PR was prepared with help from OpenAI Codex.
