### PR TITLE
Remove deprecated authors field from guide

### DIFF
--- a/docs/guides/HelloGgez.md
+++ b/docs/guides/HelloGgez.md
@@ -31,8 +31,6 @@ Open up `Cargo.toml` with a text editor and add `ggez` as a dependency:
 [package]
 name = "hello_ggez"
 version = "0.1.0"
-# Replace with your name and email
-authors = ["Awesome Person awesome@person.com"]
 
 [dependencies]
 ggez = "0.10.0-rc0"


### PR DESCRIPTION
The `authors` field in `Cargo.toml` is deprecated according to the documentation
https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field

So it can safely be removed from the ggez guide