### PR TITLE
Fix uniform arena dynamic offset crash

### DIFF
--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -364,7 +364,7 @@ impl<Uniforms: AsStd140> ShaderParams<Uniforms> {
             wgpu::ShaderStages::VERTEX_FRAGMENT,
             wgpu::BufferBindingType::Uniform,
             true,
-            None,
+            Some(Uniforms::std140_size_static() as u64),
         );
 
         let vis = if self.images_vs_visible {


### PR DESCRIPTION
Close #1310

I believe this is the root cause (not binding the actual uniform size), and the changes in https://github.com/ggez/ggez/pull/1311 shouldn't be necessary.