### PR TITLE
Shader params context bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Changed
+
+- Generalized `ShaderParamsBuilder::build` and `ShaderParams::set_uniforms` to accept custom contexts with graphics and time contexts.
+
 # 0.10.0
 
 ## Added

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -1,6 +1,10 @@
 use std::marker::PhantomData;
 
-use crate::{context::Has, Context, GameError, GameResult};
+use crate::{
+    context::{Has, HasMut},
+    timer::TimeContext,
+    GameError, GameResult,
+};
 
 use super::{
     context::GraphicsContext,
@@ -257,24 +261,22 @@ impl<'a, Uniforms: AsStd140> ShaderParamsBuilder<'a, Uniforms> {
     }
 
     /// Produce a [`ShaderParams`] from the builder.
-    pub fn build(self, ctx: &mut Context) -> ShaderParams<Uniforms> {
+    pub fn build<C>(self, ctx: &mut C) -> ShaderParams<Uniforms>
+    where
+        C: HasMut<GraphicsContext> + HasMut<TimeContext>,
+    {
+        let gfx = <C as HasMut<GraphicsContext>>::retrieve_mut(ctx);
         let images = self.images.iter().map(|image| image.view.clone()).collect();
         let samplers = self
             .samplers
             .iter()
-            .map(|&sampler| ctx.gfx.sampler_cache.get(&ctx.gfx.wgpu.device, sampler))
+            .map(|&sampler| gfx.sampler_cache.get(&gfx.wgpu.device, sampler))
             .collect();
 
         let mut params = ShaderParams {
             uniform_arena: GrowingBufferArena::new(
-                &ctx.gfx.wgpu.device,
-                u64::from(
-                    ctx.gfx
-                        .wgpu
-                        .device
-                        .limits()
-                        .min_uniform_buffer_offset_alignment,
-                ),
+                &gfx.wgpu.device,
+                u64::from(gfx.wgpu.device.limits().min_uniform_buffer_offset_alignment),
                 wgpu::BufferDescriptor {
                     label: None,
                     size: ShaderParams::<Uniforms>::UPDATES_PER_ARENA
@@ -341,19 +343,23 @@ impl<Uniforms: AsStd140> ShaderParams<Uniforms> {
     /// Updates the uniform data.
     ///
     /// When called, [`Canvas::set_shader_params`] (or [`Canvas::set_text_shader_params`]) **needs to be called again** for the new uniforms to take effect.
-    pub fn set_uniforms(&mut self, ctx: &mut Context, uniforms: &Uniforms) {
-        if ctx.time.ticks() != self.last_tick {
+    pub fn set_uniforms<C>(&mut self, ctx: &mut C, uniforms: &Uniforms)
+    where
+        C: HasMut<GraphicsContext> + HasMut<TimeContext>,
+    {
+        let ticks = <C as HasMut<TimeContext>>::retrieve_mut(ctx).ticks();
+        let gfx = <C as HasMut<GraphicsContext>>::retrieve_mut(ctx);
+
+        if ticks != self.last_tick {
             self.uniform_arena.free();
-            self.last_tick = ctx.time.ticks();
+            self.last_tick = ticks;
         }
         let alloc = self
             .uniform_arena
-            .allocate(&ctx.gfx.wgpu.device, Uniforms::std140_size_static() as u64);
-        ctx.gfx.wgpu.queue.write_buffer(
-            &alloc.buffer,
-            alloc.offset,
-            uniforms.as_std140().as_bytes(),
-        );
+            .allocate(&gfx.wgpu.device, Uniforms::std140_size_static() as u64);
+        gfx.wgpu
+            .queue
+            .write_buffer(&alloc.buffer, alloc.offset, uniforms.as_std140().as_bytes());
 
         self.buffer_offset = alloc.offset as u32;
 
@@ -381,8 +387,7 @@ impl<Uniforms: AsStd140> ShaderParams<Uniforms> {
             builder = builder.sampler(sampler, vis);
         }
 
-        let (bind_group, layout) =
-            builder.create(&ctx.gfx.wgpu.device, &mut ctx.gfx.bind_group_cache);
+        let (bind_group, layout) = builder.create(&gfx.wgpu.device, &mut gfx.bind_group_cache);
         self.layout = Some(layout);
         self.bind_group = Some(bind_group);
     }

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -307,7 +307,7 @@ impl<'a, Uniforms: AsStd140> ShaderParamsBuilder<'a, Uniforms> {
 /// ```rust,ignore
 /// ggez::graphics::ShaderParamsBuilder::new(&my_uniforms)
 ///     .images(&[&image1, &image2], &[sampler1], false)
-///     .build(&mut ctx.gfx)
+///     .build(ctx)
 /// ```
 /// Corresponds to...
 /// ```ignore


### PR DESCRIPTION
## Summary

This generalizes `ShaderParamsBuilder::build` and `ShaderParams::set_uniforms` so they accept any context implementing:

```rust
HasMut<GraphicsContext> + HasMut<TimeContext>
```
instead of requiring a concrete ggez::Context.

## Motivation

ggez already has support for divided/custom contexts through the Has / HasMut traits and the custom context builder flow. I’m using that with my own decoupled system scheduler, where resources are passed around separately instead of always through one monolithic Context.

Shader params were one of the places where this divided-context model did not fully work, because ShaderParamsBuilder::build and ShaderParams::set_uniforms still required &mut Context directly.

Internally, those functions only need graphics state and frame ticks, so this PR changes the bounds to require exactly those subcontexts. That makes shader params follow the same custom-context convention as the rest of ggez.

## Notes

I’m not sure how many users will need this, but I hit it in practice while integrating ggez with a scheduler/resource-based architecture. Without this, shader params require threading a full `Context` through code that otherwise only needs the relevant subcontexts. Existing `Context` callers continue to work unchanged.

This also fixes the adjacent ignored doc example to pass ctx instead of &mut ctx.gfx, since shader params need access to both graphics and time.
